### PR TITLE
Fix Tauri action tag in release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build and Release Tauri app
         if: ${{ inputs.target == 'all' || matrix.target == inputs.target }}
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_DATE_EPOCH: "1"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,7 +75,7 @@ jobs:
           echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Build and Release Tauri app
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_DATE_EPOCH: "1"


### PR DESCRIPTION
## Summary
- replace `tauri-apps/tauri-action@v1` with the latest published tag `tauri-apps/tauri-action@v0.6.1`
- fix both release workflows so GitHub Actions can resolve the action again

## Testing
- not run (workflow reference change only)
