### PR TITLE
fix(debug): simplify shrink toggle in debug pane

### DIFF
--- a/src/components/artifact-pane/DebugPane.test.tsx
+++ b/src/components/artifact-pane/DebugPane.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { agentAtomFamily } from "@/agent/atoms";
+import type { AgentState } from "@/agent/types";
+import DebugPane from "./DebugPane";
+
+const tabsContextMock = vi.hoisted(() => ({
+  value: {
+    tabs: [
+      {
+        id: "tab-1",
+        label: "Workspace",
+        icon: "chat_bubble_outline",
+        status: "idle" as const,
+        mode: "workspace" as const,
+      },
+    ],
+    activeTabId: "tab-1",
+    setActiveTab: vi.fn(),
+    addTab: vi.fn(),
+    addTabWithId: vi.fn(),
+    closeTab: vi.fn(),
+    updateTab: vi.fn(),
+    reorderTabs: vi.fn(),
+  },
+}));
+
+const clipboardMock = vi.hoisted(() => ({
+  writeText: vi.fn<(text: string) => Promise<void>>(),
+}));
+
+vi.mock("@/contexts/TabsContext", () => ({
+  useTabs: () => tabsContextMock.value,
+}));
+
+function buildFixture() {
+  const longSystemPrompt = "system prompt ".repeat(600);
+  const longUserMessage = `attach this screenshot data:image/png;base64,${"A".repeat(4096)}`;
+  const longChatMessage = "chat message ".repeat(600);
+  const longStreamingContent = "stream ".repeat(1200);
+  const toolArguments = JSON.stringify({
+    path: "src/App.tsx",
+    patch: "B".repeat(5000),
+  });
+  const toolResult = JSON.stringify({
+    ok: true,
+    output: "C".repeat(5000),
+  });
+
+  const state: AgentState = {
+    status: "done",
+    config: {
+      cwd: "/tmp/workspace",
+      model: "openai/gpt-5.2",
+      contextLength: 128000,
+    },
+    chatMessages: [
+      {
+        id: "chat-user",
+        role: "user",
+        content: longChatMessage,
+        timestamp: 1,
+      },
+      {
+        id: "chat-assistant",
+        role: "assistant",
+        content: "Working on it",
+        timestamp: 2,
+        toolCalls: [
+          {
+            id: "call-1",
+            tool: "workspace_applyPatch",
+            args: {
+              path: "src/App.tsx",
+              patch: "D".repeat(5000),
+            },
+            result: {
+              ok: true,
+              output: "E".repeat(5000),
+            },
+            status: "done",
+          },
+        ],
+      },
+    ],
+    apiMessages: [
+      {
+        role: "system",
+        content: longSystemPrompt,
+      },
+      {
+        role: "user",
+        content: longUserMessage,
+      },
+      {
+        role: "assistant",
+        content: "Calling tool",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: {
+              name: "workspace_applyPatch",
+              arguments: toolArguments,
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-1",
+        content: toolResult,
+      },
+    ],
+    streamingContent: longStreamingContent,
+    plan: {
+      markdown: "",
+      updatedAtMs: 0,
+      version: 0,
+    },
+    todos: [],
+    error: null,
+    errorDetails: null,
+    errorAction: null,
+    tabTitle: "Debug test",
+    reviewEdits: [],
+    autoApproveEdits: false,
+    autoApproveCommands: "no",
+    showDebug: true,
+  };
+
+  return {
+    state,
+    longSystemPrompt,
+    longUserMessage,
+    longChatMessage,
+    longStreamingContent,
+    toolArguments,
+    toolResult,
+  };
+}
+
+function renderDebugPane(state: AgentState) {
+  const store = createStore();
+  store.set(agentAtomFamily("tab-1"), state);
+
+  return render(
+    <Provider store={store}>
+      <DebugPane tabId="tab-1" />
+    </Provider>,
+  );
+}
+
+describe("DebugPane copy bundle", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    clipboardMock.writeText.mockReset();
+    clipboardMock.writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: clipboardMock.writeText,
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shrinks long message text by default but preserves tool payloads", async () => {
+    const {
+      state,
+      longSystemPrompt,
+      longChatMessage,
+      longStreamingContent,
+      toolArguments,
+      toolResult,
+    } = buildFixture();
+    renderDebugPane(state);
+
+    const shrinkButton = screen.getByRole("button", {
+      name: "Shrink long messages",
+    });
+    expect(shrinkButton.className).toContain("chat-cycle-switch--active");
+
+    fireEvent.click(screen.getByRole("button", { name: "COPY CONTEXT" }));
+
+    await waitFor(() =>
+      expect(clipboardMock.writeText).toHaveBeenCalledTimes(1),
+    );
+    const bundle = JSON.parse(clipboardMock.writeText.mock.calls[0][0]) as {
+      copyOptions: { shrinkLongMessages: boolean };
+      agent: AgentState;
+    };
+
+    expect(bundle.copyOptions.shrinkLongMessages).toBe(true);
+    const systemMessage = bundle.agent.apiMessages[0];
+    if (systemMessage.role !== "system") {
+      throw new Error("Expected system api message");
+    }
+    expect(systemMessage.content.length).toBeLessThan(longSystemPrompt.length);
+    expect(systemMessage.content).toContain("truncated");
+
+    const userMessage = bundle.agent.apiMessages[1];
+    if (userMessage.role !== "user") {
+      throw new Error("Expected user api message");
+    }
+    expect(userMessage.content).not.toContain("A".repeat(1024));
+    expect(userMessage.content).toContain(
+      "[truncated 4096 chars for debug copy]",
+    );
+    expect(bundle.agent.streamingContent?.length).toBeLessThan(
+      longStreamingContent.length,
+    );
+
+    const assistantMessage = bundle.agent.apiMessages[2];
+    if (assistantMessage.role !== "assistant") {
+      throw new Error("Expected assistant api message");
+    }
+    expect(assistantMessage.tool_calls?.[0]?.function.arguments).toBe(
+      toolArguments,
+    );
+
+    const toolMessage = bundle.agent.apiMessages[3];
+    if (toolMessage.role !== "tool") {
+      throw new Error("Expected tool api message");
+    }
+    expect(toolMessage.content).toBe(toolResult);
+
+    expect(bundle.agent.chatMessages[0].content.length).toBeLessThan(
+      longChatMessage.length,
+    );
+    expect(bundle.agent.chatMessages[1].toolCalls?.[0]?.args).toEqual(
+      state.chatMessages[1].toolCalls?.[0]?.args,
+    );
+    expect(bundle.agent.chatMessages[1].toolCalls?.[0]?.result).toEqual(
+      state.chatMessages[1].toolCalls?.[0]?.result,
+    );
+  });
+
+  it("copies the full bundle when shrinking is disabled", async () => {
+    const { state } = buildFixture();
+    renderDebugPane(state);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Shrink long messages" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Shrink long messages" }).className,
+    ).not.toContain("chat-cycle-switch--active");
+
+    fireEvent.click(screen.getByRole("button", { name: "COPY CONTEXT" }));
+
+    await waitFor(() =>
+      expect(clipboardMock.writeText).toHaveBeenCalledTimes(1),
+    );
+    const bundle = JSON.parse(clipboardMock.writeText.mock.calls[0][0]) as {
+      copyOptions: { shrinkLongMessages: boolean };
+      agent: AgentState;
+    };
+
+    expect(bundle.copyOptions.shrinkLongMessages).toBe(false);
+    expect(bundle.agent.apiMessages).toEqual(state.apiMessages);
+    expect(bundle.agent.chatMessages).toEqual(state.chatMessages);
+    expect(bundle.agent.streamingContent).toBe(state.streamingContent);
+  });
+});

