### PR TITLE
feat: move provider config from IndexedDB to disk at ~/.rakh/config

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1504,12 +1504,150 @@ pub fn db_delete_session(id: String, state: State<'_, AppState>) -> Result<(), S
     result
 }
 
+/* ── Provider config (disk-backed) ───────────────────────────────────────── */
+
+fn providers_config_path() -> Result<PathBuf, String> {
+    Ok(app_store_root()?.join("config").join("providers.json"))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderRecord {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub provider_type: String,
+    pub api_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_models: Option<Vec<Value>>,
+}
+
+#[tauri::command]
+pub fn providers_load() -> Result<Vec<ProviderRecord>, String> {
+    tool_log("providers_load", "start", json!({}));
+    let path = providers_config_path()?;
+    if !path.exists() {
+        tool_log("providers_load", "ok", json!({ "count": 0, "reason": "file_absent" }));
+        return Ok(vec![]);
+    }
+    let raw =
+        fs::read_to_string(&path).map_err(|e| format!("INTERNAL: cannot read providers: {}", e))?;
+    let records: Vec<ProviderRecord> = serde_json::from_str(&raw)
+        .map_err(|e| format!("INTERNAL: cannot parse providers: {}", e))?;
+    tool_log("providers_load", "ok", json!({ "count": records.len() }));
+    Ok(records)
+}
+
+#[tauri::command]
+pub fn providers_save(providers: Vec<ProviderRecord>) -> Result<(), String> {
+    tool_log("providers_save", "start", json!({ "count": providers.len() }));
+    let path = providers_config_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("INTERNAL: cannot create config dir: {}", e))?;
+    }
+    let raw = serde_json::to_string_pretty(&providers)
+        .map_err(|e| format!("INTERNAL: cannot serialise providers: {}", e))?;
+    let tmp = path.with_extension(format!("json.tmp-{}", now_ms()));
+    fs::write(&tmp, raw.as_bytes())
+        .map_err(|e| format!("INTERNAL: cannot write providers tmp: {}", e))?;
+    match fs::rename(&tmp, &path) {
+        Ok(()) => {}
+        Err(e) => {
+            if path.exists() {
+                let _ = fs::remove_file(&tmp);
+            } else {
+                return Err(format!("INTERNAL: cannot rename providers file: {}", e));
+            }
+        }
+    }
+    tool_log("providers_save", "ok", json!({ "count": providers.len() }));
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
     use std::sync::OnceLock;
     use tempfile::tempdir;
