### PR TITLE
fix: send attention notifications for inactive tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
 import "@/styles/globals.css";
 import { Provider, useAtom } from "jotai";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import TopChrome from "@/components/TopChrome";
+import AgentNotificationManager from "@/components/AgentNotificationManager";
 import { TabsProvider } from "@/contexts/TabsContext";
 import { useTabs } from "@/contexts/TabsContext";
 import {
   jotaiStore,
   themeModeAtom,
   themeNameAtom,
-  notifyOnAttentionAtom,
   agentAtomFamily,
 } from "@/agent/atoms";
 import { loadProviders, providersAtom } from "@/agent/db";
@@ -23,8 +23,7 @@ import {
   isSessionEmpty,
   type PersistedSession,
 } from "@/agent/persistence";
-import type { AgentStatus, ToolCallDisplay } from "@/agent/types";
-import { focusTab, showNotification } from "@/notifications";
+import type { AgentStatus } from "@/agent/types";
 import { preloadEnvProviderKeys } from "@/agent/useEnvProviderKeys";
 import { getThemeSubagentColorVariables } from "@/styles/themes/registry";
 import { checkForAppUpdates } from "@/updater";
@@ -125,74 +124,6 @@ function AutoSaveManager() {
     return () => unsubs.forEach((fn) => fn());
     // Re-subscribe whenever the tab list changes (new tabs added, mode changes)
   }, [tabs]);
-
-  return null;
-}
-
-/* ──────────────────────────────────────────────────────────────────────────────────
-   AgentNotificationManager — native notifications for agent attention
-───────────────────────────────────────────────────────────────────────────────── */
-
-function AgentNotificationManager() {
-  const { tabs, activeTabId, setActiveTab } = useTabs();
-  const [notifyOnAttention] = useAtom(notifyOnAttentionAtom);
-  const notifiedToolCallsRef = useRef<Set<string>>(new Set());
-
-  const sendNotification = useCallback(
-    async (tabId: string, tabLabel: string, toolCall: ToolCallDisplay) => {
-      await showNotification({
-        title: "Agent needs your input",
-        options: {
-          body: `${tabLabel || "Untitled"} • ${toolCall.tool}`,
-          tag: toolCall.id,
-          data: { tabId },
-        },
-        onClick: () => {
-          void focusTab(tabId, setActiveTab);
-        },
-      });
-    },
-    [setActiveTab],
-  );
-
-  useEffect(() => {
-    if (!notifyOnAttention) {
-      notifiedToolCallsRef.current.clear();
-      return;
-    }
-
-    const unsubs: Array<() => void> = [];
-
-    for (const tab of tabs) {
-      if (tab.mode !== "workspace") continue;
-      const tabAtom = agentAtomFamily(tab.id);
-
-      const unsub = jotaiStore.sub(tabAtom, () => {
-        const state = jotaiStore.get(tabAtom);
-        const attentionToolCalls = state.chatMessages
-          .flatMap((msg) => msg.toolCalls ?? [])
-          .filter(
-            (tc) =>
-              tc.status === "awaiting_approval" ||
-              tc.status === "awaiting_worktree",
-          );
-
-        for (const toolCall of attentionToolCalls) {
-          if (notifiedToolCallsRef.current.has(toolCall.id)) continue;
-          notifiedToolCallsRef.current.add(toolCall.id);
-
-          const shouldNotify = !document.hasFocus() || tab.id !== activeTabId;
-          if (!shouldNotify) continue;
-
-          void sendNotification(tab.id, tab.label, toolCall);
-        }
-      });
-
-      unsubs.push(unsub);
-    }
-
-    return () => unsubs.forEach((fn) => fn());
-  }, [tabs, notifyOnAttention, activeTabId, sendNotification]);
 
   return null;
 }