--- a/src/components/artifact-pane/DebugPane.tsx
+++ b/src/components/artifact-pane/DebugPane.tsx
@@ -1,12 +1,22 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useAtomValue } from "jotai";
 import { agentAtomFamily } from "@/agent/atoms";
 import { getModelCatalogEntry } from "@/agent/modelCatalog";
 import { getAllSubagents } from "@/agent/subagents";
+import CycleOptionSwitch from "@/components/CycleOptionSwitch";
+import { Button } from "@/components/ui";
 import { useTabs } from "@/contexts/TabsContext";
-import type { ApiMessage } from "@/agent/types";
+import type { ApiMessage, ChatMessage } from "@/agent/types";
 import { cn } from "@/utils/cn";
 import pkg from "../../../package.json";
+
+const IMAGE_DATA_URL_RE =
+  /data:(image\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)/g;
+
+const INLINE_IMAGE_DATA_MAX_CHARS = 256;
+const LONG_MESSAGE_MAX_CHARS = 6000;
+const LONG_MESSAGE_HEAD_CHARS = 2500;
+const LONG_MESSAGE_TAIL_CHARS = 1200;
 
 function estimateContextWindowPct(
   apiMessages: ApiMessage[],
@@ -88,6 +98,78 @@ function safeJsonStringify(value: unknown): string {
   }
 }
 