+
+    static PROVIDER_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn test_providers_load_returns_empty_when_absent() {
+        let _guard = PROVIDER_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+
+        let result = providers_load().expect("providers_load should not error");
+        assert!(result.is_empty(), "Expected empty list when file is absent");
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn test_providers_roundtrip() {
+        let _guard = PROVIDER_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+
+        let records = vec![
+            ProviderRecord {
+                id: "id-1".to_string(),
+                name: "OpenAI".to_string(),
+                provider_type: "openai".to_string(),
+                api_key: "sk-test-openai".to_string(),
+                base_url: None,
+                cached_models: None,
+            },
+            ProviderRecord {
+                id: "id-2".to_string(),
+                name: "Local Ollama".to_string(),
+                provider_type: "openai-compatible".to_string(),
+                api_key: "".to_string(),
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                cached_models: None,
+            },
+        ];
+
+        providers_save(records.clone()).expect("providers_save should succeed");
+
+        let loaded = providers_load().expect("providers_load should succeed");
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].id, "id-1");
+        assert_eq!(loaded[0].name, "OpenAI");
+        assert_eq!(loaded[0].api_key, "sk-test-openai");
+        assert!(loaded[0].base_url.is_none());
+        assert_eq!(loaded[1].id, "id-2");
+        assert_eq!(
+            loaded[1].base_url.as_deref(),
+            Some("http://localhost:11434/v1")
+        );
+
+        // Verify the file exists on disk and is a human-readable JSON array
+        let config_path = providers_config_path().unwrap();
+        let raw = std::fs::read_to_string(&config_path).unwrap();
+        assert!(raw.trim().starts_with('['), "File should be a JSON array");
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
 
     fn init_artifact_schema(conn: &Connection) {
         conn.execute_batch(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,8 @@ pub fn run() {
             db::db_artifact_version,
             db::db_artifact_get,
             db::db_artifact_list,
+            db::providers_load,
+            db::providers_save,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/agent/db.ts
+++ b/src/agent/db.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { atom } from "jotai";
 
 export interface ProviderInstance {
@@ -9,86 +10,20 @@ export interface ProviderInstance {
   cachedModels?: Record<string, unknown>[]; // Cached models for openai-compatible
 }
 
-const DB_NAME = "rakh-providers";
-const STORE_NAME = "providers";
-const DB_VERSION = 1;
-
-let dbPromise: Promise<IDBDatabase> | null = null;
-
-export function getDb(): Promise<IDBDatabase> {
-  if (dbPromise) return dbPromise;
-
-  dbPromise = new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: "id" });
-      }
-    };
-
-    request.onsuccess = (event) => {
-      resolve((event.target as IDBOpenDBRequest).result);
-    };
-
-    request.onerror = (event) => {
-      reject((event.target as IDBOpenDBRequest).error);
-    };
-  });
-
-  return dbPromise;
-}
-
 export async function loadProviders(): Promise<ProviderInstance[]> {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readonly");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.getAll();
-
-    request.onsuccess = () => {
-      resolve(request.result as ProviderInstance[]);
-    };
-
-    request.onerror = () => {
-      reject(request.error);
-    };
-  });
+  return invoke<ProviderInstance[]>("providers_load");
 }
 
 export async function saveProvider(provider: ProviderInstance): Promise<void> {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.put(provider);
-
-    request.onsuccess = () => {
-      resolve();
-    };
-
-    request.onerror = () => {
-      reject(request.error);
-    };
-  });
+  const current = await loadProviders();
+  const updated = [...current.filter((p) => p.id !== provider.id), provider];
+  await invoke("providers_save", { providers: updated });
 }
 
 export async function deleteProvider(id: string): Promise<void> {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.delete(id);
-
-    request.onsuccess = () => {
-      resolve();
-    };
-
-    request.onerror = () => {
-      reject(request.error);
-    };
-  });
+  const current = await loadProviders();
+  const updated = current.filter((p) => p.id !== id);
+  await invoke("providers_save", { providers: updated });
 }
 
 export const providersAtom = atom<ProviderInstance[]>([]);


### PR DESCRIPTION
## Summary

Closes #31

Provider records (API keys, base URLs, cached models) were stored in IndexedDB under `rakh-providers`, making them fragile to webview storage clears and invisible to standard backup/dotfile tooling. Sessions and artifact blobs already live under `~/.rakh/`; this change makes providers consistent with that.

## Changes

### Backend (`src-tauri/src/db.rs`, `src-tauri/src/lib.rs`)
- Add `ProviderRecord` struct (mirrors the TS `ProviderInstance` shape, camelCase JSON)
- Add `providers_config_path()` helper → `~/.rakh/config/providers.json`
- Add `providers_load` Tauri command — returns `[]` if file absent, otherwise parses the JSON array
- Add `providers_save` Tauri command — atomically writes the full array (write-to-tmp + rename)
- Register both commands in the invoke handler

### Frontend (`src/agent/db.ts`)
- Remove all IndexedDB boilerplate (`getDb`, `IDBDatabase`, `DB_NAME`, etc.)
- Replace with thin `invoke()` wrappers over the two new Tauri commands
- Exported API surface (`loadProviders`, `saveProvider`, `deleteProvider`, `providersAtom`) is unchanged — no callers need updating

## Tests
- 2 new Rust unit tests: absent-file returns `[]`, full save/load roundtrip
- All 21 Rust tests pass ✅
- All 221 frontend tests pass ✅
- TypeScript typecheck clean ✅