### PR TITLE
fix: hide broken ⌘+K shortcut hint and expand subagent messages

### DIFF
--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -447,7 +447,7 @@ export default function WorkspacePage() {
                   badge={latestMessage.badge}
                   animated={animated}
                   collapsible={isSubagent}
-                  defaultCollapsed={isSubagent}
+                  defaultCollapsed={false}
                 >
                   {groupMessages.map((msg) => {
                       const visibleToolCalls = msg.toolCalls ?? [];

--- a/src/components/NewSession.tsx
+++ b/src/components/NewSession.tsx
@@ -451,11 +451,13 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
       </div>
 
       {/* ── Footer ───────────────────────────────────────────────────────── */}
+      {/* TODO(issue #55): ⌘+K doesn't work yet, hide footer message for now
       <footer className="ns-footer">
         <span>Select Project</span>
         <kbd className="ns-kbd">⌘ K</kbd>
         <span>or Type Command</span>
       </footer>
+      */}
     </div>
   );
 }


### PR DESCRIPTION
- Comment out footer showing non-functional ⌘+K shortcut in NewSession (temporary fix for #55)
- Change subagent messages to be expanded by default instead of collapsed