### PR TITLE
fix: support middle-click tab closing and reopen archived tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,10 @@ import {
   themeModeAtom,
   themeNameAtom,
   notifyOnAttentionAtom,
-  patchAgentState,
   agentAtomFamily,
 } from "@/agent/atoms";
 import { loadProviders, providersAtom } from "@/agent/db";
+import { hydratePersistedSession } from "@/agent/sessionRestore";
 import WorkspacePage from "@/WorkspacePage";
 import SettingsSidebar from "@/components/SettingsSidebar";
 import {
@@ -23,7 +23,7 @@ import {
   isSessionEmpty,
   type PersistedSession,
 } from "@/agent/persistence";
-import type { AgentStatus, AdvancedModelOptions, ToolCallDisplay } from "@/agent/types";
+import type { AgentStatus, ToolCallDisplay } from "@/agent/types";
 import { focusTab, showNotification } from "@/notifications";
 import { preloadEnvProviderKeys } from "@/agent/useEnvProviderKeys";
 import { getThemeSubagentColorVariables } from "@/styles/themes/registry";
@@ -252,46 +252,7 @@ export default function App() {
               }
             }
 
-            let restoredAdvancedOptions: AdvancedModelOptions | undefined;
-            try {
-              const parsed = s.advancedOptions
-                ? (JSON.parse(s.advancedOptions) as Partial<AdvancedModelOptions>)
-                : {};
-              if (
-                parsed.reasoningVisibility ||
-                parsed.reasoningEffort ||
-                parsed.latencyCostProfile
-              ) {
-                restoredAdvancedOptions = parsed as AdvancedModelOptions;
-              }
-            } catch {
-              // ignore malformed JSON
-            }
-
-            patchAgentState(s.id, {
-              status: restoreError ? "error" : "idle",
-              tabTitle: s.tabTitle,
-              config: {
-                cwd: s.cwd,
-                model: s.model,
-                worktreePath: s.worktreePath || undefined,
-                worktreeBranch: s.worktreeBranch || undefined,
-                worktreeDeclined: s.worktreeDeclined || undefined,
-                advancedOptions: restoredAdvancedOptions,
-              },
-              plan: {
-                markdown: s.planMarkdown,
-                version: s.planVersion,
-                updatedAtMs: s.planUpdatedAt,
-              },
-              chatMessages: JSON.parse(s.chatMessages),
-              apiMessages: JSON.parse(s.apiMessages),
-              todos: JSON.parse(s.todos),
-              reviewEdits: JSON.parse(s.reviewEdits ?? "[]"),
-              streamingContent: null,
-              error: restoreError,
-              showDebug: s.showDebug ?? false,
-            });
+            hydratePersistedSession(s, { restoreError });
           } catch (e) {
             console.error("rakh: failed to restore session", s.id, e);
           }

