### PR TITLE
feat: replace artifact polling with Tauri push events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ cd src-tauri && cargo test
 - `src/agent/tools/exec.ts` - command execution wrappers
 - `src/agent/tools/git.ts` - `git_worktree_init`, which creates isolated
   worktrees through the backend `git_worktree_add` command
-- `src/agent/tools/artifacts.ts` - durable artifact wrappers
+- `src/agent/tools/artifacts.ts` - durable artifact wrappers plus artifact
+  change event subscription helpers
 - `src/agent/tools/agentControl.ts` - title and todo tools
 - `src/agent/tools/definitions.ts` - tool schemas exposed to the model
 - `src/agent/tools/index.ts` - central dispatch for non-intercepted tools
@@ -76,7 +77,9 @@ cd src-tauri && cargo test
 ### UI components
 
 - `src/components/ArtifactPane.tsx` and `src/components/artifact-pane/*` -
-  plans, todos, review diffs, git, debug, and durable artifact views
+  plans, todos, review diffs, git, debug, and durable artifact views; session
+  inventory now refreshes via Tauri `artifact_changed` events instead of timer
+  polling
 - `src/components/Terminal.tsx` - xterm.js terminal backed by Tauri PTY
 - `src/components/ToolCallApproval.tsx` / `src/components/UserInputCard.tsx` -
   approval and user-input surfaces
@@ -89,7 +92,8 @@ cd src-tauri && cargo test
 the backend modules:
 
 - `src-tauri/src/db.rs` - sessions, archived sessions, artifacts, blob storage,
-  provider env keys
+  provider env keys, and `artifact_changed` event emission after artifact
+  writes
 - `src-tauri/src/fs_ops.rs` - file and search operations
 - `src-tauri/src/exec.rs` - non-interactive command execution plus abort/stop
 - `src-tauri/src/pty.rs` - PTY lifecycle for the integrated terminal
@@ -130,6 +134,9 @@ If you add a new `AgentState` field that must survive restarts, update all of:
 - Path validation rejects leading `/` and normalized `..` traversal.
 - Frontend paths are POSIX-style even on Windows.
 - Tool results use `{ ok: true, data } | { ok: false, error }`.
+- Push-style frontend updates use the Tauri event API; artifact pane refreshes
+  listen for `artifact_changed` and then refetch manifests for the affected
+  session.
 - Sensitive tools go through `src/agent/approvals.ts`.
 - `workspace_writeFile` and `workspace_editFile` pre-compute original diffs so
   chat review cards and the review pane both show stable before/after state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,11 @@ It composes:
 - integrated terminal via xterm.js + Tauri PTY
 - optional voice input backed by the Rust Whisper commands
 
+The artifact pane is push-driven. `useSessionArtifactInventory()` performs an
+initial `artifactList()` fetch, then subscribes to backend `artifact_changed`
+events through the Tauri event API and refreshes inventory only when matching
+session artifacts change.
+
 ### State model
 
 [`src/agent/atoms.ts`](../src/agent/atoms.ts) is the shared state boundary
@@ -170,7 +175,8 @@ commands from the backend modules.
 Current backend modules:
 
 - [`src-tauri/src/db.rs`](../src-tauri/src/db.rs): session persistence, archived
-  sessions, artifact manifests/blob helpers, and provider env key loading
+  sessions, artifact manifests/blob helpers, artifact change event emission,
+  and provider env key loading
 - [`src-tauri/src/fs_ops.rs`](../src-tauri/src/fs_ops.rs): directory listing,
   stat, file reads/writes/deletes, glob, and grep-backed search
 - [`src-tauri/src/exec.rs`](../src-tauri/src/exec.rs): command execution,
@@ -183,6 +189,11 @@ Current backend modules:
 - [`src-tauri/src/shell_env.rs`](../src-tauri/src/shell_env.rs): login-shell
   environment discovery helpers
 - [`src-tauri/src/utils.rs`](../src-tauri/src/utils.rs): shared helpers