+function shrinkDebugMessageText(value: string): string {
+  const withShrunkImages = value.replace(
+    IMAGE_DATA_URL_RE,
+    (match, mimeType: string, base64Data: string) => {
+      const normalizedData = base64Data.replace(/\s+/g, "");
+      if (normalizedData.length <= INLINE_IMAGE_DATA_MAX_CHARS) {
+        return match;
+      }
+      return `data:${mimeType};base64,[truncated ${normalizedData.length} chars for debug copy]`;
+    },
+  );
+
+  if (withShrunkImages.length <= LONG_MESSAGE_MAX_CHARS) {
+    return withShrunkImages;
+  }
+
+  const omittedChars =
+    withShrunkImages.length - LONG_MESSAGE_HEAD_CHARS - LONG_MESSAGE_TAIL_CHARS;
+  if (omittedChars <= 0) return withShrunkImages;
+
+  return [
+    withShrunkImages.slice(0, LONG_MESSAGE_HEAD_CHARS),
+    `\n\n[... truncated ${omittedChars} chars for debug copy; original length ${withShrunkImages.length} chars ...]\n\n`,
+    withShrunkImages.slice(-LONG_MESSAGE_TAIL_CHARS),
+  ].join("");
+}
+
+function shrinkApiMessages(messages: ApiMessage[]): ApiMessage[] {
+  return messages.map((message) => {
+    switch (message.role) {
+      case "system":
+      case "user":
+        return {
+          ...message,
+          content: shrinkDebugMessageText(message.content),
+        };
+      case "assistant":
+        return {
+          ...message,
+          content:
+            typeof message.content === "string"
+              ? shrinkDebugMessageText(message.content)
+              : message.content,
+        };
+      case "tool":
+        return message;
+    }
+  });
+}
+
+function shrinkChatMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message) => ({
+    ...message,
+    content: shrinkDebugMessageText(message.content),
+    reasoning:
+      typeof message.reasoning === "string"
+        ? shrinkDebugMessageText(message.reasoning)
+        : message.reasoning,
+  }));
+}
+
+function InfoPopover({ children }: { children: ReactNode }) {
+  return (
+    <span className="chat-ctrl-info">
+      <span className="material-symbols-outlined chat-ctrl-info-icon text-sm">
+        info
+      </span>
+      <span className="chat-ctrl-popover">{children}</span>
+    </span>
+  );
+}
+
 async function copyToClipboard(text: string): Promise<boolean> {
   try {
     if (navigator.clipboard?.writeText) {
@@ -119,6 +201,7 @@ async function copyToClipboard(text: string): Promise<boolean> {
 export default function DebugPane({ tabId }: { tabId: string }) {
   const { tabs, activeTabId } = useTabs();
   const state = useAtomValue(agentAtomFamily(tabId));
+  const [shrinkLongMessages, setShrinkLongMessages] = useState(true);
   const [copyStatus, setCopyStatus] = useState<
     "idle" | "copying" | "copied" | "failed"
   >("idle");
@@ -138,7 +221,8 @@ export default function DebugPane({ tabId }: { tabId: string }) {
   );
 
   const contextUsagePct = useMemo(
-    () => estimateContextWindowPct(state.apiMessages, state.config.contextLength),
+    () =>
+      estimateContextWindowPct(state.apiMessages, state.config.contextLength),
     [state.apiMessages, state.config.contextLength],
   );
 
@@ -164,10 +248,24 @@ export default function DebugPane({ tabId }: { tabId: string }) {
       }
     })();
 
+    const copiedChatMessages = shrinkLongMessages
+      ? shrinkChatMessages(state.chatMessages)
+      : state.chatMessages;
+    const copiedApiMessages = shrinkLongMessages
+      ? shrinkApiMessages(state.apiMessages)
+      : state.apiMessages;
+    const copiedStreamingContent =
+      shrinkLongMessages && typeof state.streamingContent === "string"
+        ? shrinkDebugMessageText(state.streamingContent)
+        : state.streamingContent;
+
     const debugBundle = {
       kind: "rakh_debug_bundle",
-      version: 1,
+      version: 2,
       generatedAt: new Date().toISOString(),
+      copyOptions: {
+        shrinkLongMessages,
+      },
       app: {
         name: pkg.name,
         version: pkg.version,
@@ -195,7 +293,7 @@ export default function DebugPane({ tabId }: { tabId: string }) {
         config: state.config,
         autoApproveEdits: state.autoApproveEdits,
         autoApproveCommands: state.autoApproveCommands,
-        streamingContent: state.streamingContent,
+        streamingContent: copiedStreamingContent,
         error: state.error,
         errorDetails: state.errorDetails,
         modelCatalogEntry: modelEntry,
@@ -203,8 +301,8 @@ export default function DebugPane({ tabId }: { tabId: string }) {
         plan: state.plan,
         todos: state.todos,
         reviewEdits: state.reviewEdits,
-        chatMessages: state.chatMessages,
-        apiMessages: state.apiMessages,
+        chatMessages: copiedChatMessages,
+        apiMessages: copiedApiMessages,
       },
     };
 
@@ -215,18 +313,35 @@ export default function DebugPane({ tabId }: { tabId: string }) {
 
   return (
     <div className="artifact-tab-content">
-      <div className="flex items-center justify-between gap-3 mb-4">
-        <div className="plan-section-label m-0">DEBUG</div>
-        <div className="flex items-center gap-2">
-          {copyStatus !== "idle" && (
+      <div className="debug-pane-header">
+        <div className="plan-section-label debug-pane-label">DEBUG</div>
+
+        <div className="debug-pane-controls">
+          <div className="debug-pane-switch-row">
+            <CycleOptionSwitch
+              label="Shrink long messages"
+              value={shrinkLongMessages}
+              options={[
+                { value: false, label: "No" },
+                { value: true, label: "Yes" },
+              ]}
+              onChange={setShrinkLongMessages}
+            />
+            <InfoPopover>
+              Shortens long chat text and inline image data in copied debug
+              bundles.
+            </InfoPopover>
+          </div>
+
+          {copyStatus !== "idle" ? (
             <span
               className={cn(
-                "text-xxs",
+                "debug-pane-copy-feedback",
                 copyStatus === "copied"
-                  ? "text-success"
+                  ? "debug-pane-copy-feedback--success"
                   : copyStatus === "failed"
-                    ? "text-error"
-                    : "text-muted",
+                    ? "debug-pane-copy-feedback--error"
+                    : "debug-pane-copy-feedback--active",
               )}
             >
               {copyStatus === "copying"
@@ -235,15 +350,29 @@ export default function DebugPane({ tabId }: { tabId: string }) {
                   ? "Copied"
                   : "Copy failed"}
             </span>
-          )}
-          <button
-            className="msg-btn msg-btn--deny"
-            onClick={handleCopy}
+          ) : null}
+
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => void handleCopy()}
             disabled={copyStatus === "copying"}
-            title="Copy full debug bundle (agent context + runtime info)"
+            title={
+              shrinkLongMessages
+                ? "Copy debug bundle with long message text shrunk"
+                : "Copy full debug bundle (agent context + runtime info)"
+            }
+            leftIcon={
+              <span
+                aria-hidden="true"
+                className="material-symbols-outlined text-[14px] leading-none"
+              >
+                content_copy
+              </span>
+            }
           >
             COPY CONTEXT
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -292,7 +421,9 @@ export default function DebugPane({ tabId }: { tabId: string }) {
             <div>
               <span className="text-muted">context</span>: config=
               {state.config.contextLength ?? "(unknown)"}
-              {contextUsagePct != null ? ` · ~${contextUsagePct.toFixed(1)}%` : ""}
+              {contextUsagePct != null
+                ? ` · ~${contextUsagePct.toFixed(1)}%`
+                : ""}
             </div>
             {state.error && (
               <div>
@@ -337,12 +468,14 @@ export default function DebugPane({ tabId }: { tabId: string }) {
                     {agent.icon}
                   </span>
                   {agent.name}
-                  <span className="ml-2 text-muted font-normal">{agent.id}</span>
+                  <span className="ml-2 text-muted font-normal">
+                    {agent.id}
+                  </span>
                 </div>
                 <div className="space-y-0.5 pl-2">
                   <div>
-                    <span className="text-muted">tools</span>: {agent.tools.length} (
-                    {agent.tools.join(", ")})
+                    <span className="text-muted">tools</span>:{" "}
+                    {agent.tools.length} ({agent.tools.join(", ")})
                   </div>
                   <div>
                     <span className="text-muted">approval</span>:{" "}
@@ -382,9 +515,11 @@ export default function DebugPane({ tabId }: { tabId: string }) {
         </div>
 
         <p className="text-muted text-xxs">
-          The copied bundle includes: agent state (including apiMessages/tool
-          results), model catalog entry, tab metadata, and runtime info. API
-          keys are not included.
+          The copied bundle includes agent state, apiMessages, tool results,
+          model catalog data, tab metadata, and runtime info. When enabled, long
+          chat/api message text and embedded base64 image data are abbreviated,
+          but tool call payloads and results are always copied in full. API keys
+          are not included.
         </p>
       </div>
     </div>

--- a/src/styles/components-artifacts.css
+++ b/src/styles/components-artifacts.css
@@ -1016,6 +1016,52 @@
   line-height: 1.8;
 }
 
+.debug-pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.debug-pane-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.debug-pane-switch-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.debug-pane-label {
+  margin-bottom: 0;
+}
+
+.debug-pane-copy-feedback {
+  color: var(--color-muted);
+  font-size: var(--text-xxs);
+  font-family: var(--font-mono);
+  letter-spacing: 0.03em;
+}
+
+.debug-pane-copy-feedback--success {
+  color: var(--color-success);
+}
+
+.debug-pane-copy-feedback--error {
+  color: var(--color-error);
+}
+
+.debug-pane-copy-feedback--active {
+  color: var(--color-primary);
+}
+
 .plan-section-label {
   font-size: var(--text-xxs);
   font-weight: 700;


### PR DESCRIPTION
## Summary
- keep the debug copy control compact by using the same small cycle switch pattern as Auto edits / Auto run
- add a minimal help popover for the shrink-long-messages option
- preserve the debug bundle shrinking behavior and cover it with focused tests

## Testing
- npm run test -- --run src/components/artifact-pane/DebugPane.test.tsx
- npm run lint -- src/components/artifact-pane/DebugPane.tsx src/components/artifact-pane/DebugPane.test.tsx
- npm run typecheck

Fixes #68