### PR TITLE
fix(ci): fetch release branch via FETCH_HEAD

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,11 +36,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH_NAME=$(echo "$PR_DATA" | jq -r '.[0].headBranchName')
-          REMOTE_REF="refs/remotes/origin/$BRANCH_NAME"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "refs/heads/$BRANCH_NAME:$REMOTE_REF"
-          git checkout -B "$BRANCH_NAME" "$REMOTE_REF"
+          git fetch origin "refs/heads/$BRANCH_NAME"
+          git checkout -B "$BRANCH_NAME" FETCH_HEAD
           cd src-tauri
           cargo update -p app
           git add Cargo.lock


### PR DESCRIPTION
## Summary
- avoid updating a remote-tracking ref directly in the release-please workflow
- fetch the release PR branch into FETCH_HEAD and check out from there
- keep the Cargo.lock update step working in shallow CI clones and when the release branch has been rewritten

## Testing
- parse .github/workflows/release-please.yml as YAML
- reproduce the workflow commands in a temporary shallow clone
- confirm cargo update stages src-tauri/Cargo.lock after checking out the release branch

Fixes the non-fast-forward fetch failure from run 22842022181.