+
+The backend already uses Tauri events for streaming-style UI updates. PTY and
+exec output are emitted as app events, and artifact writes now emit an
+`artifact_changed` event after successful create/version persistence so the
+frontend can refresh the artifact pane without polling.
 
 ## Persistence and storage
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -56,6 +56,11 @@ Tool schemas live in
 wrappers live in
 [`src/agent/tools/artifacts.ts`](../src/agent/tools/artifacts.ts).
 
+In the desktop app, artifact pane updates are not poll-based anymore. The UI
+does one initial `agent_artifact_list` read per session view, then listens for
+backend `artifact_changed` Tauri events and refetches manifests when matching
+session artifacts change.
+
 ### Create
 
 `agent_artifact_create` creates a new artifact with version `1`.
@@ -91,6 +96,38 @@ For validator-backed JSON artifacts, `artifactGet()` also returns:
 
 The content is returned unchanged. Validation is supplemental metadata, not a
 transformation step.
+
+## Artifact Change Events
+
+Artifact writes also produce a lightweight UI notification event.
+
+The Rust backend emits `artifact_changed` after successful
+`db_artifact_create` and `db_artifact_version` calls. The frontend subscribes
+through `listenForArtifactChanges()` in
+[`src/agent/tools/artifacts.ts`](../src/agent/tools/artifacts.ts).
+
+Current payload shape:
+
+```json
+{
+  "sessionId": "tab-1",
+  "artifactId": "plan_deadbeef",
+  "version": 2,
+  "kind": "plan",
+  "runId": "run_1",
+  "agentId": "agent_main",
+  "change": "versioned",
+  "createdAt": 1741540000000
+}
+```
+
+Notes:
+
+- `change` is `created` or `versioned`
+- the event is advisory; the UI still treats `agent_artifact_list` as the
+  source of truth
+- listeners filter by `sessionId` so tabs only react to their own artifact
+  changes
 
 ## Framework Metadata
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
 /* ── PersistedSession ─────────────────────────────────────────────────────── */