--- a/src/agent/sessionRestore.test.ts
+++ b/src/agent/sessionRestore.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const persistenceMock = vi.hoisted(() => ({
+  loadArchivedSessions: vi.fn(),
+  restoreSession: vi.fn(),
+}));
+
+vi.mock("./persistence", async () => {
+  const actual = await vi.importActual<typeof import("./persistence")>(
+    "./persistence",
+  );
+
+  return {
+    ...actual,
+    loadArchivedSessions: (...args: unknown[]) =>
+      persistenceMock.loadArchivedSessions(...args),
+    restoreSession: (...args: unknown[]) =>
+      persistenceMock.restoreSession(...args),
+  };
+});
+
+import { agentAtomFamily, jotaiStore } from "./atoms";
+import type { PersistedSession } from "./persistence";
+import {
+  restoreArchivedTab,
+  restoreMostRecentArchivedTab,
+} from "./sessionRestore";
+
+function makeSession(
+  id: string,
+  overrides: Partial<PersistedSession> = {},
+): PersistedSession {
+  return {
+    id,
+    label: "Workspace",
+    icon: "folder",
+    mode: "workspace",
+    tabTitle: "Ship tab restore",
+    cwd: "/repo",
+    model: "openai/gpt-5.2",
+    planMarkdown: "plan",
+    planVersion: 2,
+    planUpdatedAt: 100,
+    chatMessages: JSON.stringify([{ role: "user", content: "hello" }]),
+    apiMessages: JSON.stringify([{ role: "assistant", content: "world" }]),
+    todos: JSON.stringify([{ id: "todo-1", text: "ship", status: "todo" }]),
+    reviewEdits: JSON.stringify([{ filePath: "src/App.tsx" }]),
+    archived: true,
+    createdAt: 1,
+    updatedAt: 2,
+    worktreePath: "/repo/.worktree",
+    worktreeBranch: "codex/branch",
+    worktreeDeclined: true,
+    showDebug: true,
+    advancedOptions: JSON.stringify({
+      reasoningVisibility: "detailed",
+      reasoningEffort: "high",
+      latencyCostProfile: "fast",
+    }),
+    ...overrides,
+  };
+}
+
+describe("sessionRestore", () => {
+  beforeEach(() => {
+    persistenceMock.loadArchivedSessions.mockReset();
+    persistenceMock.restoreSession.mockReset();
+  });
+
+  it("restores an archived session into agent state and the tab strip", async () => {
+    const session = makeSession("restore-session-1");
+    const addTabWithId = vi.fn();
+
+    persistenceMock.restoreSession.mockResolvedValue(undefined);
+
+    await restoreArchivedTab(session, addTabWithId);
+
+    expect(persistenceMock.restoreSession).toHaveBeenCalledWith(session);
+    expect(addTabWithId).toHaveBeenCalledWith({
+      id: session.id,
+      label: session.label,
+      icon: session.icon,
+      status: "idle",
+      mode: "workspace",
+    });
+
+    const state = jotaiStore.get(agentAtomFamily(session.id));
+    expect(state.status).toBe("idle");
+    expect(state.tabTitle).toBe(session.tabTitle);
+    expect(state.config).toMatchObject({
+      cwd: session.cwd,
+      model: session.model,
+      worktreePath: session.worktreePath,
+      worktreeBranch: session.worktreeBranch,
+      worktreeDeclined: session.worktreeDeclined,
+      advancedOptions: {
+        reasoningVisibility: "detailed",
+        reasoningEffort: "high",
+        latencyCostProfile: "fast",
+      },
+    });
+    expect(state.plan).toEqual({
+      markdown: session.planMarkdown,
+      version: session.planVersion,
+      updatedAtMs: session.planUpdatedAt,
+    });
+    expect(state.chatMessages).toEqual([{ role: "user", content: "hello" }]);
+    expect(state.apiMessages).toEqual([{ role: "assistant", content: "world" }]);
+    expect(state.todos).toEqual([{ id: "todo-1", text: "ship", status: "todo" }]);
+    expect(state.reviewEdits).toEqual([{ filePath: "src/App.tsx" }]);
+    expect(state.showDebug).toBe(true);
+  });
+
+  it("restores the most recent archived session from the archived list", async () => {
+    const mostRecent = makeSession("restore-session-2");
+    const older = makeSession("restore-session-3");
+    const addTabWithId = vi.fn();
+
+    persistenceMock.loadArchivedSessions.mockResolvedValue([mostRecent, older]);
+    persistenceMock.restoreSession.mockResolvedValue(undefined);
+
+    const restored = await restoreMostRecentArchivedTab(addTabWithId);
+
+    expect(restored).toEqual(mostRecent);
+    expect(persistenceMock.restoreSession).toHaveBeenCalledWith(mostRecent);
+    expect(addTabWithId).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when there are no archived sessions to restore", async () => {
+    const addTabWithId = vi.fn();
+
+    persistenceMock.loadArchivedSessions.mockResolvedValue([]);
+
+    const restored = await restoreMostRecentArchivedTab(addTabWithId);
+
+    expect(restored).toBeNull();
+    expect(persistenceMock.restoreSession).not.toHaveBeenCalled();
+    expect(addTabWithId).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent/sessionRestore.ts
+++ b/src/agent/sessionRestore.ts
@@ -1,0 +1,103 @@
+import type { Tab } from "@/contexts/TabsContext";
+import { patchAgentState } from "./atoms";
+import {
+  loadArchivedSessions,
+  restoreSession,
+  type PersistedSession,
+} from "./persistence";
+import type { AdvancedModelOptions } from "./types";
+
+interface HydratePersistedSessionOptions {
+  restoreError?: string | null;
+}
+
+type AddTabWithId = (tab: Tab) => void;
+
+function parseAdvancedOptions(
+  advancedOptions: string,
+): AdvancedModelOptions | undefined {
+  try {
+    const parsed = advancedOptions
+      ? (JSON.parse(advancedOptions) as Partial<AdvancedModelOptions>)
+      : {};
+
+    if (
+      parsed.reasoningVisibility ||
+      parsed.reasoningEffort ||
+      parsed.latencyCostProfile
+    ) {
+      return parsed as AdvancedModelOptions;
+    }
+  } catch {
+    // Ignore malformed JSON and fall back to defaults.
+  }
+
+  return undefined;
+}
+
+function buildTabFromSession(session: PersistedSession): Tab {
+  return {
+    id: session.id,
+    label: session.label,
+    icon: session.icon,
+    status: "idle",
+    mode: session.mode as Tab["mode"],
+  };
+}
+
+export function hydratePersistedSession(
+  session: PersistedSession,
+  options: HydratePersistedSessionOptions = {},
+): void {
+  const restoreError = options.restoreError ?? null;
+
+  patchAgentState(session.id, {
+    status: restoreError ? "error" : "idle",
+    tabTitle: session.tabTitle,
+    config: {
+      cwd: session.cwd,
+      model: session.model,
+      worktreePath: session.worktreePath || undefined,
+      worktreeBranch: session.worktreeBranch || undefined,
+      worktreeDeclined: session.worktreeDeclined || undefined,
+      advancedOptions: parseAdvancedOptions(session.advancedOptions),
+    },
+    plan: {
+      markdown: session.planMarkdown,
+      version: session.planVersion,
+      updatedAtMs: session.planUpdatedAt,
+    },
+    chatMessages: JSON.parse(session.chatMessages),
+    apiMessages: JSON.parse(session.apiMessages),
+    todos: JSON.parse(session.todos),
+    reviewEdits: JSON.parse(session.reviewEdits ?? "[]"),
+    streamingContent: null,
+    error: restoreError,
+    showDebug: session.showDebug ?? false,
+  });
+}
+
+export async function restoreArchivedTab(
+  session: PersistedSession,
+  addTabWithId: AddTabWithId,
+): Promise<void> {
+  await restoreSession(session);
+
+  try {
+    hydratePersistedSession(session);
+  } catch (error) {
+    console.error("rakh: failed to hydrate restored session", error);
+  }
+
+  addTabWithId(buildTabFromSession(session));
+}
+
+export async function restoreMostRecentArchivedTab(
+  addTabWithId: AddTabWithId,
+): Promise<PersistedSession | null> {
+  const [session] = await loadArchivedSessions();
+  if (!session) return null;
+
+  await restoreArchivedTab(session, addTabWithId);
+  return session;
+}

--- a/src/components/ArchivedTabsMenu.tsx
+++ b/src/components/ArchivedTabsMenu.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { patchAgentState } from "@/agent/atoms";
+import { restoreArchivedTab } from "@/agent/sessionRestore";
 import {
   loadArchivedSessions,
-  restoreSession,
   deleteSession,
   type PersistedSession,
 } from "@/agent/persistence";
@@ -65,35 +64,7 @@ export default function ArchivedTabsMenu() {
 
   const handleRestore = useCallback(
     async (session: PersistedSession) => {
-      await restoreSession(session);
-      try {
-        patchAgentState(session.id, {
-          status: "idle",
-          tabTitle: session.tabTitle,
-          config: { cwd: session.cwd, model: session.model },
-          plan: {
-            markdown: session.planMarkdown,
-            version: session.planVersion,
-            updatedAtMs: session.planUpdatedAt,
-          },
-          chatMessages: JSON.parse(session.chatMessages),
-          apiMessages: JSON.parse(session.apiMessages),
-          todos: JSON.parse(session.todos),
-          reviewEdits: JSON.parse(session.reviewEdits ?? "[]"),
-          streamingContent: null,
-          error: null,
-          showDebug: session.showDebug ?? false,
-        });
-      } catch (e) {
-        console.error("rakh: failed to hydrate restored session", e);
-      }
-      addTabWithId({
-        id: session.id,
-        label: session.label,
-        icon: session.icon,
-        status: "idle",
-        mode: session.mode as "new" | "workspace",
-      });
+      await restoreArchivedTab(session, addTabWithId);
       setOpen(false);
       setSessions((prev) => prev.filter((s) => s.id !== session.id));
     },

--- a/src/components/TopChrome.test.tsx
+++ b/src/components/TopChrome.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "jotai";
 import TopChrome from "./TopChrome";
 import {
@@ -25,13 +25,23 @@ const tabsContextMock = vi.hoisted(() => ({
     activeTabId: "tab-1",
     setActiveTab: vi.fn(),
     addTab: vi.fn(),
+    addTabWithId: vi.fn(),
     closeTab: vi.fn(),
     reorderTabs: vi.fn(),
   },
 }));
 
+const sessionRestoreMock = vi.hoisted(() => ({
+  restoreMostRecentArchivedTab: vi.fn(),
+}));
+
 vi.mock("@/contexts/TabsContext", () => ({
   useTabs: () => tabsContextMock.value,
+}));
+
+vi.mock("@/agent/sessionRestore", () => ({
+  restoreMostRecentArchivedTab: (...args: unknown[]) =>
+    sessionRestoreMock.restoreMostRecentArchivedTab(...args),
 }));
 
 vi.mock("@/components/ArchivedTabsMenu", () => ({
@@ -81,16 +91,36 @@ vi.mock("framer-motion", async () => {
   };
 });
 
-describe("TopChrome updater badge", () => {
+function setNavigatorPlatform(value: string) {
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("TopChrome", () => {
   beforeEach(() => {
     cleanup();
     localStorage.clear();
+    setNavigatorPlatform("MacIntel");
     jotaiStore.set(appUpdaterStateAtom, { ...defaultAppUpdaterState });
     jotaiStore.set(settingsSidebarOpenAtom, false);
+    tabsContextMock.value.tabs = [
+      {
+        id: "tab-1",
+        label: "Workspace",
+        icon: "chat_bubble_outline",
+        status: "idle",
+        mode: "workspace",
+      },
+    ];
+    tabsContextMock.value.activeTabId = "tab-1";
     tabsContextMock.value.setActiveTab.mockReset();
     tabsContextMock.value.addTab.mockReset();
+    tabsContextMock.value.addTabWithId.mockReset();
     tabsContextMock.value.closeTab.mockReset();
     tabsContextMock.value.reorderTabs.mockReset();
+    sessionRestoreMock.restoreMostRecentArchivedTab.mockReset();
   });
 
   afterEach(() => {
@@ -121,5 +151,86 @@ describe("TopChrome updater badge", () => {
     renderTopChrome();
 
     expect(screen.getByTestId("settings-update-badge")).not.toBeNull();
+  });
+
+  it("middle-click closes the clicked tab without activating it", () => {
+    tabsContextMock.value.tabs = [
+      {
+        id: "tab-1",
+        label: "Workspace",
+        icon: "chat_bubble_outline",
+        status: "idle",
+        mode: "workspace",
+      },
+      {
+        id: "tab-2",
+        label: "History",
+        icon: "history",
+        status: "idle",
+        mode: "workspace",
+      },
+    ];
+
+    renderTopChrome();
+
+    const historyTab = screen.getByRole("tab", { name: /history/i });
+    fireEvent.pointerDown(historyTab, { button: 1 });
+    fireEvent(
+      historyTab,
+      new MouseEvent("auxclick", { bubbles: true, button: 1 }),
+    );
+
+    expect(tabsContextMock.value.closeTab).toHaveBeenCalledWith("tab-2");
+    expect(tabsContextMock.value.setActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("middle-button presses do not start drag reorder", () => {
+    tabsContextMock.value.tabs = [
+      {
+        id: "tab-1",
+        label: "Workspace",
+        icon: "chat_bubble_outline",
+        status: "idle",
+        mode: "workspace",
+      },
+      {
+        id: "tab-2",
+        label: "History",
+        icon: "history",
+        status: "idle",
+        mode: "workspace",
+      },
+    ];
+
+    renderTopChrome();
+
+    const workspaceTab = screen.getByRole("tab", { name: /workspace/i });
+    const historyTab = screen.getByRole("tab", { name: /history/i });
+
+    fireEvent.pointerDown(workspaceTab, { button: 1 });
+    fireEvent.pointerEnter(historyTab);
+
+    expect(tabsContextMock.value.reorderTabs).not.toHaveBeenCalled();
+  });
+
+  it("uses Cmd+Shift+T on macOS to reopen the most recent archived tab", () => {
+    renderTopChrome();
+
+    fireEvent.keyDown(window, { key: "T", metaKey: true, shiftKey: true });
+
+    expect(sessionRestoreMock.restoreMostRecentArchivedTab).toHaveBeenCalledWith(
+      tabsContextMock.value.addTabWithId,
+    );
+  });
+
+  it("uses Ctrl+Shift+T on Windows to reopen the most recent archived tab", () => {
+    setNavigatorPlatform("Win32");
+    renderTopChrome();
+
+    fireEvent.keyDown(window, { key: "T", ctrlKey: true, shiftKey: true });
+
+    expect(sessionRestoreMock.restoreMostRecentArchivedTab).toHaveBeenCalledWith(
+      tabsContextMock.value.addTabWithId,
+    );
   });
 });

--- a/src/components/TopChrome.tsx
+++ b/src/components/TopChrome.tsx
@@ -14,6 +14,7 @@ import {
   agentStatusAtomFamily,
   jotaiStore,
 } from "@/agent/atoms";
+import { restoreMostRecentArchivedTab } from "@/agent/sessionRestore";
 import CloseTabModal from "@/components/CloseTabModal";
 import ArchivedTabsMenu from "@/components/ArchivedTabsMenu";
 import { cn } from "@/utils/cn";
@@ -87,8 +88,15 @@ const IconClose = () => (
 
 /* ── Component ──────────────────────────────────────────────────────────── */
 export default function TopChrome() {
-  const { tabs, activeTabId, setActiveTab, addTab, closeTab, reorderTabs } =
-    useTabs();
+  const {
+    tabs,
+    activeTabId,
+    setActiveTab,
+    addTab,
+    addTabWithId,
+    closeTab,
+    reorderTabs,
+  } = useTabs();
   const [, setSettingsSidebarOpen] = useAtom(settingsSidebarOpenAtom);
   const [appUpdater] = useAtom(appUpdaterStateAtom);
   const showUpdateBadge = shouldShowAppUpdateBadge(appUpdater);
@@ -183,27 +191,47 @@ export default function TopChrome() {
     };
   }, []);
 
+  // ── Window state ─────────────────────────────────────────────────────
+  const [platform, setPlatform] = useState<Platform>("other");
+  const [isMaximized, setIsMaximized] = useState(false);
+  const [isFocused, setIsFocused] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
   // ── Keyboard shortcuts ────────────────────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === "Tab" && !e.shiftKey) {
+      const key = e.key.toLowerCase();
+      const isMac = platform === "mac";
+
+      if (e.ctrlKey && key === "tab" && !e.shiftKey) {
         e.preventDefault();
         const idx = tabs.findIndex((t) => t.id === activeTabId);
         setActiveTab(tabs[(idx + 1) % tabs.length].id);
         return;
       }
-      if (e.ctrlKey && e.key === "Tab" && e.shiftKey) {
+      if (e.ctrlKey && key === "tab" && e.shiftKey) {
         e.preventDefault();
         const idx = tabs.findIndex((t) => t.id === activeTabId);
         setActiveTab(tabs[(idx - 1 + tabs.length) % tabs.length].id);
         return;
       }
-      if (e.metaKey && e.key === "t") {
+      if (e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && key === "t") {
         e.preventDefault();
         addTab();
         return;
       }
-      if (e.metaKey && e.key === "w") {
+      if (
+        ((isMac && e.metaKey && !e.ctrlKey) ||
+          (!isMac && e.ctrlKey && !e.metaKey)) &&
+        !e.altKey &&
+        e.shiftKey &&
+        key === "t"
+      ) {
+        e.preventDefault();
+        void restoreMostRecentArchivedTab(addTabWithId);
+        return;
+      }
+      if (e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && key === "w") {
         e.preventDefault();
         const activeTab = tabs.find((t) => t.id === activeTabId);
         if (tabs.length === 1 && activeTab?.mode === "new") {
@@ -221,13 +249,15 @@ export default function TopChrome() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [tabs, activeTabId, setActiveTab, addTab, handleCloseTab]);
-
-  // ── Window state ─────────────────────────────────────────────────────
-  const [platform, setPlatform] = useState<Platform>("other");
-  const [isMaximized, setIsMaximized] = useState(false);
-  const [isFocused, setIsFocused] = useState(true);
-  const [isFullscreen, setIsFullscreen] = useState(false);
+  }, [
+    tabs,
+    activeTabId,
+    setActiveTab,
+    addTab,
+    addTabWithId,
+    handleCloseTab,
+    platform,
+  ]);
 
   useEffect(() => {
     setPlatform(detectPlatform());
@@ -326,11 +356,23 @@ export default function TopChrome() {
                   tab.id === activeTabId && "tab--active",
                   dragTabId === tab.id && "tab--dragging",
                 )}
-                onMouseDown={(e) => e.stopPropagation()}
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  if (e.button === 1) {
+                    e.preventDefault();
+                  }
+                }}
                 onPointerDown={(e) => {
                   e.stopPropagation();
+                  if (e.button !== 0) return;
                   dragTabIdRef.current = tab.id;
                   setDragTabId(tab.id);
+                }}
+                onAuxClick={(e) => {
+                  if (e.button !== 1) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleCloseTab(tab.id);
                 }}
                 onPointerEnter={() => {
                   if (!dragTabIdRef.current || dragTabIdRef.current === tab.id)


### PR DESCRIPTION
## Summary
- add middle-click tab closing without triggering tab activation or drag reordering
- add browser-style reopen shortcuts to restore the most recently archived tab
- share archived-session restore hydration between startup, the archived menu, and the new shortcut

## Testing
- npm run test -- --run src/components/TopChrome.test.tsx src/agent/sessionRestore.test.ts src/agent/persistence.test.ts
- npm run typecheck

Fixes #56