### PR TITLE
feat(ui): enhance tab tooltip status popover

### DIFF
--- a/src/components/TopChrome.test.tsx
+++ b/src/components/TopChrome.test.tsx
@@ -1,15 +1,19 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "jotai";
 import TopChrome from "./TopChrome";
+import type { Tab } from "@/contexts/TabsContext";
 import {
+  DEFAULT_MODEL,
   appUpdaterStateAtom,
   defaultAppUpdaterState,
   jotaiStore,
+  patchAgentState,
   settingsSidebarOpenAtom,
 } from "@/agent/atoms";
+import type { AgentStatus, ChatMessage } from "@/agent/types";
 
 const tabsContextMock = vi.hoisted(() => ({
   value: {
@@ -21,7 +25,7 @@ const tabsContextMock = vi.hoisted(() => ({
         status: "idle" as const,
         mode: "workspace" as const,
       },
-    ],
+    ] as Tab[],
     activeTabId: "tab-1",
     setActiveTab: vi.fn(),
     addTab: vi.fn(),
@@ -98,6 +102,57 @@ function setNavigatorPlatform(value: string) {
   });
 }
 
+function renderTopChrome() {
+  return render(
+    <Provider store={jotaiStore}>
+      <TopChrome />
+    </Provider>,
+  );
+}
+
+function setAgentState(
+  tabId: string,
+  {
+    chatMessages = [],
+    cwd = "",
+    status = "idle",
+    tabTitle = "",
+    worktreeBranch,
+  }: {
+    chatMessages?: ChatMessage[];
+    cwd?: string;
+    status?: AgentStatus;
+    tabTitle?: string;
+    worktreeBranch?: string;
+  } = {},
+) {
+  patchAgentState(tabId, {
+    chatMessages,
+    config: {
+      cwd,
+      model: DEFAULT_MODEL,
+      ...(worktreeBranch ? { worktreeBranch } : {}),
+    },
+    status,
+    tabTitle,
+  });
+}
+
+function hoverTab(label: string) {
+  const tab = screen.getByText(label).closest('[role="tab"]');
+  if (!(tab instanceof HTMLElement)) {
+    throw new Error(`Unable to find tab for ${label}`);
+  }
+  fireEvent.mouseEnter(tab);
+  return tab;
+}
+
+function revealTooltip() {
+  act(() => {
+    vi.advanceTimersByTime(500);
+  });
+}
+
 describe("TopChrome", () => {
   beforeEach(() => {
     cleanup();
@@ -110,8 +165,8 @@ describe("TopChrome", () => {
         id: "tab-1",
         label: "Workspace",
         icon: "chat_bubble_outline",
-        status: "idle",
-        mode: "workspace",
+        status: "idle" as const,
+        mode: "workspace" as const,
       },
     ];
     tabsContextMock.value.activeTabId = "tab-1";
@@ -121,19 +176,12 @@ describe("TopChrome", () => {
     tabsContextMock.value.closeTab.mockReset();
     tabsContextMock.value.reorderTabs.mockReset();
     sessionRestoreMock.restoreMostRecentArchivedTab.mockReset();
+    setAgentState("tab-1");
   });
 
   afterEach(() => {
     cleanup();
   });
-
-  function renderTopChrome() {
-    return render(
-      <Provider store={jotaiStore}>
-        <TopChrome />
-      </Provider>,
-    );
-  }
 
   it("hides the settings update badge when no update is available", () => {
     renderTopChrome();
@@ -232,5 +280,208 @@ describe("TopChrome", () => {
     expect(sessionRestoreMock.restoreMostRecentArchivedTab).toHaveBeenCalledWith(
       tabsContextMock.value.addTabWithId,
     );
+  });
+});
+
+describe("TopChrome tooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cleanup();
+    jotaiStore.set(appUpdaterStateAtom, { ...defaultAppUpdaterState });
+    jotaiStore.set(settingsSidebarOpenAtom, false);
+    tabsContextMock.value.tabs = [
+      {
+        id: "tab-1",
+        label: "Workspace",
+        icon: "chat_bubble_outline",
+        status: "idle" as const,
+        mode: "workspace" as const,
+      },
+    ];
+    tabsContextMock.value.activeTabId = "tab-1";
+    patchAgentState("tab-1", {
+      chatMessages: [],
+      config: {
+        cwd: "",
+        model: DEFAULT_MODEL,
+      },
+      status: "idle",
+      tabTitle: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("shows structured tooltip content after the hover delay", () => {
+    patchAgentState("tab-1", {
+      chatMessages: [],
+      config: {
+        cwd: "/Users/amir/projects/my-project",
+        model: DEFAULT_MODEL,
+        worktreeBranch: "feat/auth",
+      },
+      status: "working",
+      tabTitle: "Fix login session handling",
+    });
+
+    renderTopChrome();
+
+    hoverTab("Workspace");
+    expect(screen.queryByText("my-project [feat/auth]")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(screen.queryByText("my-project [feat/auth]")).toBeNull();
+
+    revealTooltip();
+
+    expect(screen.getByText("my-project [feat/auth]")).not.toBeNull();
+    expect(screen.getByText("Fix login session handling")).not.toBeNull();
+    expect(screen.getByText("Working")).not.toBeNull();
+    expect(document.querySelector(".tab-popover__status-pill")?.textContent).toBe(
+      "Working",
+    );
+    expect(document.querySelector(".tab-popover__header .tab-popover__status-pill")).not.toBeNull();
+  });
+
+  it("shows done for settled tabs that already produced activity", () => {
+    patchAgentState("tab-1", {
+      chatMessages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "Finished the refactor.",
+          timestamp: 1,
+        },
+      ],
+      config: {
+        cwd: "/Users/amir/projects/refactor-db",
+        model: DEFAULT_MODEL,
+      },
+      status: "idle",
+      tabTitle: "",
+    });
+
+    renderTopChrome();
+
+    hoverTab("Workspace");
+    revealTooltip();
+
+    expect(screen.getByText("refactor-db")).not.toBeNull();
+    expect(screen.getByText("Done")).not.toBeNull();
+    const popover = document.querySelector(".tab-popover");
+    expect(popover?.querySelector(".tab-popover__title")).toBeNull();
+  });
+
+  it("shows a new-session fallback without an idle pill", () => {
+    tabsContextMock.value.tabs = [
+      {
+        id: "tab-new",
+        label: "New Tab",
+        icon: "chat_bubble_outline",
+        status: "idle" as const,
+        mode: "new" as const,
+      },
+    ];
+    tabsContextMock.value.activeTabId = "tab-new";
+    patchAgentState("tab-new", {
+      chatMessages: [],
+      config: {
+        cwd: "",
+        model: DEFAULT_MODEL,
+      },
+      status: "idle",
+      tabTitle: "",
+    });
+
+    renderTopChrome();
+
+    hoverTab("New Tab");
+    revealTooltip();
+
+    expect(screen.getByText("New session")).not.toBeNull();
+    expect(document.querySelector(".tab-popover__status-pill")).toBeNull();
+  });
+
+  it("prioritizes awaiting approval over the base agent status", () => {
+    patchAgentState("tab-1", {
+      chatMessages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "",
+          timestamp: 1,
+          toolCalls: [
+            {
+              id: "tc-1",
+              tool: "exec_run",
+              args: { cmd: "npm test" },
+              status: "awaiting_approval",
+            },
+          ],
+        },
+      ],
+      config: {
+        cwd: "/Users/amir/projects/my-project",
+        model: DEFAULT_MODEL,
+      },
+      status: "working",
+      tabTitle: "Run checks",
+    });
+
+    renderTopChrome();
+
+    hoverTab("Workspace");
+    revealTooltip();
+
+    expect(screen.getByText("Requires attention")).not.toBeNull();
+    expect(screen.queryByText("Working")).toBeNull();
+  });
+
+  it("prioritizes awaiting worktree over other statuses", () => {
+    patchAgentState("tab-1", {
+      chatMessages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "",
+          timestamp: 1,
+          toolCalls: [
+            {
+              id: "tc-1",
+              tool: "git_worktree_init",
+              args: {},
+              status: "awaiting_worktree",
+            },
+            {
+              id: "tc-2",
+              tool: "exec_run",
+              args: { cmd: "npm test" },
+              status: "awaiting_approval",
+            },
+          ],
+        },
+      ],
+      config: {
+        cwd: "/Users/amir/projects/my-project",
+        model: DEFAULT_MODEL,
+      },
+      status: "thinking",
+      tabTitle: "Prepare worktree",
+    });
+
+    renderTopChrome();
+
+    hoverTab("Workspace");
+    revealTooltip();
+
+    expect(screen.getByText("Requires attention")).not.toBeNull();
+    expect(screen.queryByText("Working")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
   });
 });

--- a/src/components/TopChrome.tsx
+++ b/src/components/TopChrome.tsx
@@ -5,13 +5,16 @@ import {
   useCallback,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { useTabs } from "@/contexts/TabsContext";
-import { useAtom } from "jotai";
+import { useTabs, type Tab } from "@/contexts/TabsContext";
+import { useAtom, useAtomValue } from "jotai";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   settingsSidebarOpenAtom,
   appUpdaterStateAtom,
+  agentChatMessagesAtomFamily,
+  agentConfigAtomFamily,
   agentStatusAtomFamily,
+  agentTabTitleAtomFamily,
   jotaiStore,
 } from "@/agent/atoms";
 import { restoreMostRecentArchivedTab } from "@/agent/sessionRestore";
@@ -19,9 +22,16 @@ import CloseTabModal from "@/components/CloseTabModal";
 import ArchivedTabsMenu from "@/components/ArchivedTabsMenu";
 import { cn } from "@/utils/cn";
 import { shouldShowAppUpdateBadge } from "@/updater";
+import type { AgentStatus, ChatMessage } from "@/agent/types";
 
 /* ── Types ──────────────────────────────────────────────────────────────── */
 type Platform = "mac" | "windows" | "other";
+type TooltipStatusTone = "attention" | "working" | "done";
+
+interface TooltipStatusDisplay {
+  label: string;
+  tone: TooltipStatusTone;
+}
 
 function detectPlatform(): Platform {
   const p = (navigator.platform ?? "").toLowerCase();
@@ -35,6 +45,84 @@ function isTauriRuntime(): boolean {
   return (
     typeof window !== "undefined" &&
     ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+  );
+}
+
+function getWorkspaceName(cwd: string, branch?: string): string {
+  const trimmedCwd = cwd.trim();
+  if (!trimmedCwd) return "Workspace";
+  const folder = trimmedCwd.split("/").filter(Boolean).pop() ?? trimmedCwd;
+  return branch ? `${folder} [${branch}]` : folder;
+}
+
+function resolveTooltipStatus(
+  status: AgentStatus,
+  chatMessages: ChatMessage[],
+  tabTitle: string,
+): TooltipStatusDisplay | null {
+  const toolCalls = chatMessages.flatMap((message) => message.toolCalls ?? []);
+  const requiresAttention =
+    status === "error" ||
+    toolCalls.some(
+      (toolCall) =>
+        toolCall.status === "awaiting_worktree" ||
+        toolCall.status === "awaiting_approval",
+    );
+  if (requiresAttention) {
+    return { label: "Requires attention", tone: "attention" };
+  }
+
+  if (status === "thinking" || status === "working") {
+    return { label: "Working", tone: "working" };
+  }
+
+  const hasCompletedActivity =
+    chatMessages.length > 0 || tabTitle.trim().length > 0 || status === "done";
+  if (hasCompletedActivity) {
+    return { label: "Done", tone: "done" };
+  }
+
+  return null;
+}
+
+function TabPopoverContent({
+  tabId,
+  mode,
+}: {
+  tabId: string;
+  mode: Tab["mode"];
+}) {
+  const config = useAtomValue(agentConfigAtomFamily(tabId));
+  const tabTitle = useAtomValue(agentTabTitleAtomFamily(tabId));
+  const status = useAtomValue(agentStatusAtomFamily(tabId));
+  const chatMessages = useAtomValue(agentChatMessagesAtomFamily(tabId));
+
+  const workspaceName =
+    mode === "new"
+      ? "New session"
+      : getWorkspaceName(config.cwd, config.worktreeBranch);
+  const trimmedTitle = tabTitle.trim();
+  const tooltipStatus = resolveTooltipStatus(status, chatMessages, trimmedTitle);
+
+  return (
+    <>
+      <div className="tab-popover__header">
+        <div className="tab-popover__workspace">{workspaceName}</div>
+        {tooltipStatus ? (
+          <div className="tab-popover__status">
+            <span
+              className="tab-popover__status-pill"
+              data-tone={tooltipStatus.tone}
+            >
+              {tooltipStatus.label}
+            </span>
+          </div>
+        ) : null}
+      </div>
+      {trimmedTitle ? (
+        <div className="tab-popover__title">{trimmedTitle}</div>
+      ) : null}
+    </>
   );
 }
 
@@ -451,7 +539,7 @@ export default function TopChrome() {
                       zIndex: 10000,
                     }}
                   >
-                    {tab.label || "Untitled"}
+                    <TabPopoverContent tabId={tab.id} mode={tab.mode} />
                   </motion.div>
                 );
               })()}