@@ -87,6 +87,26 @@ pub struct ArtifactManifest {
     pub created_at: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactChangeKind {
+    Created,
+    Versioned,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactChangeEvent {
+    pub session_id: String,
+    pub artifact_id: String,
+    pub version: i64,
+    pub kind: String,
+    pub run_id: String,
+    pub agent_id: String,
+    pub change: ArtifactChangeKind,
+    pub created_at: i64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -432,6 +452,22 @@ fn manifest_row_to_api(
         created_at: row.created_at,
         content,
     })
+}
+
+fn artifact_change_event_from_manifest(
+    manifest: &ArtifactManifest,
+    change: ArtifactChangeKind,
+) -> ArtifactChangeEvent {
+    ArtifactChangeEvent {
+        session_id: manifest.session_id.clone(),
+        artifact_id: manifest.artifact_id.clone(),
+        version: manifest.version,
+        kind: manifest.kind.clone(),
+        run_id: manifest.run_id.clone(),
+        agent_id: manifest.agent_id.clone(),
+        change,
+        created_at: manifest.created_at,
+    }
 }
 
 fn load_latest_manifest_row(
@@ -1024,6 +1060,7 @@ pub fn db_artifact_create(
     run_id: String,
     agent_id: String,
     input: ArtifactCreateInput,
+    app_handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ArtifactManifest, String> {
     let start = Instant::now();
@@ -1122,16 +1159,20 @@ pub fn db_artifact_create(
     })();
 
     match &result {
-        Ok(v) => tool_log(
-            "db_artifact_create",
-            "ok",
-            json!({
-                "durationMs": start.elapsed().as_millis() as u64,
-                "artifactId": v.artifact_id,
-                "version": v.version,
-                "blobHash": v.blob_hash
-            }),
-        ),
+        Ok(v) => {
+            let payload = artifact_change_event_from_manifest(v, ArtifactChangeKind::Created);
+            let _ = app_handle.emit("artifact_changed", &payload);
+            tool_log(
+                "db_artifact_create",
+                "ok",
+                json!({
+                    "durationMs": start.elapsed().as_millis() as u64,
+                    "artifactId": v.artifact_id,
+                    "version": v.version,
+                    "blobHash": v.blob_hash
+                }),
+            )
+        }
         Err(e) => tool_log(
             "db_artifact_create",
             "err",
@@ -1151,6 +1192,7 @@ pub fn db_artifact_version(
     run_id: String,
     agent_id: String,
     input: ArtifactVersionInput,
+    app_handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ArtifactManifest, String> {
     let start = Instant::now();
@@ -1258,16 +1300,20 @@ pub fn db_artifact_version(
     })();
 
     match &result {
-        Ok(v) => tool_log(
-            "db_artifact_version",
-            "ok",
-            json!({
-                "durationMs": start.elapsed().as_millis() as u64,
-                "artifactId": v.artifact_id,
-                "version": v.version,
-                "blobHash": v.blob_hash
-            }),
-        ),
+        Ok(v) => {
+            let payload = artifact_change_event_from_manifest(v, ArtifactChangeKind::Versioned);
+            let _ = app_handle.emit("artifact_changed", &payload);
+            tool_log(
+                "db_artifact_version",
+                "ok",
+                json!({
+                    "durationMs": start.elapsed().as_millis() as u64,
+                    "artifactId": v.artifact_id,
+                    "version": v.version,
+                    "blobHash": v.blob_hash
+                }),
+            )
+        }
         Err(e) => tool_log(
             "db_artifact_version",
             "err",
@@ -1956,6 +2002,82 @@ mod tests {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
         }
+    }
+
+    #[test]
+    fn test_artifact_change_event_created_serializes() {
+        let manifest = ArtifactManifest {
+            session_id: "tab-1".to_string(),
+            run_id: "run_1".to_string(),
+            agent_id: "agent_main".to_string(),
+            artifact_seq: 1,
+            artifact_id: "plan_deadbeef".to_string(),
+            version: 1,
+            kind: "plan".to_string(),
+            summary: "Plan".to_string(),
+            parent: None,
+            metadata: json!({}),
+            content_format: "markdown".to_string(),
+            blob_hash: "blob_hash".to_string(),
+            size_bytes: 42,
+            created_at: 123,
+            content: None,
+        };
+
+        let event =
+            artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Created);
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            json!({
+                "sessionId": "tab-1",
+                "artifactId": "plan_deadbeef",
+                "version": 1,
+                "kind": "plan",
+                "runId": "run_1",
+                "agentId": "agent_main",
+                "change": "created",
+                "createdAt": 123,
+            })
+        );
+    }
+
+    #[test]
+    fn test_artifact_change_event_versioned_serializes() {
+        let manifest = ArtifactManifest {
+            session_id: "tab-2".to_string(),
+            run_id: "run_2".to_string(),
+            agent_id: "agent_subagent".to_string(),
+            artifact_seq: 7,
+            artifact_id: "review_cafebabe".to_string(),
+            version: 3,
+            kind: "review-report".to_string(),
+            summary: "Review".to_string(),
+            parent: None,
+            metadata: json!({ "scope": "src" }),
+            content_format: "json".to_string(),
+            blob_hash: "blob_hash_2".to_string(),
+            size_bytes: 99,
+            created_at: 456,
+            content: None,
+        };
+
+        let event =
+            artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Versioned);
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            json!({
+                "sessionId": "tab-2",
+                "artifactId": "review_cafebabe",
+                "version": 3,
+                "kind": "review-report",
+                "runId": "run_2",
+                "agentId": "agent_subagent",
+                "change": "versioned",
+                "createdAt": 456,
+            })
+        );
     }
 
     #[test]

--- a/src/agent/tools/artifacts.test.ts
+++ b/src/agent/tools/artifacts.test.ts
@@ -1,23 +1,51 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { invokeMock } = vi.hoisted(() => ({
+const { invokeMock, listenMock, eventHandlers } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+  eventHandlers: new Map<string, (event: { payload: unknown }) => void>(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
 import {
+  type ArtifactChangeEvent,
   artifactCreate,
   artifactGet,
   artifactList,
   artifactVersion,
+  listenForArtifactChanges,
 } from "./artifacts";
 
 describe("artifact tools", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    listenMock.mockReset();
+    eventHandlers.clear();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+
+    listenMock.mockImplementation(
+      async (
+        event: string,
+        handler: (event: { payload: ArtifactChangeEvent }) => void,
+      ) => {
+        eventHandlers.set(event, handler as (event: { payload: unknown }) => void);
+        return () => {
+          eventHandlers.delete(event);
+        };
+      },
+    );
   });
 
   it("validates create input before invoking", async () => {
@@ -328,5 +356,54 @@ describe("artifact tools", () => {
         message: "NOT_FOUND: artifact a1 not found",
       },
     });
+  });
+
+  it("listens for artifact changes and filters by session", async () => {
+    const onChange = vi.fn();
+    const unlisten = await listenForArtifactChanges("tab-1", onChange);
+    const handler = eventHandlers.get("artifact_changed");
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "artifact_changed",
+      expect.any(Function),
+    );
+    expect(handler).toBeTypeOf("function");
+
+    handler?.({
+      payload: {
+        sessionId: "tab-1",
+        artifactId: "plan_deadbeef",
+        version: 1,
+        kind: "plan",
+        runId: "run_1",
+        agentId: "agent_main",
+        change: "created",
+        createdAt: 123,
+      } satisfies ArtifactChangeEvent,
+    });
+    handler?.({
+      payload: {
+        sessionId: "tab-2",
+        artifactId: "plan_deadbeef",
+        version: 2,
+        kind: "plan",
+        runId: "run_2",
+        agentId: "agent_main",
+        change: "versioned",
+        createdAt: 124,
+      } satisfies ArtifactChangeEvent,
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "tab-1",
+        artifactId: "plan_deadbeef",
+        change: "created",
+      }),
+    );
+
+    await unlisten?.();
+    expect(eventHandlers.has("artifact_changed")).toBe(false);
   });
 });

--- a/src/agent/tools/artifacts.ts
+++ b/src/agent/tools/artifacts.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   getSubagentArtifactValidatorById,
 } from "../subagents";
