### PR TITLE
feat(chat): add slash command autocomplete

### DIFF
--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -104,7 +104,18 @@ vi.mock("@/agent/atoms", () => ({
 }));
 
 vi.mock("@/agent/subagents", () => ({
-  getAllSubagents: () => [],
+  getAllSubagents: () => [
+    {
+      id: "planner",
+      name: "Planner",
+      icon: "assignment",
+      description:
+        "Analyses a task, explores the codebase, and writes a structured plan with todos.",
+      triggerCommand: "/plan",
+      triggerCommandDisplay: "/plan <task>",
+      triggerCommandTakesArguments: true,
+    },
+  ],
   getSubagentThemeColorToken: () => "var(--color-primary)",
 }));
 
@@ -330,6 +341,22 @@ function emitTranscript(text: string) {
   });
 }
 
+function applyLastPatch<T extends object>(state: T): T {
+  const updater = workspaceMocks.patchAgentStateMock.mock.calls.at(-1)?.[1];
+  if (typeof updater !== "function") {
+    throw new Error("Expected patchAgentState to be called with an updater");
+  }
+  return updater(state);
+}
+
+type PatchedChatState = {
+  chatMessages: Array<{ role?: string; content?: string }>;
+  showDebug: boolean;
+  status: string;
+  error: unknown;
+  errorDetails: unknown;
+};
+
 describe("WorkspacePage chat input", () => {
   beforeEach(() => {
     cleanup();
@@ -446,5 +473,133 @@ describe("WorkspacePage chat input", () => {
     expect(document.activeElement).toBe(textbox);
     const focusText = document.getSelection()?.focusNode?.textContent ?? "";
     expect(focusText.endsWith("Refine edit in src/test.ts: ")).toBe(true);
+  });
+
+  it("injects local help content for /help without sending a message", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/help");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/help");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    const nextState = applyLastPatch<PatchedChatState>({
+      chatMessages: [],
+      showDebug: false,
+      status: "idle",
+      error: null,
+      errorDetails: null,
+    });
+    expect(nextState.chatMessages).toHaveLength(1);
+    expect(nextState.chatMessages[0]?.role).toBe("assistant");
+    expect(nextState.chatMessages[0]?.content).toContain("**Available slash commands:**");
+    expect(nextState.chatMessages[0]?.content).toContain("`/plan <task>`");
+  });
+
+  it("treats /? as an alias for /help", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/?");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/?");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(workspaceMocks.patchAgentStateMock).toHaveBeenCalled();
+    });
+
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    const nextState = applyLastPatch<PatchedChatState>({
+      chatMessages: [],
+      showDebug: false,
+      status: "idle",
+      error: null,
+      errorDetails: null,
+    });
+    expect(nextState.chatMessages[0]?.content).toContain("`/help`");
+  });
+
+  it("accepts /plan from the slash menu before submitting it on the next Enter", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/pl");
+
+    await waitFor(() => {
+      expect(screen.getByText("/plan <task>")).not.toBeNull();
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/plan ");
+    });
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.sendMessageMock).toHaveBeenCalledWith("/plan");
+  });
+
+  it("keeps the local /model behavior", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/model");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/model");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    const nextState = applyLastPatch<PatchedChatState>({
+      chatMessages: [],
+      showDebug: false,
+      status: "idle",
+      error: null,
+      errorDetails: null,
+    });
+    expect(nextState.chatMessages[0]?.content).toContain("**Available models:**");
+    expect(nextState.chatMessages[0]?.content).toContain("`model-1`");
+  });
+
+  it("keeps the local /debug toggle behavior", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/debug");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/debug");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    const nextState = applyLastPatch({
+      showDebug: false,
+    });
+    expect(nextState.showDebug).toBe(true);
   });
 });

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -42,6 +42,11 @@ import { useTabs } from "@/contexts/TabsContext";
 import { useAgent } from "@/agent/useAgents";
 import { useModels } from "@/agent/useModels";
 import { patchAgentState, voiceInputEnabledAtom } from "@/agent/atoms";
+import {
+  formatSlashCommandHelpMarkdown,
+  getSlashCommandCatalog,
+  matchesSlashCommandInput,
+} from "@/agent/slashCommands";
 import { getAllSubagents, getSubagentThemeColorToken } from "@/agent/subagents";
 import { groupChatMessagesForBubbles } from "@/agent/chatBubbleGroups";
 import { useArtifactContentCache } from "@/components/artifact-pane/useSessionArtifacts";
