### PR TITLE
fix: add macOS microphone entitlement for production builds

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -2,7 +2,8 @@
   "bundle": {
     "macOS": {
       "minimumSystemVersion": "10.15",
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "entitlements": "Entitlements.plist"
     }
   },
   "app": {


### PR DESCRIPTION
## Summary
- add a macOS entitlements file for audio input
- wire the entitlement into the production Tauri macOS bundle config
- keep the existing microphone usage description in Info.plist

## Verification
- npm run tauri:build
- npm run typecheck

Fixes #26