### PR TITLE
feat: add execute action for plan artifact cards

### DIFF
--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -373,6 +373,17 @@ export default function WorkspacePage() {
     return () => window.removeEventListener("keydown", handleGlobalKeyDown);
   }, [toggleTerminal, toggleArtifacts]);
 
+  const executePlanDisabled =
+    isAgentBusy || voiceInput.busy || voiceInput.isRecording;
+  const handleExecutePlan = useCallback(
+    (message: string) => {
+      if (executePlanDisabled) return;
+      voiceInput.clearError();
+      agent.sendMessage(message);
+    },
+    [agent, executePlanDisabled, voiceInput],
+  );
+
   /* ── New session screen ────────────────────────────────────────────── */
   if (isNewSession) {
     return (
@@ -536,6 +547,8 @@ export default function WorkspacePage() {
                       artifactInventoryLoading={artifactInventoryLoading}
                       getArtifactContentEntry={getArtifactContentEntry}
                       ensureArtifactContent={ensureArtifactContent}
+                      onExecutePlan={handleExecutePlan}
+                      executePlanDisabled={executePlanDisabled}
                     />
                   ) : null}
                 </div>

--- a/src/components/ConversationCards.test.tsx
+++ b/src/components/ConversationCards.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ArtifactManifest } from "@/agent/tools/artifacts";
+import { buildSessionArtifactInventory } from "@/components/artifact-pane/model";
+import type { ArtifactContentEntry } from "@/components/artifact-pane/types";
+import ConversationCards, {
+  buildExecutePlanArtifactMessage,
+} from "./ConversationCards";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeArtifact(
+  overrides: Partial<ArtifactManifest> = {},
+): ArtifactManifest {
+  return {
+    sessionId: "tab-1",
+    runId: "run-1",
+    agentId: "agent_main",
+    artifactSeq: 1,
+    artifactId: "plan_123",
+    version: 1,
+    kind: "plan",
+    summary: "Implementation plan",
+    metadata: {},
+    contentFormat: "markdown",
+    blobHash: "hash",
+    sizeBytes: 128,
+    createdAt: 1_000,
+    content: "# Plan\n\n1. Ship it.",
+    ...overrides,
+  };
+}
+
+function renderConversationCards(
+  artifact: ArtifactManifest,
+  options?: { executePlanDisabled?: boolean },
+) {
+  const onExecutePlan = vi.fn();
+  const ensureArtifactContent = vi.fn(async () => undefined);
+  const inventory = buildSessionArtifactInventory([artifact]);
+  const entry: ArtifactContentEntry = {
+    status: "loaded",
+    artifact,
+  };
+
+  render(
+    <ConversationCards
+      cards={[
+        {
+          id: "card-1",
+          kind: "artifact",
+          artifactId: artifact.artifactId,
+          version: artifact.version,
+        },
+      ]}
+      artifactInventory={inventory}
+      artifactInventoryLoading={false}
+      getArtifactContentEntry={(artifactId, version) =>
+        artifactId === artifact.artifactId && version === artifact.version
+          ? entry
+          : undefined
+      }
+      ensureArtifactContent={ensureArtifactContent}
+      onExecutePlan={onExecutePlan}
+      executePlanDisabled={options?.executePlanDisabled ?? false}
+    />,
+  );
+
+  return { onExecutePlan, ensureArtifactContent };
+}
+
+describe("ConversationCards", () => {
+  it("renders an execute button for plan artifacts and sends the artifact-aware prompt", () => {
+    const artifact = makeArtifact();
+    const { onExecutePlan } = renderConversationCards(artifact);
+
+    fireEvent.click(screen.getByRole("button", { name: "Execute the plan" }));
+
+    expect(onExecutePlan).toHaveBeenCalledWith(
+      buildExecutePlanArtifactMessage(artifact.artifactId),
+    );
+  });
+
+  it("does not render the execute button for non-plan artifacts", () => {
+    renderConversationCards(
+      makeArtifact({
+        artifactId: "review_123",
+        kind: "review-report",
+        contentFormat: "json",
+        content: JSON.stringify({ summary: "Looks fine", findings: [] }),
+      }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Execute the plan" }),
+    ).toBeNull();
+  });
+
+  it("disables plan execution while the workspace is busy", () => {
+    const artifact = makeArtifact();
+    const { onExecutePlan } = renderConversationCards(artifact, {
+      executePlanDisabled: true,
+    });
+
+    const button = screen.getByRole("button", { name: "Execute the plan" });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(button);
+
+    expect(onExecutePlan).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ConversationCards.tsx
+++ b/src/components/ConversationCards.tsx
@@ -8,6 +8,7 @@ import type {
   SessionArtifactInventory,
 } from "@/components/artifact-pane/types";
 import ArtifactDetailModal from "@/components/artifact-pane/ArtifactDetailModal";
+import { resolveArtifactRenderKind } from "@/components/artifact-pane/model";
 import { ArtifactRenderer } from "@/components/artifact-pane/renderers";
 import { Badge, Button, Panel } from "@/components/ui";
 
@@ -46,12 +47,18 @@ function resolveArtifactVersionLabel(
   return "latest";
 }
 
+export function buildExecutePlanArtifactMessage(artifactId: string): string {
+  return `Execute the plan with artifact ID: ${artifactId}`;
+}
+
 function ArtifactConversationCard({
   card,
   inventory,
   inventoryLoading,
   getArtifactContentEntry,
   ensureArtifactContent,
+  onExecutePlan,
+  executePlanDisabled = false,
 }: {
   card: Extract<ConversationCard, { kind: "artifact" }>;
   inventory: SessionArtifactInventory;
@@ -61,6 +68,8 @@ function ArtifactConversationCard({
     version: number,
   ) => ArtifactContentEntry | undefined;
   ensureArtifactContent: (artifactId: string, version: number) => Promise<void>;
+  onExecutePlan: (message: string) => void;
+  executePlanDisabled?: boolean;
 }) {
   const group = findArtifactGroup(inventory, card.artifactId);
   const resolvedVersion = resolveArtifactVersion(card, inventory);
@@ -92,6 +101,11 @@ function ArtifactConversationCard({
   const title = resolveArtifactSummary(card, previewEntry, group);
   const canOpenDetail = group != null && detailVersion !== null;
   const canCopy = typeof hydratedArtifact?.content === "string";
+  const isPlanArtifact =
+    (hydratedArtifact != null &&
+      resolveArtifactRenderKind(hydratedArtifact) === "plan") ||
+    group?.renderKind === "plan" ||
+    group?.kind === "plan";
   const [copyFeedbackToken, setCopyFeedbackToken] = useState(0);
   const copied = copyFeedbackToken > 0;
 
@@ -180,6 +194,28 @@ function ArtifactConversationCard({
           ) : (
             <p className="artifact-loading-copy">Loading preview…</p>
           )}
+          {isPlanArtifact ? (
+            <div className="mt-3 flex flex-wrap justify-end">
+              <Button
+                type="button"
+                variant="secondary"
+                size="xxs"
+                onClick={() =>
+                  onExecutePlan(
+                    buildExecutePlanArtifactMessage(card.artifactId),
+                  )
+                }
+                disabled={executePlanDisabled}
+                title={
+                  executePlanDisabled
+                    ? "Wait for the current run to finish before executing this plan"
+                    : "Send this plan to the agent for execution"
+                }
+              >
+                Execute the plan
+              </Button>
+            </div>
+          ) : null}
         </div>
       </Panel>
 
@@ -210,6 +246,8 @@ export default function ConversationCards({
   artifactInventoryLoading,
   getArtifactContentEntry,
   ensureArtifactContent,
+  onExecutePlan,
+  executePlanDisabled = false,
 }: {
   cards: ConversationCard[];
   accentColor?: string;
@@ -220,6 +258,8 @@ export default function ConversationCards({
     version: number,
   ) => ArtifactContentEntry | undefined;
   ensureArtifactContent: (artifactId: string, version: number) => Promise<void>;
+  onExecutePlan: (message: string) => void;
+  executePlanDisabled?: boolean;
 }) {
   if (cards.length === 0) return null;
 
@@ -256,6 +296,8 @@ export default function ConversationCards({
             inventoryLoading={artifactInventoryLoading}
             getArtifactContentEntry={getArtifactContentEntry}
             ensureArtifactContent={ensureArtifactContent}
+            onExecutePlan={onExecutePlan}
+            executePlanDisabled={executePlanDisabled}
           />
         ),
       )}


### PR DESCRIPTION
## Summary
- add an `Execute the plan` action to plan artifact cards rendered in chat
- route the action through the normal workspace send flow with busy-state guards
- add focused tests for plan-only rendering and disabled behavior

## Testing
- npm run test -- --run src/components/ConversationCards.test.tsx src/WorkspacePage.test.tsx
- npm run typecheck
- npm run lint -- src/components/ConversationCards.tsx src/components/ConversationCards.test.tsx src/WorkspacePage.tsx

Fixes #71