@@ -54,6 +55,19 @@ export interface ArtifactManifest {
 export interface ArtifactRuntimeContext {
   runId: string;
   agentId: string;
+}
+
+export type ArtifactChangeType = "created" | "versioned";
+
+export interface ArtifactChangeEvent {
+  sessionId: string;
+  artifactId: string;
+  version: number;
+  kind: string;
+  runId: string;
+  agentId: string;
+  change: ArtifactChangeType;
+  createdAt: number;
 }
 
 export interface ArtifactCreateInput {
@@ -163,6 +177,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function cloneMetadataRecord(value: unknown): Record<string, unknown> {
   return isRecord(value) ? { ...value } : {};
+}
+
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
 export function getArtifactFrameworkMetadata(
@@ -397,5 +415,21 @@ export async function artifactList(
   } catch (err) {
     const parsed = parseInvokeError(err);
     return { ok: false, error: parsed };
+  }
+}
+
+export async function listenForArtifactChanges(
+  sessionId: string,
+  onChange: (event: ArtifactChangeEvent) => void,
+): Promise<UnlistenFn | null> {
+  if (!sessionId.trim() || !isTauriRuntime()) return null;
+
+  try {
+    return await listen<ArtifactChangeEvent>("artifact_changed", (event) => {
+      if (event.payload.sessionId !== sessionId) return;
+      onChange(event.payload);
+    });
+  } catch {
+    return null;
   }
 }

--- a/src/components/artifact-pane/model.ts
+++ b/src/components/artifact-pane/model.ts
@@ -14,8 +14,6 @@ import type {
 } from "./types";
 import { ARTIFACT_FILTER_ALL } from "./types";
 
-export const ARTIFACT_POLL_MS = 2_000;
-
 const KNOWN_RENDER_KINDS = new Set<ArtifactRenderKind>([
   "plan",
   "review-report",

--- a/src/components/artifact-pane/useSessionArtifacts.test.tsx
+++ b/src/components/artifact-pane/useSessionArtifacts.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArtifactChangeEvent, ArtifactManifest } from "@/agent/tools/artifacts";
+import type { ToolResult } from "@/agent/types";
+
+const {
+  artifactGetMock,
+  artifactListMock,
+  eventHandlers,
+  listenMock,
+} = vi.hoisted(() => ({
+  artifactGetMock: vi.fn(),
+  artifactListMock: vi.fn(),
+  eventHandlers: new Map<string, (event: { payload: unknown }) => void>(),
+  listenMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+vi.mock("@/agent/tools/artifacts", async () => {
+  const actual = await vi.importActual<typeof import("@/agent/tools/artifacts")>(
+    "@/agent/tools/artifacts",
+  );
+  return {
+    ...actual,
+    artifactGet: (...args: unknown[]) => artifactGetMock(...args),
+    artifactList: (...args: unknown[]) => artifactListMock(...args),
+  };
+});
+
+import { useSessionArtifactInventory } from "./useSessionArtifacts";
+
+function makeArtifact(
+  artifactId: string,
+  version: number,
+  createdAt: number,
+): ArtifactManifest {
+  return {
+    sessionId: "tab-1",
+    runId: "run_1",
+    agentId: "agent_main",
+    artifactSeq: 1,
+    artifactId,
+    version,
+    kind: "plan",
+    summary: `plan v${version}`,
+    metadata: {},
+    contentFormat: "markdown",
+    blobHash: `blob-${artifactId}-${version}`,
+    sizeBytes: 100,
+    createdAt,
+  };
+}
+
+function okResult(
+  artifacts: ArtifactManifest[],
+): ToolResult<{ artifacts: ArtifactManifest[] }> {
+  return {
+    ok: true,
+    data: { artifacts },
+  };
+}
+
+function deferredResult() {
+  let resolve!: (value: ToolResult<{ artifacts: ArtifactManifest[] }>) => void;
+  const promise = new Promise<ToolResult<{ artifacts: ArtifactManifest[] }>>(
+    (nextResolve) => {
+      resolve = nextResolve;
+    },
+  );
+  return { promise, resolve };
+}
+
+function emitArtifactChange(event: ArtifactChangeEvent) {
+  act(() => {
+    eventHandlers.get("artifact_changed")?.({ payload: event });
+  });
+}
+
+describe("useSessionArtifactInventory", () => {
+  beforeEach(() => {
+    artifactGetMock.mockReset();
+    artifactListMock.mockReset();
+    listenMock.mockReset();
+    eventHandlers.clear();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+
+    listenMock.mockImplementation(
+      async (
+        event: string,
+        handler: (event: { payload: ArtifactChangeEvent }) => void,
+      ) => {
+        eventHandlers.set(event, handler as (event: { payload: unknown }) => void);
+        return () => {
+          eventHandlers.delete(event);
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads once on mount and refreshes only for matching artifact events", async () => {
+    artifactListMock
+      .mockResolvedValueOnce(okResult([makeArtifact("plan_deadbeef", 1, 100)]))
+      .mockResolvedValueOnce(okResult([makeArtifact("plan_deadbeef", 2, 200)]));
+
+    const { result } = renderHook(() => useSessionArtifactInventory("tab-1", true));
+
+    await waitFor(() => {
+      expect(result.current.inventory.groups[0]?.latest.version).toBe(1);
+    });
+
+    expect(artifactListMock).toHaveBeenCalledTimes(1);
+    expect(listenMock).toHaveBeenCalledTimes(1);
+
+    emitArtifactChange({
+      sessionId: "tab-2",
+      artifactId: "plan_deadbeef",
+      version: 2,
+      kind: "plan",
+      runId: "run_2",
+      agentId: "agent_main",
+      change: "versioned",
+      createdAt: 200,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(artifactListMock).toHaveBeenCalledTimes(1);
+
+    emitArtifactChange({
+      sessionId: "tab-1",
+      artifactId: "plan_deadbeef",
+      version: 2,
+      kind: "plan",
+      runId: "run_1",
+      agentId: "agent_main",
+      change: "versioned",
+      createdAt: 200,
+    });
+
+    await waitFor(() => {
+      expect(result.current.inventory.groups[0]?.latest.version).toBe(2);
+    });
+    expect(artifactListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces bursty artifact events into one follow-up refresh", async () => {
+    const firstRefresh = deferredResult();
+
+    artifactListMock
+      .mockResolvedValueOnce(okResult([makeArtifact("plan_deadbeef", 1, 100)]))
+      .mockImplementationOnce(() => firstRefresh.promise)
+      .mockResolvedValueOnce(okResult([makeArtifact("plan_deadbeef", 3, 300)]));
+
+    const { result } = renderHook(() => useSessionArtifactInventory("tab-1", true));
+
+    await waitFor(() => {
+      expect(result.current.inventory.groups[0]?.latest.version).toBe(1);
+    });
+
+    emitArtifactChange({
+      sessionId: "tab-1",
+      artifactId: "plan_deadbeef",
+      version: 2,
+      kind: "plan",
+      runId: "run_1",
+      agentId: "agent_main",
+      change: "versioned",
+      createdAt: 200,
+    });
+    emitArtifactChange({
+      sessionId: "tab-1",
+      artifactId: "plan_deadbeef",
+      version: 3,
+      kind: "plan",
+      runId: "run_1",
+      agentId: "agent_main",
+      change: "versioned",
+      createdAt: 300,
+    });
+
+    expect(artifactListMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstRefresh.resolve(okResult([makeArtifact("plan_deadbeef", 2, 200)]));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(artifactListMock).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(result.current.inventory.groups[0]?.latest.version).toBe(3);
+    });
+  });
+
+  it("retries listener registration and does not fall back to polling", async () => {
+    vi.useFakeTimers();
+
+    artifactListMock.mockResolvedValue(okResult([makeArtifact("plan_deadbeef", 1, 100)]));
+    listenMock
+      .mockRejectedValueOnce(new Error("listener unavailable"))
+      .mockImplementation(
+        async (
+          event: string,
+          handler: (event: { payload: ArtifactChangeEvent }) => void,
+        ) => {
+          eventHandlers.set(event, handler as (event: { payload: unknown }) => void);
+          return () => {
+            eventHandlers.delete(event);
+          };
+        },
+      );
+
+    renderHook(() => useSessionArtifactInventory("tab-1", true));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(artifactListMock).toHaveBeenCalledTimes(1);
+    expect(listenMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999);
+    });
+    expect(listenMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+
+    expect(listenMock).toHaveBeenCalledTimes(2);
+    expect(artifactListMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+      await Promise.resolve();
+    });
+
+    expect(artifactListMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/artifact-pane/useSessionArtifacts.ts
+++ b/src/components/artifact-pane/useSessionArtifacts.ts
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { artifactGet, artifactList } from "@/agent/tools/artifacts";
+import {
+  artifactGet,
+  artifactList,
+  listenForArtifactChanges,
+} from "@/agent/tools/artifacts";
 import type {
   ArtifactContentCache,
   ArtifactContentEntry,
   SessionArtifactInventory,
 } from "./types";
 import {
-  ARTIFACT_POLL_MS,
   buildSessionArtifactInventory,
   getArtifactContentKey,
 } from "./model";
@@ -31,6 +34,9 @@ interface ArtifactCacheState {
   entries: ArtifactContentCache;
 }
 
+const ARTIFACT_SUBSCRIPTION_RETRY_BASE_MS = 1_000;
+const ARTIFACT_SUBSCRIPTION_RETRY_MAX_MS = 30_000;
+
 function isTauriRuntime() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -47,52 +53,111 @@ export function useSessionArtifactInventory(tabId: string, enabled = true) {
 
   useEffect(() => {
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    let refreshInFlight = false;
+    let refreshQueued = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let retryDelayMs = ARTIFACT_SUBSCRIPTION_RETRY_BASE_MS;
+    let shouldCatchUpOnResubscribe = false;
+    let unlisten: (() => void) | null = null;
 
     if (!runtimeEnabled) return;
 
-    const poll = async () => {
+    const refreshInventory = async () => {
+      if (cancelled) return;
+      if (refreshInFlight) {
+        refreshQueued = true;
+        return;
+      }
+
+      refreshInFlight = true;
       const result = await artifactList(tabId, {
         latestOnly: false,
         limit: 1_000,
       });
 
-      if (cancelled) return;
+      try {
+        if (cancelled) return;
 
-      if (result.ok) {
-        setState({
-          tabId,
-          loading: false,
-          error: null,
-          inventory: buildSessionArtifactInventory(result.data.artifacts),
-          hasLoadedSuccessfully: true,
-        });
-      } else {
-        setState((prev) =>
-          prev.tabId !== tabId
-            ? {
-                tabId,
-                loading: false,
-                error: result.error.message,
-                inventory: EMPTY_INVENTORY,
-                hasLoadedSuccessfully: false,
-              }
-            : {
-                ...prev,
-                loading: false,
-                error: result.error.message,
-              },
-        );
+        if (result.ok) {
+          setState({
+            tabId,
+            loading: false,
+            error: null,
+            inventory: buildSessionArtifactInventory(result.data.artifacts),
+            hasLoadedSuccessfully: true,
+          });
+        } else {
+          setState((prev) =>
+            prev.tabId !== tabId
+              ? {
+                  tabId,
+                  loading: false,
+                  error: result.error.message,
+                  inventory: EMPTY_INVENTORY,
+                  hasLoadedSuccessfully: false,
+                }
+              : {
+                  ...prev,
+                  loading: false,
+                  error: result.error.message,
+                },
+          );
+        }
+      } finally {
+        refreshInFlight = false;
+        if (!cancelled && refreshQueued) {
+          refreshQueued = false;
+          void refreshInventory();
+        }
       }
-
-      timer = setTimeout(poll, ARTIFACT_POLL_MS);
     };
 
-    void poll();
+    const scheduleSubscriptionRetry = () => {
+      if (cancelled || retryTimer) return;
+      shouldCatchUpOnResubscribe = true;
+      const currentDelay = retryDelayMs;
+      retryDelayMs = Math.min(
+        retryDelayMs * 2,
+        ARTIFACT_SUBSCRIPTION_RETRY_MAX_MS,
+      );
+      retryTimer = setTimeout(() => {
+        retryTimer = undefined;
+        void subscribeToArtifactChanges();
+      }, currentDelay);
+    };
+
+    const subscribeToArtifactChanges = async () => {
+      if (cancelled) return;
+      const nextUnlisten = await listenForArtifactChanges(tabId, () => {
+        void refreshInventory();
+      });
+
+      if (cancelled) {
+        nextUnlisten?.();
+        return;
+      }
+
+      if (!nextUnlisten) {
+        scheduleSubscriptionRetry();
+        return;
+      }
+
+      retryDelayMs = ARTIFACT_SUBSCRIPTION_RETRY_BASE_MS;
+      unlisten = nextUnlisten;
+
+      if (shouldCatchUpOnResubscribe) {
+        shouldCatchUpOnResubscribe = false;
+        void refreshInventory();
+      }
+    };
+
+    void refreshInventory();
+    void subscribeToArtifactChanges();
 
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
+      if (retryTimer) clearTimeout(retryTimer);
+      unlisten?.();
     };
   }, [runtimeEnabled, tabId]);
 


### PR DESCRIPTION
## Summary
- replace artifact pane polling with Tauri artifact_changed push events
- add listener retry/coalesced refresh behavior and tests for the new subscription path
- document the new artifact update architecture in the repo docs

## Testing
- npm test -- --run src/agent/tools/artifacts.test.ts src/components/artifact-pane/useSessionArtifacts.test.tsx
- npm run typecheck
- npm run lint -- src/agent/tools/artifacts.ts src/agent/tools/artifacts.test.ts src/components/artifact-pane/useSessionArtifacts.ts src/components/artifact-pane/useSessionArtifacts.test.tsx
- cargo test

Fixes #67