### PR TITLE
fix(storage): separate debug app store root from release

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ graph TB
     Tauri --> Whisper["Whisper voice commands"]
     Runner --> Artifacts["Artifact wrappers"]
     Artifacts --> SQLite
-    SQLite --> Blobs["Artifact blobs<br/>~/.rakh/artifacts/blobs/sha256"]
+    SQLite --> Blobs["Artifact blobs<br/>release: ~/.rakh/artifacts/blobs/sha256<br/>debug: ~/.rakh-dev/artifacts/blobs/sha256"]
 ```
 
 ## Frontend architecture
@@ -190,9 +190,12 @@ Rakh persists data in multiple places by design:
 
 - provider instances: browser IndexedDB (`rakh-providers`)
 - theme mode, theme name, selected model, and some UI preferences: localStorage
-- sessions and artifact manifests: `~/.rakh/sessions/sessions.db`
-- artifact content blobs: `~/.rakh/artifacts/blobs/sha256`
-- git worktrees created by the agent: `~/.rakh/worktrees/<owner>/<repo>/<branch>`
+- release sessions and artifact manifests: `~/.rakh/sessions/sessions.db`
+- debug/dev sessions and artifact manifests: `~/.rakh-dev/sessions/sessions.db`
+- release artifact content blobs: `~/.rakh/artifacts/blobs/sha256`
+- debug/dev artifact content blobs: `~/.rakh-dev/artifacts/blobs/sha256`
+- release git worktrees created by the agent: `~/.rakh/worktrees/<owner>/<repo>/<branch>`
+- debug/dev git worktrees created by the agent: `~/.rakh-dev/worktrees/<owner>/<repo>/<branch>`
 
 Session persistence is front-to-back:
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -18,8 +18,12 @@ blob is stored separately by content hash.
 
 Current storage layout:
 
-- Session/manifests DB: `~/.rakh/sessions/sessions.db`
-- Blob storage: `~/.rakh/artifacts/blobs/sha256`
+- Release builds:
+  - Session/manifests DB: `~/.rakh/sessions/sessions.db`
+  - Blob storage: `~/.rakh/artifacts/blobs/sha256`
+- Debug/dev builds:
+  - Session/manifests DB: `~/.rakh-dev/sessions/sessions.db`
+  - Blob storage: `~/.rakh-dev/artifacts/blobs/sha256`
 
 ## Core Model
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "glob",

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,6 +1,6 @@
 #[cfg(not(test))]
 use crate::shell_env::{login_shell_candidates, run_login_shell_script};
-use crate::utils::{home_dir, non_empty_env_var, now_ms, tool_log};
+use crate::utils::{app_store_root, non_empty_env_var, now_ms, tool_log};
 use portable_pty::MasterPty;
 use rusqlite::{params, types::Value as SqlValue, Connection, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
@@ -247,9 +247,7 @@ fn is_retryable_artifact_id_collision(err: &rusqlite::Error) -> bool {
 }
 
 fn artifact_blob_root() -> Result<PathBuf, String> {
-    let home = home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
-    Ok(home
-        .join(".rakh")
+    Ok(app_store_root()?
         .join("artifacts")
         .join("blobs")
         .join("sha256"))
@@ -609,12 +607,17 @@ fn resolve_provider_env_api_keys() -> (ProviderEnvApiKeys, bool) {
 /* ── init_db ─────────────────────────────────────────────────────────────── */
 
 pub fn init_db() -> Result<Connection, String> {
-    let home = home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
-    let sessions_dir = home.join(".rakh").join("sessions");
-    fs::create_dir_all(&sessions_dir)
-        .map_err(|e| format!("Cannot create ~/.rakh/sessions: {}", e))?;
+    let sessions_dir = app_store_root()?.join("sessions");
+    fs::create_dir_all(&sessions_dir).map_err(|e| {
+        format!(
+            "Cannot create sessions directory {}: {}",
+            sessions_dir.display(),
+            e
+        )
+    })?;
     let db_path = sessions_dir.join("sessions.db");
-    let conn = Connection::open(&db_path).map_err(|e| format!("Cannot open sessions.db: {}", e))?;
+    let conn = Connection::open(&db_path)
+        .map_err(|e| format!("Cannot open {}: {}", db_path.display(), e))?;
     // Enable WAL mode for better concurrent read performance
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
         .map_err(|e| format!("PRAGMA failed: {}", e))?;

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,13 +1,82 @@
-use crate::utils::tool_log;
+use crate::utils::{app_store_root, tool_log};
 use serde_json::{json, Value};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
+
+fn sanitize_repo_slug_segment(segment: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut prev_dash = false;
+
+    for ch in segment.trim().chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+            out.push(ch);
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+
+    let trimmed = out.trim_matches(|ch| ch == '-' || ch == '_' || ch == '.');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn sanitize_repo_slug(repo_slug: &str) -> String {
+    let segments = repo_slug
+        .split('/')
+        .filter_map(sanitize_repo_slug_segment)
+        .collect::<Vec<_>>();
+
+    if segments.is_empty() {
+        "repo".to_string()
+    } else {
+        segments.join("/")
+    }
+}
+
+fn derive_worktree_path(app_root: &Path, repo_slug: &str, branch: &str) -> Result<PathBuf, String> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Err("INVALID_ARGUMENT: branch must not be empty".to_string());
+    }
+
+    let branch_path = Path::new(branch);
+    if branch_path.is_absolute() {
+        return Err("INVALID_ARGUMENT: branch must be a relative path".to_string());
+    }
+
+    let mut out = app_root.join("worktrees");
+    for segment in sanitize_repo_slug(repo_slug).split('/') {
+        out.push(segment);
+    }
+
+    for component in branch_path.components() {
+        match component {
+            Component::Normal(segment) => out.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(
+                    "INVALID_ARGUMENT: branch must not contain parent traversal".to_string()
+                );
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err("INVALID_ARGUMENT: branch must be a relative path".to_string());
+            }
+        }
+    }
+
+    Ok(out)
+}
 
 #[tauri::command]
 pub fn git_worktree_add(
     repo_path: String,
-    worktree_path: String,
+    repo_slug: String,
     branch: String,
 ) -> Result<Value, String> {
     let start = Instant::now();
@@ -16,15 +85,17 @@ pub fn git_worktree_add(
         "start",
         json!({
             "repoPath": repo_path,
-            "worktreePath": worktree_path,
+            "repoSlug": repo_slug,
             "branch": branch
         }),
     );
 
     let result: Result<Value, String> = (|| {
+        let worktree_path = derive_worktree_path(&app_store_root()?, &repo_slug, &branch)?;
+        let worktree_path_str = worktree_path.to_string_lossy().to_string();
+
         // Ensure the parent directory exists
-        let wt_path = PathBuf::from(&worktree_path);
-        if let Some(parent) = wt_path.parent() {
+        if let Some(parent) = worktree_path.parent() {
             fs::create_dir_all(parent)
                 .map_err(|e| format!("Cannot create worktree parent dir: {}", e))?;
         }
@@ -35,7 +106,7 @@ pub fn git_worktree_add(
                 &repo_path,
                 "worktree",
                 "add",
-                &worktree_path,
+                &worktree_path_str,
                 "-b",
                 &branch,
             ])
@@ -43,7 +114,10 @@ pub fn git_worktree_add(
             .map_err(|e| format!("Failed to run git: {}", e))?;
 
         if output.status.success() {
-            Ok(json!({ "path": worktree_path, "branch": branch }))
+            Ok(json!({
+                "path": worktree_path_str,
+                "branch": branch
+            }))
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             Err(format!("git worktree add failed: {}", stderr.trim()))
@@ -71,4 +145,37 @@ pub fn git_worktree_add(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_worktree_path_uses_app_store_root() {
+        let app_root = Path::new("/Users/test/.rakh-dev");
+        let path = derive_worktree_path(app_root, "owner/repo", "feature/name").unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("/Users/test/.rakh-dev/worktrees/owner/repo/feature/name")
+        );
+    }
+
+    #[test]
+    fn test_derive_worktree_path_sanitizes_repo_slug_without_escaping_root() {
+        let app_root = Path::new("/Users/test/.rakh-dev");
+        let path = derive_worktree_path(app_root, "../../bad slug///repo.git", "feature").unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("/Users/test/.rakh-dev/worktrees/bad-slug/repo.git/feature")
+        );
+        assert!(path.starts_with(app_root.join("worktrees")));
+    }
+
+    #[test]
+    fn test_derive_worktree_path_rejects_parent_traversal_in_branch() {
+        let app_root = Path::new("/Users/test/.rakh-dev");
+        let err = derive_worktree_path(app_root, "owner/repo", "../feature").unwrap_err();
+        assert!(err.contains("parent traversal"));
+    }
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,5 +1,5 @@
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn home_dir() -> Option<PathBuf> {
@@ -21,6 +21,23 @@ pub fn now_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64
+}
+
+pub fn app_store_dir_name(is_debug: bool) -> &'static str {
+    if is_debug {
+        ".rakh-dev"
+    } else {
+        ".rakh"
+    }
+}
+
+pub fn app_store_root_from_home(home: &Path, is_debug: bool) -> PathBuf {
+    home.join(app_store_dir_name(is_debug))
+}
+
+pub fn app_store_root() -> Result<PathBuf, String> {
+    let home = home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(app_store_root_from_home(&home, cfg!(debug_assertions)))
 }
 
 pub fn non_empty_env_var(name: &str) -> Option<String> {
@@ -71,5 +88,30 @@ pub fn truncate_bytes(data: &[u8], max: usize) -> (Vec<u8>, bool) {
         (data.to_vec(), false)
     } else {
         (data[..max].to_vec(), true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_app_store_dir_name_switches_by_build_type() {
+        assert_eq!(app_store_dir_name(true), ".rakh-dev");
+        assert_eq!(app_store_dir_name(false), ".rakh");
+    }
+
+    #[test]
+    fn test_app_store_root_from_home_joins_expected_directory() {
+        let home = Path::new("/Users/tester");
+        assert_eq!(
+            app_store_root_from_home(home, true),
+            PathBuf::from("/Users/tester/.rakh-dev")
+        );
+        assert_eq!(
+            app_store_root_from_home(home, false),
+            PathBuf::from("/Users/tester/.rakh")
+        );
     }
 }

--- a/src-tauri/src/whisper.rs
+++ b/src-tauri/src/whisper.rs
@@ -1,4 +1,4 @@
-use crate::utils::{home_dir, tool_log};
+use crate::utils::{app_store_root, tool_log};
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use serde_json::{json, Value};
 use std::fs;
@@ -18,12 +18,10 @@ fn whisper_model_download_lock() -> &'static Mutex<()> {
     WHISPER_MODEL_DOWNLOAD_LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn default_whisper_model_path() -> Option<PathBuf> {
-    home_dir().map(|home| {
-        home.join(".rakh")
-            .join("whisper")
-            .join(DEFAULT_WHISPER_MODEL_FILENAME)
-    })
+fn default_whisper_model_path() -> Result<PathBuf, String> {
+    Ok(app_store_root()?
+        .join("whisper")
+        .join(DEFAULT_WHISPER_MODEL_FILENAME))
 }
 
 fn ensure_existing_model_file(path: &PathBuf) -> Result<(), String> {
@@ -152,9 +150,7 @@ fn download_default_whisper_model(target_path: &PathBuf) -> Result<(), String> {
 }
 
 fn resolve_whisper_model_path() -> Result<PathBuf, String> {
-    let default_path = default_whisper_model_path().ok_or_else(|| {
-        "Cannot determine home directory for default Whisper model storage.".to_string()
-    })?;
+    let default_path = default_whisper_model_path()?;
 
     let existed_before = default_path.exists();
     if !existed_before {

--- a/src/agent/tools/git.test.ts
+++ b/src/agent/tools/git.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockAgentState = {
   config: {
@@ -70,18 +70,6 @@ vi.mock("../atoms", () => ({
 
 import { gitWorktreeInit } from "./git";
 
-function setWindowHome(home?: string): void {
-  if (home) {
-    (
-      globalThis as unknown as {
-        window: { __EVE_HOME__?: string };
-      }
-    ).window = { __EVE_HOME__: home };
-  } else {
-    (globalThis as unknown as { window?: unknown }).window = undefined;
-  }
-}
-
 function makeState(overrides?: Partial<MockAgentState>): MockAgentState {
   return {
     status: "idle",
@@ -145,12 +133,6 @@ describe("gitWorktreeInit", () => {
           typeof patch === "function" ? patch(prev) : { ...prev, ...patch };
       },
     );
-
-    setWindowHome();
-  });
-
-  afterEach(() => {
-    setWindowHome();
   });
 
   it("returns alreadyExists when a worktree is already configured", async () => {
@@ -220,7 +202,6 @@ describe("gitWorktreeInit", () => {
 
   it("marks config as declined when user rejects approval", async () => {
     setState("tab");
-    setWindowHome("/Users/test");
 
     invokeMock
       .mockResolvedValueOnce({
@@ -245,12 +226,13 @@ describe("gitWorktreeInit", () => {
     expect(result).toEqual({ ok: true, data: { declined: true } });
     expect(states.tab.config.worktreeDeclined).toBe(true);
     const toolStatus = states.tab.chatMessages[0].toolCalls?.[0].status;
+    const toolArgs = states.tab.chatMessages[0].toolCalls?.[0].args;
     expect(toolStatus).toBe("awaiting_worktree");
+    expect(toolArgs).toMatchObject({ suggestedBranch: "feature", repoSlug: "repo" });
   });
 
   it("creates a worktree with sanitized branch name on approval", async () => {
     setState("tab");
-    setWindowHome("/Users/test");
 
     invokeMock
       .mockResolvedValueOnce({
@@ -263,7 +245,10 @@ describe("gitWorktreeInit", () => {
         stdout: "git@github.com:owner/repo.git\n",
         stderr: "",
       })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({
+        path: "/backend/worktrees/owner/repo/feature-name",
+        branch: "feature-name",
+      });
     requestWorktreeApprovalMock.mockResolvedValueOnce({
       approved: true,
       branchName: "Feature Name!!",
@@ -276,27 +261,35 @@ describe("gitWorktreeInit", () => {
     expect(result).toEqual({
       ok: true,
       data: {
-        path: "/Users/test/.rakh/worktrees/owner/repo/feature-name",
+        path: "/backend/worktrees/owner/repo/feature-name",
         branch: "feature-name",
       },
     });
     expect(invokeMock).toHaveBeenNthCalledWith(3, "git_worktree_add", {
       repoPath: "/tmp/repo",
-      worktreePath: "/Users/test/.rakh/worktrees/owner/repo/feature-name",
+      repoSlug: "owner/repo",
       branch: "feature-name",
     });
+    const homeLookupCalls = invokeMock.mock.calls.filter(
+      ([command, payload]) =>
+        command === "exec_run" &&
+        typeof payload === "object" &&
+        payload !== null &&
+        "command" in payload &&
+        (payload as { command?: string }).command === "sh",
+    );
+    expect(homeLookupCalls).toHaveLength(0);
     expect(states.tab.config.cwd).toBe(
-      "/Users/test/.rakh/worktrees/owner/repo/feature-name",
+      "/backend/worktrees/owner/repo/feature-name",
     );
     expect(states.tab.config.worktreePath).toBe(
-      "/Users/test/.rakh/worktrees/owner/repo/feature-name",
+      "/backend/worktrees/owner/repo/feature-name",
     );
     expect(states.tab.config.worktreeBranch).toBe("feature-name");
   });
 
-  it("trims trailing slash from worktree cwd", async () => {
+  it("uses the backend-returned worktree path verbatim", async () => {
     setState("tab");
-    setWindowHome("/Users/test/");
 
     invokeMock
       .mockResolvedValueOnce({
@@ -308,6 +301,10 @@ describe("gitWorktreeInit", () => {
         exitCode: 0,
         stdout: "git@github.com:owner/repo.git\n",
         stderr: "",
+      })
+      .mockResolvedValueOnce({
+        path: "/custom/root/worktrees/owner/repo/feature",
+        branch: "feature",
       });
     requestWorktreeApprovalMock.mockResolvedValueOnce({
       approved: true,
@@ -321,18 +318,17 @@ describe("gitWorktreeInit", () => {
     expect(result).toEqual({
       ok: true,
       data: {
-        path: "/Users/test/.rakh/worktrees/owner/repo/feature",
+        path: "/custom/root/worktrees/owner/repo/feature",
         branch: "feature",
       },
     });
     expect(states.tab.config.cwd).toBe(
-      "/Users/test/.rakh/worktrees/owner/repo/feature",
+      "/custom/root/worktrees/owner/repo/feature",
     );
   });
 
   it("returns INTERNAL when git_worktree_add fails", async () => {
     setState("tab");
-    setWindowHome("/Users/test");
 
     invokeMock
       .mockResolvedValueOnce({

--- a/src/agent/tools/git.ts
+++ b/src/agent/tools/git.ts
@@ -3,8 +3,8 @@
  *
  * git_worktree_init: called by the agent before its first file write.
  * Presents a custom approval card to the user who can name the branch;
- * on approval, creates a worktree under ~/.rakh/worktrees/<owner>/<repo>/<branch>
- * and updates AgentConfig.cwd so all subsequent tool calls use the new path.
+ * on approval, asks the backend to create a worktree under the active app
+ * store root and updates AgentConfig.cwd to the returned path.
  */
 import { invoke } from "@tauri-apps/api/core";
 import { getAgentState, patchAgentState } from "../atoms";
@@ -49,9 +49,8 @@ function parseRemoteSlug(remoteUrl: string, fallbackName: string): string {
   return fallbackName;
 }
 
-function trimTrailingSlash(path: string): string {
-  if (!path || path === "/") return path;
-  return path.replace(/\/+$/g, "");
+function trimEdgeSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
 }
 
 export async function gitWorktreeInit(
@@ -140,29 +139,7 @@ export async function gitWorktreeInit(
 
   // 5. Build worktree path proposal
   const sanitised = sanitiseBranch(input.suggestedBranch || "agent-branch");
-  const home =
-    typeof window !== "undefined"
-      ? (window as unknown as { __EVE_HOME__?: string }).__EVE_HOME__
-      : undefined;
-  // Use HOME env via a quick invoke if needed; fall back to a known path
-  let homeDir = home ?? "";
-  if (!homeDir) {
-    try {
-      const r = await invoke<{ exitCode: number; stdout: string }>("exec_run", {
-        command: "sh",
-        args: ["-c", "echo $HOME"],
-        cwd: repoRoot,
-        env: {},
-        timeoutMs: 5_000,
-        maxStdoutBytes: 512,
-        maxStderrBytes: 512,
-        stdin: null,
-      });
-      homeDir = r.stdout.trim();
-    } catch {
-      homeDir = "~";
-    }
-  }
+  const repoSlug = trimEdgeSlashes(slug) || repoName;
   // 6. Update the tool call display status so the UI renders the custom card,
   //    then block until the user makes a decision.
   patchAgentState(tabId, (prev) => ({
@@ -173,7 +150,15 @@ export async function gitWorktreeInit(
             ...m,
             toolCalls: m.toolCalls.map((t) =>
               t.id === toolCallId
-                ? { ...t, status: "awaiting_worktree" as const }
+                ? {
+                    ...t,
+                    status: "awaiting_worktree" as const,
+                    args: {
+                      ...t.args,
+                      suggestedBranch: input.suggestedBranch,
+                      repoSlug,
+                    },
+                  }
                 : t,
             ),
           }
@@ -194,18 +179,18 @@ export async function gitWorktreeInit(
 
   // 8. Create the worktree
   const finalBranch = sanitiseBranch(branchName || sanitised);
-  const baseHome = trimTrailingSlash(homeDir);
-  const slugClean = slug.replace(/^\/+|\/+$/g, "");
-  const finalPath = trimTrailingSlash(
-    `${baseHome}/.rakh/worktrees/${slugClean}/${finalBranch}`,
-  );
+  let finalPath: string;
 
   try {
-    await invoke("git_worktree_add", {
-      repoPath: repoRoot,
-      worktreePath: finalPath,
-      branch: finalBranch,
-    });
+    const created = await invoke<{ path: string; branch: string }>(
+      "git_worktree_add",
+      {
+        repoPath: repoRoot,
+        repoSlug,
+        branch: finalBranch,
+      },
+    );
+    finalPath = created.path;
   } catch (e) {
     return {
       ok: false,

--- a/src/components/ToolCallApproval.tsx
+++ b/src/components/ToolCallApproval.tsx
@@ -229,6 +229,10 @@ function WorktreeApprovalCard({ toolCall }: { toolCall: ToolCallDisplay }) {
   const { id, args } = toolCall;
   const suggested =
     typeof args.suggestedBranch === "string" ? args.suggestedBranch : "";
+  const repoSlug =
+    typeof args.repoSlug === "string" && args.repoSlug.trim()
+      ? args.repoSlug.replace(/^\/+|\/+$/g, "")
+      : "repo";
   const [branch, setBranch] = useState(suggested);
 
   return (
@@ -263,7 +267,7 @@ function WorktreeApprovalCard({ toolCall }: { toolCall: ToolCallDisplay }) {
           }}
         />
         <div className="text-xxs text-muted font-mono mt-[5px] opacity-60">
-          A worktree will be created at ~/.rakh/worktrees/…/
+          A worktree will be created under worktrees/{repoSlug}/
           {branch.trim() || suggested || "branch"}
         </div>
       </div>


### PR DESCRIPTION
fix(storage): separate debug app store root from release

Summary
- route sessions, artifact blobs, and the Whisper model cache through a debug-aware app store helper
- move worktree path derivation to the backend and remove frontend HOME and ~/.rakh assumptions
- update the worktree approval copy, docs, and tests for separate debug and release storage roots

Testing
- npm run test -- --run src/agent/tools/git.test.ts
- npm run typecheck
- cd src-tauri && cargo test