@@ -125,6 +130,11 @@ export default function WorkspacePage() {
     }
     return byName;
   }, []);
+  const slashCommands = useMemo(() => getSlashCommandCatalog(), []);
+  const helpCommand = useMemo(
+    () => slashCommands.find((command) => command.command === "/help") ?? null,
+    [slashCommands],
+  );
 
   const textareaRef = useRef<MentionTextareaHandle>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -261,6 +271,12 @@ export default function WorkspacePage() {
     const text = input.trim();
     if (!text) return;
 
+    if (helpCommand && matchesSlashCommandInput(text, helpCommand)) {
+      injectAssistantMessage(formatSlashCommandHelpMarkdown(slashCommands));
+      setInput("");
+      return;
+    }
+
     if (text === "/debug") {
       patchAgentState(activeTabId, (prev) => ({
         ...prev,
@@ -313,12 +329,14 @@ export default function WorkspacePage() {
   }, [
     input,
     activeTabId,
+    helpCommand,
     isAgentBusy,
     voiceInput,
     agent,
     setInput,
     models,
     injectAssistantMessage,
+    slashCommands,
   ]);
 
   const handleKeyDown = useCallback(
@@ -578,6 +596,7 @@ export default function WorkspacePage() {
                   onChange={handleInput}
                   onKeyDown={handleKeyDown}
                   cwd={agent.config.cwd}
+                  slashCommands={slashCommands}
                   placeholder="Type a message…"
                   rows={1}
                   disabled={false}

--- a/src/agent/slashCommands.ts
+++ b/src/agent/slashCommands.ts
@@ -1,0 +1,147 @@
+import { getAllSubagents } from "./subagents";
+
+export interface SlashCommandDefinition {
+  command: string;
+  description: string;
+  aliases?: string[];
+  displayLabel?: string;
+  insertText?: string;
+  takesArguments?: boolean;
+}
+
+const STATIC_SLASH_COMMANDS: SlashCommandDefinition[] = [
+  {
+    command: "/model",
+    displayLabel: "/model [id]",
+    description: "List available models or switch the active model.",
+    insertText: "/model ",
+    takesArguments: true,
+  },
+  {
+    command: "/debug",
+    description: "Toggle debug mode (stream event logging).",
+    insertText: "/debug ",
+    takesArguments: false,
+  },
+  {
+    command: "/help",
+    aliases: ["/?"],
+    description: "Show this list.",
+    insertText: "/help ",
+    takesArguments: false,
+  },
+];
+
+function normalizeSlashLookupValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeSlashSearchValue(value: string): string {
+  return normalizeSlashLookupValue(value)
+    .replace(/^\//, "")
+    .replace(/\s+/g, " ");
+}
+
+function buildSubagentSlashCommand(
+  input: {
+    command: string;
+    description: string;
+    displayLabel?: string;
+    takesArguments?: boolean;
+  },
+): SlashCommandDefinition {
+  const takesArguments = input.takesArguments ?? true;
+  return {
+    command: input.command,
+    description: input.description,
+    displayLabel: input.displayLabel,
+    insertText: `${input.command} `,
+    takesArguments,
+  };
+}
+
+export function getSlashCommandCatalog(): SlashCommandDefinition[] {
+  const staticByCommand = new Map(
+    STATIC_SLASH_COMMANDS.map((definition) => [definition.command, definition]),
+  );
+  const seen = new Set<string>();
+  const commands: SlashCommandDefinition[] = [];
+
+  const pushUnique = (definition?: SlashCommandDefinition) => {
+    if (!definition || seen.has(definition.command)) return;
+    commands.push(definition);
+    seen.add(definition.command);
+  };
+
+  const subagentCommands = getAllSubagents()
+    .map((subagent) => {
+      if (!subagent.triggerCommand) return null;
+      return buildSubagentSlashCommand({
+        command: subagent.triggerCommand.trim(),
+        description: subagent.description,
+        displayLabel: subagent.triggerCommandDisplay,
+        takesArguments: subagent.triggerCommandTakesArguments,
+      });
+    })
+    .filter((definition): definition is SlashCommandDefinition => definition !== null);
+
+  pushUnique(
+    subagentCommands.find((definition) => definition.command === "/plan"),
+  );
+  pushUnique(staticByCommand.get("/model"));
+  pushUnique(staticByCommand.get("/debug"));
+  pushUnique(staticByCommand.get("/help"));
+
+  for (const definition of subagentCommands) {
+    pushUnique(definition);
+  }
+
+  return commands;
+}
+
+export function filterSlashCommands(
+  commands: SlashCommandDefinition[],
+  query: string,
+  limit: number,
+): SlashCommandDefinition[] {
+  const normalizedQuery = normalizeSlashSearchValue(query);
+
+  return commands
+    .filter((definition) => {
+      if (!normalizedQuery) return true;
+
+      const searchFields = [
+        definition.command,
+        ...(definition.aliases ?? []),
+        definition.displayLabel ?? "",
+      ].map(normalizeSlashSearchValue);
+
+      return searchFields.some((field) => field.startsWith(normalizedQuery));
+    })
+    .slice(0, limit);
+}
+
+export function matchesSlashCommandInput(
+  input: string,
+  definition: SlashCommandDefinition,
+): boolean {
+  const normalizedInput = normalizeSlashLookupValue(input);
+  if (normalizedInput === normalizeSlashLookupValue(definition.command)) {
+    return true;
+  }
+
+  return (definition.aliases ?? []).some(
+    (alias) => normalizeSlashLookupValue(alias) === normalizedInput,
+  );
+}
+
+export function formatSlashCommandHelpMarkdown(
+  commands: SlashCommandDefinition[],
+): string {
+  const lines = commands.map((definition) => {
+    const label = definition.displayLabel ?? definition.command;
+    return `- \`${label}\` — ${definition.description}`;
+  });
+
+  return `**Available slash commands:**\n\n${lines.join("\n")}`;
+}

--- a/src/agent/subagents/copywriter.ts
+++ b/src/agent/subagents/copywriter.ts
@@ -12,6 +12,7 @@ export const copywriterSubagent: SubagentDefinition = {
   description:
     "Reviews user-facing copy in the codebase and suggests improvements. Does not make edits — returns suggestions to the parent agent.",
   triggerCommand: "/copywrite",
+  triggerCommandTakesArguments: true,
   requiresApproval: false,
   recommendedModels: [],
   whenToUse: [

--- a/src/agent/subagents/github.ts
+++ b/src/agent/subagents/github.ts
@@ -11,6 +11,7 @@ export const githubSubagent: SubagentDefinition = {
   description:
     "Handles GitHub tasks with the gh CLI: issue creation, triage, assignment, commenting, PR/repo operations, and other repo-side actions. May do quick read-only codebase checks first to gather context. Returns a concise action summary only.",
   triggerCommand: "/github",
+  triggerCommandTakesArguments: true,
   requiresApproval: false,
   recommendedModels: [],
   whenToUse: [

--- a/src/agent/subagents/planner.ts
+++ b/src/agent/subagents/planner.ts
@@ -11,6 +11,8 @@ export const plannerSubagent: SubagentDefinition = {
   description:
     "Analyses a task, explores the codebase, and writes a structured plan with todos.",
   triggerCommand: "/plan",
+  triggerCommandDisplay: "/plan <task>",
+  triggerCommandTakesArguments: true,
   requiresApproval: false,
   recommendedModels: [],
   whenToUse: [

--- a/src/agent/subagents/reviewer.ts
+++ b/src/agent/subagents/reviewer.ts
@@ -12,6 +12,7 @@ export const reviewerSubagent: SubagentDefinition = {
   description:
     "Reviews code in a requested scope and returns actionable findings to the parent agent. Always include a concrete scope (file(s), directory, or commit range) in the message. Does not modify code.",
   triggerCommand: "/review",
+  triggerCommandTakesArguments: true,
   requiresApproval: false,
   recommendedModels: [],
   whenToUse: [

--- a/src/agent/subagents/security.ts
+++ b/src/agent/subagents/security.ts
@@ -12,6 +12,7 @@ export const securitySubagent: SubagentDefinition = {
   description:
     "Audits code and security-relevant configuration in a requested scope and returns actionable findings. Always include a concrete scope (file(s), directory, or commit range) in the message. Does not modify code.",
   triggerCommand: "/security",
+  triggerCommandTakesArguments: true,
   requiresApproval: false,
   recommendedModels: [],
   whenToUse: [

--- a/src/agent/subagents/types.ts
+++ b/src/agent/subagents/types.ts
@@ -119,6 +119,18 @@ export interface SubagentDefinition {
   triggerCommand?: string;
 
   /**
+   * Optional display label for slash-command discoverability surfaces.
+   * Example: triggerCommand "/plan" with triggerCommandDisplay "/plan <task>".
+   */
+  triggerCommandDisplay?: string;
+
+  /**
+   * Whether the slash command normally expects trailing input after selection.
+   * Defaults to true when a trigger command is defined.
+   */
+  triggerCommandTakesArguments?: boolean;
+
+  /**
    * Concrete situations when the main agent should invoke this subagent.
    * Rendered as bullet points under the subagent entry in the main system prompt.
    */

--- a/src/components/MentionTextarea.test.tsx
+++ b/src/components/MentionTextarea.test.tsx
@@ -20,6 +20,7 @@ import {
   MentionTextarea,
   type MentionTextareaHandle,
 } from "./MentionTextarea";
+import type { SlashCommandDefinition } from "@/agent/slashCommands";
 
 const tauriMocks = vi.hoisted(() => ({
   invokeMock: vi.fn(),
@@ -109,11 +110,13 @@ function ControlledMentionTextarea({
   handleRef,
   initialValue = "",
   onKeyDown,
+  slashCommands,
 }: {
   cwd?: string;
   handleRef?: RefObject<MentionTextareaHandle | null>;
   initialValue?: string;
   onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  slashCommands?: SlashCommandDefinition[];
 }) {
   const [value, setValue] = useState(initialValue);
 
@@ -130,12 +133,37 @@ function ControlledMentionTextarea({
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={onKeyDown}
         placeholder="Type a message…"
+        slashCommands={slashCommands}
         value={value}
       />
       <div data-testid="value">{value}</div>
     </>
   );
 }
+
+const slashCommands: SlashCommandDefinition[] = [
+  {
+    command: "/plan",
+    displayLabel: "/plan <task>",
+    description: "Run the Planner subagent to explore and write a structured plan.",
+    insertText: "/plan ",
+    takesArguments: true,
+  },
+  {
+    command: "/model",
+    displayLabel: "/model [id]",
+    description: "List available models or switch the active model.",
+    insertText: "/model ",
+    takesArguments: true,
+  },
+  {
+    command: "/help",
+    aliases: ["/?"],
+    description: "Show this list.",
+    insertText: "/help ",
+    takesArguments: false,
+  },
+];
 
 describe("MentionTextarea", () => {
   beforeEach(() => {
@@ -394,5 +422,174 @@ describe("MentionTextarea", () => {
     });
 
     expect(document.activeElement).not.toBe(textbox);
+  });
+
+  it("shows slash suggestions at the start of the input, filters them, and inserts with Enter", async () => {
+    const handleRef = createRef<MentionTextareaHandle>();
+
+    render(
+      <ControlledMentionTextarea
+        handleRef={handleRef}
+        initialValue="/pl"
+        slashCommands={slashCommands}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox");
+    setEditorRect(textbox);
+
+    act(() => {
+      handleRef.current?.focus();
+      handleRef.current?.setSelectionRange(3, 3);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("/plan <task>")).not.toBeNull();
+    });
+    expect(screen.queryByText("/model [id]")).toBeNull();
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("/plan ");
+    });
+  });
+
+  it("matches the /? alias and inserts the canonical /help command with Tab", async () => {
+    const handleRef = createRef<MentionTextareaHandle>();
+
+    render(
+      <ControlledMentionTextarea
+        handleRef={handleRef}
+        initialValue="/?"
+        slashCommands={slashCommands}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox");
+    setEditorRect(textbox);
+
+    act(() => {
+      handleRef.current?.focus();
+      handleRef.current?.setSelectionRange(2, 2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("/help")).not.toBeNull();
+    });
+
+    fireEvent.keyDown(textbox, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("/help ");
+    });
+    expect(screen.queryByText("Show this list.")).toBeNull();
+  });
+
+  it("lets Enter reach the parent handler after selecting a zero-argument slash command", async () => {
+    const handleRef = createRef<MentionTextareaHandle>();
+    const onKeyDown = vi.fn((event: KeyboardEvent<HTMLTextAreaElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <ControlledMentionTextarea
+        handleRef={handleRef}
+        initialValue="/h"
+        onKeyDown={onKeyDown}
+        slashCommands={slashCommands}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox");
+    setEditorRect(textbox);
+
+    act(() => {
+      handleRef.current?.focus();
+      handleRef.current?.setSelectionRange(2, 2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("/help")).not.toBeNull();
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("/help ");
+    });
+    expect(screen.queryByText("Show this list.")).toBeNull();
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses the slash autocomplete on Escape and lets Enter reach the parent handler afterwards", async () => {
+    const handleRef = createRef<MentionTextareaHandle>();
+    const onKeyDown = vi.fn((event: KeyboardEvent<HTMLTextAreaElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <MentionTextarea
+        ref={handleRef}
+        onChange={vi.fn()}
+        onKeyDown={onKeyDown}
+        placeholder="Type a message…"
+        slashCommands={slashCommands}
+        value="/"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox");
+    setEditorRect(textbox);
+
+    act(() => {
+      handleRef.current?.focus();
+      handleRef.current?.setSelectionRange(1, 1);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("/plan <task>")).not.toBeNull();
+    });
+
+    act(() => {
+      fireEvent.keyDown(textbox, { key: "Escape" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("/plan <task>")).toBeNull();
+    });
+
+    act(() => {
+      fireEvent.keyDown(textbox, { key: "Enter" });
+    });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show the slash autocomplete after the first token", async () => {
+    const handleRef = createRef<MentionTextareaHandle>();
+
+    render(
+      <ControlledMentionTextarea
+        handleRef={handleRef}
+        initialValue="/plan write tests"
+        slashCommands={slashCommands}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox");
+    setEditorRect(textbox);
+
+    act(() => {
+      handleRef.current?.focus();
+      handleRef.current?.setSelectionRange(17, 17);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("/plan <task>")).toBeNull();
+    });
   });
 });

--- a/src/components/MentionTextarea.tsx
+++ b/src/components/MentionTextarea.tsx
@@ -39,6 +39,11 @@ import {
   type LexicalNode,
   type NodeKey,
 } from "lexical";
+import type { SlashCommandDefinition } from "@/agent/slashCommands";
+import {
+  filterSlashCommands,
+  matchesSlashCommandInput,
+} from "@/agent/slashCommands";
 import { cn } from "@/utils/cn";
 
 export interface MentionTextareaProps {
@@ -46,6 +51,7 @@ export interface MentionTextareaProps {
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
   cwd?: string;
+  slashCommands?: SlashCommandDefinition[];
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -65,15 +71,23 @@ type SelectionRange = {
 };
 
 type AutocompleteState = {
-  triggerId: "mention";
+  triggerId: "mention" | "slash";
   query: string;
   startPos: number;
   endPos: number;
 };
 
 type TriggerDefinition = {
-  id: "mention";
+  id: AutocompleteState["triggerId"];
   match: (textBeforeCursor: string) => null | Omit<AutocompleteState, "triggerId" | "endPos">;
+};
+
+type AutocompleteOption = {
+  key: string;
+  title: string;
+  description?: string;
+  insertText: string;
+  slashCommand?: SlashCommandDefinition;
 };
 
 type SelectionPoint =
@@ -297,6 +311,7 @@ export const MentionTextarea = forwardRef<
     onChange,
     onKeyDown,
     cwd,
+    slashCommands = [],
     placeholder,
     disabled = false,
     className,
@@ -311,7 +326,7 @@ export const MentionTextarea = forwardRef<
   const editorTextRef = useRef(value);
   const selectionRef = useRef<SelectionRange>({ start: value.length, end: value.length });
   const suppressOnChangeRef = useRef(false);
-  const mentionListRef = useRef<HTMLUListElement>(null);
+  const autocompleteListRef = useRef<HTMLUListElement>(null);
   const domDragDepthRef = useRef(0);
 
   const [files, setFiles] = useState<string[]>([]);
@@ -328,6 +343,18 @@ export const MentionTextarea = forwardRef<
 
   const triggerDefinitions = useMemo<TriggerDefinition[]>(
     () => [
+      {
+        id: "slash",
+        match(textBeforeCursor) {
+          const match = /^\/([^\s]*)$/.exec(textBeforeCursor);
+          if (!match) return null;
+
+          return {
+            query: match[1],
+            startPos: 0,
+          };
+        },
+      },
       {
         id: "mention",
         match(textBeforeCursor) {
@@ -425,16 +452,33 @@ export const MentionTextarea = forwardRef<
     [onChange, setEditorValue, syncAutocomplete],
   );
 
-  const filteredFiles = useMemo(() => {
-    if (autocomplete?.triggerId !== "mention") {
+  const autocompleteOptions = useMemo<AutocompleteOption[]>(() => {
+    if (!autocomplete) {
       return [];
     }
 
-    const normalizedQuery = autocomplete.query.toLowerCase();
-    return files
-      .filter((file) => file.toLowerCase().includes(normalizedQuery))
-      .slice(0, MAX_RESULTS);
-  }, [autocomplete, files]);
+    if (autocomplete.triggerId === "mention") {
+      const normalizedQuery = autocomplete.query.toLowerCase();
+      return files
+        .filter((file) => file.toLowerCase().includes(normalizedQuery))
+        .slice(0, MAX_RESULTS)
+        .map((file) => ({
+          key: `mention:${file}`,
+          title: file,
+          insertText: `@${file} `,
+        }));
+    }
+
+    return filterSlashCommands(slashCommands, autocomplete.query, MAX_RESULTS).map(
+      (definition) => ({
+        key: `slash:${definition.command}`,
+        title: definition.displayLabel ?? definition.command,
+        description: definition.description,
+        insertText: definition.insertText ?? definition.command,
+        slashCommand: definition,
+      }),
+    );
+  }, [autocomplete, files, slashCommands]);
 
   const autocompleteKey = autocomplete
     ? `${autocomplete.triggerId}:${autocomplete.query}`
@@ -445,12 +489,12 @@ export const MentionTextarea = forwardRef<
       : 0;
 
   const safeSelectedIndex =
-    filteredFiles.length > 0
-      ? Math.min(selectedIndex, filteredFiles.length - 1)
+    autocompleteOptions.length > 0
+      ? Math.min(selectedIndex, autocompleteOptions.length - 1)
       : 0;
 
-  const insertMention = useCallback(
-    (file: string) => {
+  const applyAutocompleteSelection = useCallback(
+    (option: AutocompleteOption) => {
       const currentValue = editorTextRef.current;
       const currentSelection = selectionRef.current;
       const activeAutocomplete = autocomplete;
@@ -459,7 +503,7 @@ export const MentionTextarea = forwardRef<
 
       const before = currentValue.slice(0, activeAutocomplete.startPos);
       const after = currentValue.slice(currentSelection.end);
-      const inserted = `@${file} `;
+      const inserted = option.insertText;
       const nextValue = before + inserted + after;
       const nextCursor = before.length + inserted.length;
 
@@ -593,13 +637,13 @@ export const MentionTextarea = forwardRef<
   }, [cwd]);
 
   useEffect(() => {
-    if (!autocomplete || filteredFiles.length === 0) return;
+    if (!autocomplete || autocompleteOptions.length === 0) return;
 
-    const list = mentionListRef.current;
+    const list = autocompleteListRef.current;
     if (!list) return;
 
     const selected = list.querySelector<HTMLElement>(
-      `[data-mention-index="${safeSelectedIndex}"]`,
+      `[data-autocomplete-index="${safeSelectedIndex}"]`,
     );
     if (!selected) return;
 
@@ -613,7 +657,7 @@ export const MentionTextarea = forwardRef<
     } else if (itemBottom > viewBottom) {
       list.scrollTop = itemBottom - list.clientHeight;
     }
-  }, [autocomplete, filteredFiles.length, safeSelectedIndex]);
+  }, [autocomplete, autocompleteOptions.length, safeSelectedIndex]);
 
   useEffect(() => {
     const unlistenFns: Array<() => void> = [];
@@ -727,14 +771,14 @@ export const MentionTextarea = forwardRef<
         event.nativeEvent.stopImmediatePropagation?.();
       };
 
-      if (autocomplete && filteredFiles.length > 0) {
+      if (autocomplete && autocompleteOptions.length > 0) {
         if (event.key === "ArrowDown") {
           consumeEvent();
           setAutocompleteSelection((current) => {
             const currentIndex = current.key === autocompleteKey ? current.index : 0;
             return {
               key: autocompleteKey,
-              index: (currentIndex + 1) % filteredFiles.length,
+              index: (currentIndex + 1) % autocompleteOptions.length,
             };
           });
           return;
@@ -746,15 +790,33 @@ export const MentionTextarea = forwardRef<
             const currentIndex = current.key === autocompleteKey ? current.index : 0;
             return {
               key: autocompleteKey,
-              index: (currentIndex - 1 + filteredFiles.length) % filteredFiles.length,
+              index:
+                (currentIndex - 1 + autocompleteOptions.length) %
+                autocompleteOptions.length,
             };
           });
           return;
         }
 
         if (event.key === "Enter" || event.key === "Tab") {
+          const selectedOption = autocompleteOptions[safeSelectedIndex];
+          const shouldSubmitExactSlashCommand =
+            event.key === "Enter" &&
+            autocomplete.triggerId === "slash" &&
+            !!selectedOption?.slashCommand &&
+            selectedOption.slashCommand.takesArguments === false &&
+            matchesSlashCommandInput(
+              editorTextRef.current,
+              selectedOption.slashCommand,
+            );
+
+          if (shouldSubmitExactSlashCommand) {
+            onKeyDown?.(event as unknown as KeyboardEvent<HTMLTextAreaElement>);
+            return;
+          }
+
           consumeEvent();
-          insertMention(filteredFiles[safeSelectedIndex]);
+          applyAutocompleteSelection(selectedOption);
           return;
         }
 
@@ -768,7 +830,14 @@ export const MentionTextarea = forwardRef<
 
       onKeyDown?.(event as unknown as KeyboardEvent<HTMLTextAreaElement>);
     },
-    [autocomplete, autocompleteKey, filteredFiles, insertMention, onKeyDown, safeSelectedIndex],
+    [
+      applyAutocompleteSelection,
+      autocomplete,
+      autocompleteKey,
+      autocompleteOptions,
+      onKeyDown,
+      safeSelectedIndex,
+    ],
   );
 
   const handleFocusCapture = useCallback(() => {
@@ -862,19 +931,19 @@ export const MentionTextarea = forwardRef<
           {placeholder}
         </div>
       )}
-      {autocomplete && filteredFiles.length > 0 && (
-        <ul ref={mentionListRef} className="mention-list">
-          {filteredFiles.map((file, index) => (
+      {autocomplete && autocompleteOptions.length > 0 && (
+        <ul ref={autocompleteListRef} className="mention-list">
+          {autocompleteOptions.map((option, index) => (
             <li
-              key={file}
-              data-mention-index={index}
+              key={option.key}
+              data-autocomplete-index={index}
               className={cn(
                 "mention-item",
                 index === safeSelectedIndex && "mention-item--active",
               )}
               onMouseDown={(event) => {
                 event.preventDefault();
-                insertMention(file);
+                applyAutocompleteSelection(option);
               }}
               onMouseEnter={() =>
                 setAutocompleteSelection({
@@ -883,7 +952,10 @@ export const MentionTextarea = forwardRef<
                 })
               }
             >
-              {file}
+              <div className="mention-item__title">{option.title}</div>
+              {option.description ? (
+                <div className="mention-item__description">{option.description}</div>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -643,6 +643,19 @@
   background: transparent;
   color: var(--color-text);
   border-radius: 4px;
+}
+
+.mention-item__title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mention-item__description {
+  margin-top: 2px;
+  color: var(--color-muted);
+  font-size: calc(var(--text-xs) - 1px);
+  line-height: 1.4;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -651,4 +664,8 @@
 .mention-item--active {
   background: var(--color-hover);
   color: var(--color-primary);
+}
+
+.mention-item--active .mention-item__description {
+  color: color-mix(in srgb, var(--color-primary) 75%, var(--color-text));
 }


### PR DESCRIPTION
## Summary
- add a shared slash command catalog for local commands and subagent triggers
- extend the Lexical chat input to autocomplete slash commands alongside file mentions
- keep zero-argument commands submit-friendly while closing the autocomplete after selection
- derive subagent slash command labels/argument behavior from subagent definitions

## Testing
- npm test -- --run src/components/MentionTextarea.test.tsx src/WorkspacePage.test.tsx
- npm run typecheck

Fixes #7