### PR TITLE
Fix artifact copy feedback and session inventory loading

### DIFF
--- a/src/components/ConversationCards.tsx
+++ b/src/components/ConversationCards.tsx
@@ -92,23 +92,25 @@ function ArtifactConversationCard({
   const title = resolveArtifactSummary(card, previewEntry, group);
   const canOpenDetail = group != null && detailVersion !== null;
   const canCopy = typeof hydratedArtifact?.content === "string";
-  const [copiedAt, setCopiedAt] = useState<number | null>(null);
-  const copied = copiedAt !== null;
+  const [copyFeedbackToken, setCopyFeedbackToken] = useState(0);
+  const copied = copyFeedbackToken > 0;
 
   useEffect(() => {
-    if (copiedAt === null) return;
+    if (copyFeedbackToken === 0) return;
     const timeoutId = window.setTimeout(() => {
-      setCopiedAt((current) => (current === copiedAt ? null : current));
+      setCopyFeedbackToken((current) =>
+        current === copyFeedbackToken ? 0 : current,
+      );
     }, 2200);
     return () => window.clearTimeout(timeoutId);
-  }, [copiedAt]);
+  }, [copyFeedbackToken]);
 
   const handleCopy = async () => {
     const content = hydratedArtifact?.content;
     if (typeof content !== "string") return;
     try {
       await navigator.clipboard.writeText(content);
-      setCopiedAt(Date.now());
+      setCopyFeedbackToken((current) => current + 1);
     } catch {
       // Ignore clipboard failures; the button is a convenience action.
     }

--- a/src/components/artifact-pane/useSessionArtifacts.ts
+++ b/src/components/artifact-pane/useSessionArtifacts.ts
@@ -36,9 +36,10 @@ function isTauriRuntime() {
 }
 
 export function useSessionArtifactInventory(tabId: string, enabled = true) {
+  const runtimeEnabled = isTauriRuntime() && enabled;
   const [state, setState] = useState<SessionInventoryState>({
     tabId,
-    loading: isTauriRuntime() && enabled,
+    loading: runtimeEnabled,
     error: null,
     inventory: EMPTY_INVENTORY,
     hasLoadedSuccessfully: false,
@@ -48,16 +49,7 @@ export function useSessionArtifactInventory(tabId: string, enabled = true) {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    if (!isTauriRuntime() || !enabled) {
-      setState({
-        tabId,
-        loading: false,
-        error: null,
-        inventory: EMPTY_INVENTORY,
-        hasLoadedSuccessfully: false,
-      });
-      return;
-    }
+    if (!runtimeEnabled) return;
 
     const poll = async () => {
       const result = await artifactList(tabId, {
@@ -102,18 +94,34 @@ export function useSessionArtifactInventory(tabId: string, enabled = true) {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [enabled, tabId]);
+  }, [runtimeEnabled, tabId]);
 
-  if (state.tabId !== tabId) {
+  if (!runtimeEnabled) {
     return {
       inventory: EMPTY_INVENTORY,
-      loading: isTauriRuntime() && enabled,
+      loading: false,
       error: null,
       hasLoadedSuccessfully: false,
     };
   }
 
-  return state;
+  if (state.tabId !== tabId) {
+    return {
+      inventory: EMPTY_INVENTORY,
+      loading: true,
+      error: null,
+      hasLoadedSuccessfully: false,
+    };
+  }
+
+  return {
+    ...state,
+    loading:
+      state.loading ||
+      (!state.hasLoadedSuccessfully &&
+        state.error === null &&
+        state.inventory.groups.length === 0),
+  };
 }
 
 export function useArtifactContentCache(tabId: string) {


### PR DESCRIPTION
## Summary
- improve copy feedback timing by using a token counter instead of timestamp comparisons
- guard session artifact inventory polling with runtime-aware enabled flag and expose consistent default state
- keep loading state active until artifacts successfully load when tab data is stale

## Testing
- Not run (not requested)