--- a/src/components/AgentNotificationManager.test.tsx
+++ b/src/components/AgentNotificationManager.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { Provider } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  agentAtomFamily,
+  jotaiStore,
+  notifyOnAttentionAtom,
+} from "@/agent/atoms";
+import type { PersistedSession } from "@/agent/persistence";
+import { TabsProvider } from "@/contexts/TabsContext";
+import AgentNotificationManager from "./AgentNotificationManager";
+
+const notificationMocks = vi.hoisted(() => ({
+  showNotificationMock: vi.fn(async () => true),
+  focusTabMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/notifications", () => ({
+  showNotification: notificationMocks.showNotificationMock,
+  focusTab: notificationMocks.focusTabMock,
+}));
+
+function makeSession(id: string, label: string): PersistedSession {
+  return {
+    id,
+    label,
+    icon: "chat_bubble_outline",
+    mode: "workspace",
+    tabTitle: "",
+    cwd: "",
+    model: "",
+    planMarkdown: "",
+    planVersion: 0,
+    planUpdatedAt: 0,
+    chatMessages: "[]",
+    apiMessages: "[]",
+    todos: "[]",
+    reviewEdits: "[]",
+    archived: false,
+    createdAt: 0,
+    updatedAt: 0,
+    worktreePath: "",
+    worktreeBranch: "",
+    worktreeDeclined: false,
+    showDebug: false,
+    advancedOptions: "{}",
+  };
+}
+
+function setAwaitingToolCall(tabId: string, toolCallId: string) {
+  const state = jotaiStore.get(agentAtomFamily(tabId));
+  jotaiStore.set(agentAtomFamily(tabId), {
+    ...state,
+    chatMessages: [
+      {
+        id: `msg-${toolCallId}`,
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        toolCalls: [
+          {
+            id: toolCallId,
+            tool: "request_user_input",
+            args: {},
+            status: "awaiting_approval",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function renderManager(sessions: PersistedSession[]) {
+  return render(
+    <Provider store={jotaiStore}>
+      <TabsProvider initialSessions={sessions}>
+        <AgentNotificationManager />
+      </TabsProvider>
+    </Provider>,
+  );
+}
+
+describe("AgentNotificationManager", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    notificationMocks.showNotificationMock.mockClear();
+    notificationMocks.focusTabMock.mockClear();
+    jotaiStore.set(notifyOnAttentionAtom, true);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("sends a notification for an awaiting tool call on an inactive tab", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    renderManager([
+      makeSession("tab-1", "Tab One"),
+      makeSession("tab-2", "Tab Two"),
+    ]);
+
+    await act(async () => {
+      setAwaitingToolCall("tab-2", "tool-1");
+    });
+
+    await waitFor(() => {
+      expect(notificationMocks.showNotificationMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(notificationMocks.showNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Agent needs your input",
+        options: expect.objectContaining({
+          body: "Tab Two • request_user_input",
+          tag: "tool-1",
+        }),
+      }),
+    );
+
+    hasFocusSpy.mockRestore();
+  });
+
+  it("notifies after the window loses focus for an active tab that is still awaiting input", async () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus");
+    hasFocusSpy.mockReturnValue(true);
+
+    renderManager([makeSession("tab-active", "Focused Tab")]);
+
+    await act(async () => {
+      setAwaitingToolCall("tab-active", "tool-active");
+    });
+
+    expect(notificationMocks.showNotificationMock).not.toHaveBeenCalled();
+
+    hasFocusSpy.mockReturnValue(false);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    await waitFor(() => {
+      expect(notificationMocks.showNotificationMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    expect(notificationMocks.showNotificationMock).toHaveBeenCalledTimes(1);
+
+    hasFocusSpy.mockRestore();
+  });
+});

--- a/src/components/AgentNotificationManager.tsx
+++ b/src/components/AgentNotificationManager.tsx
@@ -1,0 +1,154 @@
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  agentAtomFamily,
+  jotaiStore,
+  notifyOnAttentionAtom,
+} from "@/agent/atoms";
+import type { ToolCallDisplay } from "@/agent/types";
+import { useTabs } from "@/contexts/TabsContext";
+import { focusTab, showNotification } from "@/notifications";
+
+function getAttentionToolCalls(tabId: string): ToolCallDisplay[] {
+  const state = jotaiStore.get(agentAtomFamily(tabId));
+  return state.chatMessages
+    .flatMap((message) => message.toolCalls ?? [])
+    .filter(
+      (toolCall) =>
+        toolCall.status === "awaiting_approval" ||
+        toolCall.status === "awaiting_worktree",
+    );
+}
+
+function documentHasFocus(): boolean {
+  return typeof document !== "undefined" && document.hasFocus();
+}
+
+export default function AgentNotificationManager() {
+  const { tabs, activeTabId, setActiveTab } = useTabs();
+  const [notifyOnAttention] = useAtom(notifyOnAttentionAtom);
+  const tabsRef = useRef(tabs);
+  const activeTabIdRef = useRef(activeTabId);
+  const notifiedToolCallsRef = useRef<Set<string>>(new Set());
+  const pendingToolCallsRef = useRef<Set<string>>(new Set());
+
+  tabsRef.current = tabs;
+  activeTabIdRef.current = activeTabId;
+
+  const sendAttentionNotification = useCallback(
+    async (tabId: string, tabLabel: string, toolCall: ToolCallDisplay) => {
+      if (
+        pendingToolCallsRef.current.has(toolCall.id) ||
+        notifiedToolCallsRef.current.has(toolCall.id)
+      ) {
+        return;
+      }
+
+      pendingToolCallsRef.current.add(toolCall.id);
+
+      try {
+        const sent = await showNotification({
+          title: "Agent needs your input",
+          options: {
+            body: `${tabLabel || "Untitled"} • ${toolCall.tool}`,
+            tag: toolCall.id,
+            data: { tabId },
+          },
+          onClick: () => {
+            void focusTab(tabId, setActiveTab, {
+              focusWindow: !documentHasFocus(),
+            });
+          },
+        });
+
+        if (sent) {
+          notifiedToolCallsRef.current.add(toolCall.id);
+        }
+      } finally {
+        pendingToolCallsRef.current.delete(toolCall.id);
+      }
+    },
+    [setActiveTab],
+  );
+
+  const scanAttentionStates = useCallback(() => {
+    if (!notifyOnAttention) return;
+
+    const activeAttentionIds = new Set<string>();
+    const isFocused = documentHasFocus();
+
+    for (const tab of tabsRef.current) {
+      if (tab.mode !== "workspace") continue;
+
+      for (const toolCall of getAttentionToolCalls(tab.id)) {
+        activeAttentionIds.add(toolCall.id);
+
+        if (
+          notifiedToolCallsRef.current.has(toolCall.id) ||
+          pendingToolCallsRef.current.has(toolCall.id)
+        ) {
+          continue;
+        }
+
+        const shouldNotify = !isFocused || tab.id !== activeTabIdRef.current;
+        if (!shouldNotify) continue;
+
+        void sendAttentionNotification(tab.id, tab.label, toolCall);
+      }
+    }
+
+    for (const toolCallId of Array.from(notifiedToolCallsRef.current)) {
+      if (!activeAttentionIds.has(toolCallId)) {
+        notifiedToolCallsRef.current.delete(toolCallId);
+      }
+    }
+
+    for (const toolCallId of Array.from(pendingToolCallsRef.current)) {
+      if (!activeAttentionIds.has(toolCallId)) {
+        pendingToolCallsRef.current.delete(toolCallId);
+      }
+    }
+  }, [notifyOnAttention, sendAttentionNotification]);
+
+  useEffect(() => {
+    if (!notifyOnAttention) {
+      notifiedToolCallsRef.current.clear();
+      pendingToolCallsRef.current.clear();
+      return;
+    }
+
+    scanAttentionStates();
+
+    const unsubs: Array<() => void> = [];
+    for (const tab of tabs) {
+      if (tab.mode !== "workspace") continue;
+      unsubs.push(jotaiStore.sub(agentAtomFamily(tab.id), scanAttentionStates));
+    }
+
+    return () => unsubs.forEach((fn) => fn());
+  }, [tabs, notifyOnAttention, scanAttentionStates]);
+
+  useEffect(() => {
+    scanAttentionStates();
+  }, [activeTabId, scanAttentionStates]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleFocusChange = () => {
+      scanAttentionStates();
+    };
+
+    window.addEventListener("focus", handleFocusChange);
+    window.addEventListener("blur", handleFocusChange);
+    document.addEventListener("visibilitychange", handleFocusChange);
+
+    return () => {
+      window.removeEventListener("focus", handleFocusChange);
+      window.removeEventListener("blur", handleFocusChange);
+      document.removeEventListener("visibilitychange", handleFocusChange);
+    };
+  }, [scanAttentionStates]);
+
+  return null;
+}

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -371,7 +371,8 @@ function NotificationsSection({
         <div className="settings-row-info">
           <span className="settings-row-label">Agent attention</span>
           <span className="settings-row-desc">
-            Desktop notifications are shown only when focus is elsewhere.
+            Desktop notifications are shown when focus is elsewhere or the
+            relevant tab is inactive.
           </span>
         </div>
         <ToggleSwitch

--- a/src/notifications.test.ts
+++ b/src/notifications.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const notificationMocks = vi.hoisted(() => ({
+  isPermissionGrantedMock: vi.fn(async () => true),
+  requestPermissionMock: vi.fn(async () => "granted" as const),
+  sendNotificationMock: vi.fn(),
+  onActionHandler: null as null | ((event: unknown) => void),
+  onActionMock: vi.fn(async (handler: (event: unknown) => void) => {
+    notificationMocks.onActionHandler = handler;
+    return { unregister: vi.fn() };
+  }),
+}));
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted: notificationMocks.isPermissionGrantedMock,
+  requestPermission: notificationMocks.requestPermissionMock,
+  sendNotification: notificationMocks.sendNotificationMock,
+  onAction: notificationMocks.onActionMock,
+}));
+
+describe("notifications", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    notificationMocks.isPermissionGrantedMock.mockClear();
+    notificationMocks.requestPermissionMock.mockClear();
+    notificationMocks.sendNotificationMock.mockClear();
+    notificationMocks.onActionMock.mockClear();
+    notificationMocks.onActionHandler = null;
+
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+  });
+
+  it("defers Tauri click handlers until a notification action event arrives", async () => {
+    const { showNotification } = await import("./notifications");
+    const onClick = vi.fn();
+
+    const sent = await showNotification({
+      title: "Agent needs your input",
+      options: { body: "Workspace • request_user_input" },
+      onClick,
+    });
+
+    expect(sent).toBe(true);
+    expect(notificationMocks.sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+
+    const [{ id }] = notificationMocks.sendNotificationMock.mock.calls[0] ?? [];
+    notificationMocks.onActionHandler?.({ notification: { id } });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("can activate a tab without redundantly refocusing the window", async () => {
+    const windowFocusSpy = vi
+      .spyOn(window, "focus")
+      .mockImplementation(() => undefined);
+    const { focusTab } = await import("./notifications");
+    const setActiveTab = vi.fn();
+
+    await focusTab("tab-2", setActiveTab, { focusWindow: false });
+
+    expect(setActiveTab).toHaveBeenCalledWith("tab-2");
+    expect(windowFocusSpy).not.toHaveBeenCalled();
+
+    windowFocusSpy.mockRestore();
+  });
+});

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -4,8 +4,80 @@ export interface NotificationPayload {
   onClick?: () => void;
 }
 
+interface FocusTabOptions {
+  focusWindow?: boolean;
+}
+
+interface TauriNotificationActionEvent {
+  id?: number;
+  notification?: {
+    id?: number;
+  };
+}
+
+const MAX_TAURI_CLICK_CALLBACKS = 200;
+const TAURI_NOTIFICATION_ICON = "icons/icon.png";
+const tauriClickCallbacks = new Map<number, () => void>();
+let nextTauriNotificationId = 1;
+let tauriActionListenerPromise: Promise<void> | null = null;
+
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function createTauriNotificationId(): number {
+  const id = nextTauriNotificationId;
+  nextTauriNotificationId += 1;
+  if (nextTauriNotificationId > 2_147_483_647) {
+    nextTauriNotificationId = 1;
+  }
+  return id;
+}
+
+function pruneTauriClickCallbacks(): void {
+  const overflow = tauriClickCallbacks.size - MAX_TAURI_CLICK_CALLBACKS;
+  if (overflow <= 0) return;
+
+  for (const id of tauriClickCallbacks.keys()) {
+    tauriClickCallbacks.delete(id);
+    if (tauriClickCallbacks.size <= MAX_TAURI_CLICK_CALLBACKS) {
+      return;
+    }
+  }
+}
+
+function getTauriNotificationId(event: unknown): number | null {
+  if (!event || typeof event !== "object") return null;
+  const actionEvent = event as TauriNotificationActionEvent;
+  return actionEvent.notification?.id ?? actionEvent.id ?? null;
+}
+
+async function ensureTauriActionListener(): Promise<void> {
+  if (!isTauri()) return;
+  if (tauriActionListenerPromise) {
+    await tauriActionListenerPromise;
+    return;
+  }
+
+  tauriActionListenerPromise = (async () => {
+    try {
+      const { onAction } = await import("@tauri-apps/plugin-notification");
+      await onAction((event: unknown) => {
+        const notificationId = getTauriNotificationId(event);
+        if (notificationId == null) return;
+
+        const onClick = tauriClickCallbacks.get(notificationId);
+        if (!onClick) return;
+
+        tauriClickCallbacks.delete(notificationId);
+        onClick();
+      });
+    } catch (err) {
+      console.error("Failed to register Tauri notification listener:", err);
+    }
+  })();
+
+  await tauriActionListenerPromise;
 }
 
 export async function ensureNotificationPermission(): Promise<boolean> {
@@ -83,36 +155,43 @@ export function playNotificationSound(): void {
 
 export async function showNotification(
   payload: NotificationPayload,
-): Promise<void> {
-  if (typeof window === "undefined") return;
+): Promise<boolean> {
+  if (typeof window === "undefined") return false;
   const hasPermission = await ensureNotificationPermission();
-  if (!hasPermission) return;
+  if (!hasPermission) return false;
 
   // Use Tauri notification plugin
   if (isTauri()) {
+    const notificationId = createTauriNotificationId();
+
+    if (payload.onClick) {
+      tauriClickCallbacks.set(notificationId, payload.onClick);
+      pruneTauriClickCallbacks();
+      await ensureTauriActionListener();
+    }
+
     try {
       const { sendNotification } = await import(
         "@tauri-apps/plugin-notification"
       );
-      await sendNotification({
+      sendNotification({
+        id: notificationId,
         title: payload.title,
         body: payload.options?.body ?? "",
-        icon: "icons/icon.png", // Use app icon
+        icon: TAURI_NOTIFICATION_ICON,
+        autoCancel: true,
       });
-      if (payload.onClick) {
-        // Note: Tauri v2 doesn't support click handlers in the same way
-        // You'd need to listen to the notification click event globally
-        payload.onClick();
-      }
     } catch (err) {
+      tauriClickCallbacks.delete(notificationId);
       console.error("Failed to send Tauri notification:", err);
+      return false;
     }
     playNotificationSound();
-    return;
+    return true;
   }
 
   // Browser fallback
-  if (!("Notification" in window)) return;
+  if (!("Notification" in window)) return false;
   const notification = new Notification(payload.title, payload.options);
   if (payload.onClick) {
     notification.onclick = () => {
@@ -122,6 +201,7 @@ export async function showNotification(
   }
 
   playNotificationSound();
+  return true;
 }
 
 export async function focusAppWindow(): Promise<void> {
@@ -143,7 +223,10 @@ export async function focusAppWindow(): Promise<void> {
 export async function focusTab(
   tabId: string,
   setActiveTab: (id: string) => void,
+  options?: FocusTabOptions,
 ): Promise<void> {
   setActiveTab(tabId);
-  await focusAppWindow();
+  if (options?.focusWindow ?? true) {
+    await focusAppWindow();
+  }
 }


### PR DESCRIPTION
Fixes #27

## Summary
- move agent attention notification logic into a dedicated manager that reevaluates the latest active tab and window focus state
- defer Tauri notification click handling until the actual action event fires, and avoid redundant window refocus when the tab is already visible
- add regression tests for inactive-tab notifications and deferred notification click handling

## Testing
- npm run test -- --run
- npm run typecheck
- npm run lint -- src/App.tsx src/notifications.ts src/components/AgentNotificationManager.tsx src/notifications.test.ts src/components/AgentNotificationManager.test.tsx src/components/settings/SettingsSurface.tsx