### PR TITLE
fix: avoid showing archived session artifacts in new tabs

### DIFF
--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -50,6 +50,7 @@ export default function WorkspacePage() {
   const { tabs, activeTabId, updateTab } = useTabs();
   const activeTab = tabs.find((t) => t.id === activeTabId);
   const isNewSession = activeTab?.mode !== "workspace";
+  const artifactInventoryEnabled = activeTab?.mode === "workspace";
   const voiceInputEnabled = useAtomValue(voiceInputEnabledAtom);
 
   // Agent state — always called (hooks must not be conditional)
@@ -90,7 +91,12 @@ export default function WorkspacePage() {
     artifactInventory,
     artifactInventoryLoading,
     artifactInventoryError,
-  } = useArtifactUpdates(activeTabId, !artifactOpen, agent.showDebug ?? false);
+  } = useArtifactUpdates(
+    activeTabId,
+    artifactInventoryEnabled,
+    !artifactOpen,
+    agent.showDebug ?? false,
+  );
   const artifactHasUpdates = unseenTabs.size > 0;
 
   // Chat controls state

--- a/src/components/artifact-pane/useArtifactUpdates.ts
+++ b/src/components/artifact-pane/useArtifactUpdates.ts
@@ -50,6 +50,7 @@ function artifactPaneUiReducer(
 
 export function useArtifactUpdates(
   activeTabId: string,
+  enabled: boolean,
   isCollapsed: boolean,
   showDebug: boolean,
 ) {
@@ -60,7 +61,7 @@ export function useArtifactUpdates(
     loading: artifactInventoryLoading,
     error: artifactInventoryError,
     hasLoadedSuccessfully: artifactInventoryHasLoadedSuccessfully,
-  } = useSessionArtifactInventory(activeTabId);
+  } = useSessionArtifactInventory(activeTabId, enabled);
 
   const [{ activeTab, unseenTabs }, dispatch] = useReducer(
     artifactPaneUiReducer,
@@ -82,6 +83,16 @@ export function useArtifactUpdates(
   );
 
   useEffect(() => {
+    if (!enabled) {
+      prevPlanVersion.current = 0;
+      prevTodoSnapshot.current = buildTodoSnapshot(todos);
+      prevReviewCount.current = reviewEdits.length;
+      prevArtifactFingerprint.current = "";
+      hasArtifactBaseline.current = false;
+      dispatch({ type: "reset" });
+      return;
+    }
+
     if (prevActiveTabId.current === activeTabId) return;
     prevActiveTabId.current = activeTabId;
     prevPlanVersion.current = inventory.latestPlanGroup?.latest.version ?? 0;
@@ -92,6 +103,7 @@ export function useArtifactUpdates(
     dispatch({ type: "reset" });
   }, [
     activeTabId,
+    enabled,
     artifactInventoryHasLoadedSuccessfully,
     inventory.fingerprint,
     inventory.latestPlanGroup,
@@ -100,32 +112,36 @@ export function useArtifactUpdates(
   ]);
 
   useEffect(() => {
+    if (!enabled) return;
     const nextPlanVersion = inventory.latestPlanGroup?.latest.version ?? 0;
     if (nextPlanVersion === prevPlanVersion.current) return;
     prevPlanVersion.current = nextPlanVersion;
     if (activeTab !== "PLAN" || isCollapsed) {
       dispatch({ type: "mark-unseen", tab: "PLAN" });
     }
-  }, [activeTab, inventory.latestPlanGroup, isCollapsed]);
+  }, [activeTab, enabled, inventory.latestPlanGroup, isCollapsed]);
 
   useEffect(() => {
+    if (!enabled) return;
     const nextTodoSnapshot = buildTodoSnapshot(todos);
     if (nextTodoSnapshot === prevTodoSnapshot.current) return;
     prevTodoSnapshot.current = nextTodoSnapshot;
     if (activeTab !== "TODO" || isCollapsed) {
       dispatch({ type: "mark-unseen", tab: "TODO" });
     }
-  }, [activeTab, isCollapsed, todos]);
+  }, [activeTab, enabled, isCollapsed, todos]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (reviewEdits.length === prevReviewCount.current) return;
     prevReviewCount.current = reviewEdits.length;
     if (activeTab !== "REVIEW" || isCollapsed) {
       dispatch({ type: "mark-unseen", tab: "REVIEW" });
     }
-  }, [activeTab, isCollapsed, reviewEdits.length]);
+  }, [activeTab, enabled, isCollapsed, reviewEdits.length]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (!artifactInventoryHasLoadedSuccessfully) return;
 
     if (!hasArtifactBaseline.current) {
@@ -141,6 +157,7 @@ export function useArtifactUpdates(
     }
   }, [
     activeTab,
+    enabled,
     artifactInventoryHasLoadedSuccessfully,
     inventory.fingerprint,
     isCollapsed,

--- a/src/components/artifact-pane/useSessionArtifacts.ts
+++ b/src/components/artifact-pane/useSessionArtifacts.ts
@@ -35,10 +35,10 @@ function isTauriRuntime() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
-export function useSessionArtifactInventory(tabId: string) {
+export function useSessionArtifactInventory(tabId: string, enabled = true) {
   const [state, setState] = useState<SessionInventoryState>({
     tabId,
-    loading: isTauriRuntime(),
+    loading: isTauriRuntime() && enabled,
     error: null,
     inventory: EMPTY_INVENTORY,
     hasLoadedSuccessfully: false,
@@ -48,7 +48,14 @@ export function useSessionArtifactInventory(tabId: string) {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    if (!isTauriRuntime()) {
+    if (!isTauriRuntime() || !enabled) {
+      setState({
+        tabId,
+        loading: false,
+        error: null,
+        inventory: EMPTY_INVENTORY,
+        hasLoadedSuccessfully: false,
+      });
       return;
     }
 
@@ -95,12 +102,12 @@ export function useSessionArtifactInventory(tabId: string) {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [tabId]);
+  }, [enabled, tabId]);
 
   if (state.tabId !== tabId) {
     return {
       inventory: EMPTY_INVENTORY,
-      loading: isTauriRuntime(),
+      loading: isTauriRuntime() && enabled,
       error: null,
       hasLoadedSuccessfully: false,
     };

--- a/src/contexts/TabsContext.tsx
+++ b/src/contexts/TabsContext.tsx
@@ -33,6 +33,23 @@ interface State {
   activeTabId: string;
 }
 
+function createTabId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return `tab-${uuid}`;
+  return `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function createNewTab(partial?: Partial<Omit<Tab, "id">>): Tab {
+  return {
+    id: createTabId(),
+    label: "New Tab",
+    icon: "chat_bubble_outline",
+    status: "idle",
+    mode: "new",
+    ...partial,
+  };
+}
+
 type Action =
   | { type: "SET_ACTIVE"; id: string }
   | { type: "ADD_TAB"; tab: Tab }
@@ -92,21 +109,16 @@ function reducer(state: State, action: Action): State {
    Initial state — one tab labelled "New Tab" (fallback when no sessions)
 ───────────────────────────────────────────────────────────────────────────── */
 
-const EMPTY_INITIAL: State = {
-  tabs: [
-    {
-      id: "tab-1",
-      label: "New Tab",
-      icon: "chat_bubble_outline",
-      status: "idle" as const,
-      mode: "new" as const,
-    },
-  ],
-  activeTabId: "tab-1",
-};
+function createEmptyInitialState(): State {
+  const tab = createNewTab();
+  return {
+    tabs: [tab],
+    activeTabId: tab.id,
+  };
+}
 
 function buildInitialState(sessions: PersistedSession[]): State {
-  if (sessions.length === 0) return EMPTY_INITIAL;
+  if (sessions.length === 0) return createEmptyInitialState();
   const tabs: Tab[] = sessions.map((s) => ({
     id: s.id,
     label: s.label,
@@ -160,17 +172,9 @@ export function TabsProvider({
   );
 
   const addTab = useCallback((partial?: Partial<Omit<Tab, "id">>) => {
-    const id = `tab-${Date.now()}`;
-    const tab: Tab = {
-      id,
-      label: "New Tab",
-      icon: "chat_bubble_outline",
-      status: "idle",
-      mode: "new",
-      ...partial,
-    };
+    const tab = createNewTab(partial);
     dispatch({ type: "ADD_TAB", tab });
-    return id;
+    return tab.id;
   }, []);
 
   const addTabWithId = useCallback((tab: Tab) => {
@@ -183,14 +187,7 @@ export function TabsProvider({
         const tab = state.tabs.find((t) => t.id === id);
         if (!tab || tab.mode === "new") return; // don't close the last new-session tab
         // Last workspace tab → replace with a fresh new-session tab
-        const newId = `tab-${Date.now()}`;
-        const newTab: Tab = {
-          id: newId,
-          label: "New Tab",
-          icon: "chat_bubble_outline",
-          status: "idle",
-          mode: "new",
-        };
+        const newTab = createNewTab();
         dispatch({ type: "ADD_TAB", tab: newTab });
         dispatch({ type: "CLOSE_TAB", id });
         return;


### PR DESCRIPTION
Summary
- stop fallback new-session tabs from reusing the static `tab-1` id
- skip artifact inventory polling until a tab is actually in workspace mode
- prevent archived session artifacts from appearing in brand new sessions

Testing
- npm run typecheck
- npm test -- --run src/agent/persistence.test.ts src/components/artifact-pane/model.test.ts