--- a/src/styles/layout-chrome.css
+++ b/src/styles/layout-chrome.css
@@ -200,18 +200,100 @@
 
 /* ── Tab popover ─────────────────────────────────────────────────────────── */
 .tab-popover {
-  padding: 6px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 180px;
+  max-width: 320px;
+  padding: 8px 10px;
   background: var(--color-elevated);
   border: 1px solid var(--color-border-mid);
   border-radius: 6px;
   color: var(--color-text);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  white-space: nowrap;
   box-shadow: var(--shadow-soft);
-  max-width: 400px;
+}
+
+.tab-popover__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tab-popover__workspace {
+  flex: 1;
   overflow: hidden;
+  color: var(--color-muted);
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tab-popover__title {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.tab-popover__status {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.tab-popover__status-pill {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 1px 6px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tab-popover__status-pill[data-tone="idle"] {
+  color: var(--color-muted);
+  background: color-mix(in srgb, var(--color-muted) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-muted) 18%, transparent);
+}
+
+.tab-popover__status-pill[data-tone="attention"] {
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.tab-popover__status-pill[data-tone="working"] {
+  color: var(--color-status-working);
+  background: color-mix(in srgb, var(--color-status-working) 14%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--color-status-working) 24%,
+    transparent
+  );
+}
+
+.tab-popover__status-pill[data-tone="done"] {
+  color: var(--color-status-done);
+  background: color-mix(in srgb, var(--color-status-done) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-status-done) 24%, transparent);
 }
 
 /* ── New-tab button ──────────────────────────────────────────────────────── */
@@ -410,4 +492,3 @@
   color: var(--color-error) !important;
   background: color-mix(in srgb, var(--color-error) 12%, transparent);
 }
-


### PR DESCRIPTION
## Summary
- replace the single-line tab tooltip with structured workspace, title, and status content
- simplify the tooltip status pill to Requires attention, Working, and Done, with no pill for untouched idle tabs
- move the pill to the top-right corner and shrink its visual footprint

## Testing
- npm test -- --run src/components/TopChrome.test.tsx src/WorkspacePage.test.tsx
- npm run typecheck

Fixes #29