### PR TITLE
feat: image attachment support in chat

### DIFF
--- a/src-tauri/src/fs_ops.rs
+++ b/src-tauri/src/fs_ops.rs
@@ -1,3 +1,4 @@
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use crate::utils::tool_log;
 use serde_json::{json, Value};
 use std::fs;
@@ -760,6 +761,34 @@ pub fn search_files_grep(
     }
 
     result
+}
+
+#[tauri::command]
+pub fn read_file_base64(path: String) -> Result<Value, String> {
+    let p = PathBuf::from(&path);
+    let bytes = fs::read(&p).map_err(|e| format!("Cannot read {}: {}", path, e))?;
+    let encoded = BASE64.encode(&bytes);
+    // Derive a best-effort MIME type from the extension.
+    let ext = p
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let mime = match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        _ => "application/octet-stream",
+    };
+    Ok(json!({
+        "data": encoded,
+        "mimeType": mime,
+        "sizeBytes": bytes.len(),
+    }))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run() {
             fs_ops::list_dir,
             fs_ops::stat_file,
             fs_ops::read_file,
+            fs_ops::read_file_base64,
             fs_ops::write_file,
             fs_ops::delete_file,
             fs_ops::glob_files,

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -8,6 +8,7 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
 } from "react";
+import type { AttachedImage } from "@/agent/types";
 import { useAtomValue } from "jotai";
 import ArtifactPane, { useArtifactUpdates } from "@/components/ArtifactPane";
 import ConversationCards from "@/components/ConversationCards";
@@ -85,6 +86,95 @@ export default function WorkspacePage() {
     },
     [activeTabId],
   );
+  const [attachedImagesByTab, setAttachedImagesByTab] = useState<
+    Record<string, AttachedImage[]>
+  >({});
+  const attachedImages = useMemo(
+    () => attachedImagesByTab[activeTabId] ?? [],
+    [attachedImagesByTab, activeTabId],
+  );
+
+  const addAttachedImages = useCallback(
+    async (files: File[]) => {
+      const readAsDataUrl = (file: File): Promise<string> =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = reject;
+          reader.readAsDataURL(file);
+        });
+      const newImages = await Promise.all(
+        files.map(async (file) => ({
+          id: Math.random().toString(36).slice(2) + Date.now().toString(36),
+          name: file.name,
+          previewUrl: await readAsDataUrl(file),
+          mimeType: file.type || "image/",
+        })),
+      );
+      setAttachedImagesByTab((prev) => ({
+        ...prev,
+        [activeTabId]: [...(prev[activeTabId] ?? []), ...newImages],
+      }));
+    },
+    [activeTabId],
+  );
+
+  const removeAttachedImage = useCallback(
+    (id: string) => {
+      setAttachedImagesByTab((prev) => {
+        const current = prev[activeTabId] ?? [];
+        const removed = current.find((img) => img.id === id);
+        if (removed?.previewUrl.startsWith("blob:"))
+          URL.revokeObjectURL(removed.previewUrl);
+        return {
+          ...prev,
+          [activeTabId]: current.filter((img) => img.id !== id),
+        };
+      });
+    },
+    [activeTabId],
+  );
+
+  const clearAttachedImages = useCallback(() => {
+    setAttachedImagesByTab((prev) => {
+      const current = prev[activeTabId] ?? [];
+      for (const img of current) {
+        if (img.previewUrl.startsWith("blob:"))
+          URL.revokeObjectURL(img.previewUrl);
+      }
+      return { ...prev, [activeTabId]: [] };
+    });
+  }, [activeTabId]);
+
+  const handleImagePathDrop = useCallback(
+    async (paths: string[]) => {
+      const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+      const newImages = await Promise.all(
+        paths.map(async (filePath) => {
+          const result = await tauriInvoke<{ data: string; mimeType: string }>(
+            "read_file_base64",
+            { path: filePath },
+          );
+          const dataUrl = `data:${result.mimeType};base64,${result.data}`;
+          const name = filePath.split("/").pop() ?? filePath;
+          return {
+            id: Math.random().toString(36).slice(2) + Date.now().toString(36),
+            name,
+            previewUrl: dataUrl,
+            mimeType: result.mimeType,
+          } satisfies AttachedImage;
+        }),
+      );
+      setAttachedImagesByTab((prev) => ({
+        ...prev,
+        [activeTabId]: [...(prev[activeTabId] ?? []), ...newImages],
+      }));
+    },
+    [activeTabId],
+  );
+
+  const [isChatDropActive, setIsChatDropActive] = useState(false);
+
   const [leftWidth, setLeftWidth] = useState(70);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [artifactOpen, setArtifactOpen] = useState(true);
@@ -275,7 +365,7 @@ export default function WorkspacePage() {
 
   const handleSubmit = useCallback(async () => {
     const text = input.trim();
-    if (!text) return;
+    if (!text && attachedImages.length === 0) return;
 
     if (helpCommand && matchesSlashCommandInput(text, helpCommand)) {
       injectAssistantMessage(formatSlashCommandHelpMarkdown(slashCommands));
@@ -329,11 +419,19 @@ export default function WorkspacePage() {
 
     if (isAgentBusy || voiceInput.busy) return;
 
+    const currentAttachments = attachedImages.slice();
     voiceInput.clearError();
     setInput("");
-    agent.sendMessage(text);
+    clearAttachedImages();
+    if (currentAttachments.length > 0) {
+      agent.sendMessage(text, currentAttachments);
+    } else {
+      agent.sendMessage(text);
+    }
   }, [
     input,
+    attachedImages,
+    clearAttachedImages,
     activeTabId,
     helpCommand,
     isAgentBusy,
@@ -404,7 +502,7 @@ export default function WorkspacePage() {
   }
 
   const hasSendableText = input.trim().length > 0;
-  const canSend = hasSendableText;
+  const canSend = hasSendableText || attachedImages.length > 0;
   const voiceBusy = voiceInput.busy;
   const sendTitle = voiceInput.isPreparingModel
     ? "Downloading Whisper model..."
@@ -430,7 +528,10 @@ export default function WorkspacePage() {
             {chatBubbleGroups.map((group) => {
               if (group.kind === "user") {
                 return (
-                  <UserMessage key={group.key}>
+                  <UserMessage
+                    key={group.key}
+                    images={group.message.attachments}
+                  >
                     <Markdown>{group.message.content}</Markdown>
                   </UserMessage>
                 );
@@ -619,13 +720,45 @@ export default function WorkspacePage() {
             />
             <VoiceInputStateProvider value={voiceInput}>
               <div className="chat-input-shell">
+                {isChatDropActive && (
+                  <div className="chat-drop-overlay" aria-hidden="true">
+                    <span className="material-symbols-outlined">upload_file</span>
+                    <span>Drop to attach</span>
+                  </div>
+                )}
                 <VoiceInputStatusSlot />
                 <VoiceInputRecordingRow />
+                {attachedImages.length > 0 && (
+                  <div className="chat-attachment-strip">
+                    {attachedImages.map((img) => (
+                      <div key={img.id} className="chat-attachment-chip">
+                        <img
+                          src={img.previewUrl}
+                          alt={img.name}
+                          className="chat-attachment-thumb"
+                        />
+                        <span className="chat-attachment-name">{img.name}</span>
+                        <button
+                          className="chat-attachment-remove"
+                          onClick={() => removeAttachedImage(img.id)}
+                          title={`Remove ${img.name}`}
+                          aria-label={`Remove ${img.name}`}
+                          type="button"
+                        >
+                          <span className="material-symbols-outlined" style={{ fontSize: 14 }}>close</span>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <MentionTextarea
                   ref={textareaRef}
                   value={input}
                   onChange={handleInput}
                   onKeyDown={handleKeyDown}
+                  onImageDrop={addAttachedImages}
+                  onImagePathDrop={handleImagePathDrop}
+                  onDragActiveChange={setIsChatDropActive}
                   cwd={agent.config.cwd}
                   slashCommands={slashCommands}
                   placeholder="Type a message…"

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -44,6 +44,7 @@ import {
   consumeApprovalReason,
 } from "./approvals";
 import type {
+  AttachedImage,
   ConversationCard,
   SerializedConversationCard,
   AdvancedModelOptions,
@@ -293,8 +294,26 @@ function mapApiMessagesToModelMessages(messages: ApiMessage[]): ModelMessage[] {
       }
     }
 
-    if (msg.role === "system" || msg.role === "user") {
-      mapped.push({ role: msg.role, content: msg.content ?? "" });
+    if (msg.role === "system") {
+      mapped.push({ role: "system", content: msg.content ?? "" });
+      continue;
+    }
+
+    if (msg.role === "user") {
+      const imgs = msg.attachments;
+      if (imgs && imgs.length > 0) {
+        const parts: Array<Record<string, unknown>> = [
+          ...imgs.map((img) => ({
+            type: "image",
+            image: img.previewUrl,
+            mimeType: img.mimeType,
+          })),
+          ...(msg.content ? [{ type: "text", text: msg.content }] : []),
+        ];
+        mapped.push({ role: "user", content: parts } as unknown as ModelMessage);
+      } else {
+        mapped.push({ role: "user", content: msg.content ?? "" });
+      }
       continue;
     }
 
@@ -1924,6 +1943,7 @@ export async function retryAgent(tabId: string): Promise<void> {
 export async function runAgent(
   tabId: string,
   userMessage: string,
+  attachments?: AttachedImage[],
 ): Promise<void> {
   // Cancel any in-flight run for this tab
   stopAgent(tabId);
@@ -1947,6 +1967,7 @@ export async function runAgent(
       role: "user",
       content: userMessage,
       timestamp: Date.now(),
+      ...(attachments && attachments.length > 0 ? { attachments } : {}),
     };
     patchAgentState(tabId, (prev) => ({
       ...prev,
@@ -2080,6 +2101,7 @@ export async function runAgent(
     role: "user",
     content: userMessage,
     timestamp: Date.now(),
+    ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
 
   // Detect git repo on first turn so the system prompt can include the GIT ISOLATION section.
@@ -2139,6 +2161,7 @@ export async function runAgent(
     {
       role: "user" as const,
       content: userMessage,
+      ...(attachments && attachments.length > 0 ? { attachments } : {}),
     },
   ];
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -44,6 +44,7 @@ export interface SystemApiMessage {
 export interface UserApiMessage {
   role: "user";
   content: string;
+  attachments?: AttachedImage[];
 }
 
 export interface AssistantApiMessage {
@@ -195,10 +196,18 @@ export type SerializedConversationCard =
   | SerializedSummaryConversationCard
   | SerializedArtifactConversationCard;
 
+export interface AttachedImage {
+  id: string;
+  name: string;
+  previewUrl: string;
+  mimeType: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
+  attachments?: AttachedImage[];
   /**
    * Display name of the agent that produced this message.
    * Undefined / omitted means the main Rakh agent.

--- a/src/agent/useAgents.ts
+++ b/src/agent/useAgents.ts
@@ -39,6 +39,7 @@ import {
 import type {
   AgentConfig,
   ApiMessage,
+  AttachedImage,
   AutoApproveCommandsMode,
 } from "./types";
 
@@ -156,10 +157,13 @@ export function useAgentShowDebug(tabId: string) {
  * Safe to call concurrently for different tabIds (they run in parallel).
  */
 export function useSendMessage() {
-  return useCallback((tabId: string, message: string) => {
-    // fire-and-forget; the runner updates atoms reactively
-    runAgent(tabId, message).catch(console.error);
-  }, []);
+  return useCallback(
+    (tabId: string, message: string, attachments?: AttachedImage[]) => {
+      // fire-and-forget; the runner updates atoms reactively
+      runAgent(tabId, message, attachments).catch(console.error);
+    },
+    [],
+  );
 }
 
 /** stopAgent — abort the currently running turn for a tab */
@@ -290,7 +294,8 @@ export function useAgent(tabId: string) {
     autoApproveCommands,
     showDebug,
     sendMessage: useCallback(
-      (msg: string) => sendMessage(tabId, msg),
+      (msg: string, attachments?: AttachedImage[]) =>
+        sendMessage(tabId, msg, attachments),
       [tabId, sendMessage],
     ),
     stop: useCallback(() => stopAgent(tabId), [tabId, stopAgent]),

--- a/src/components/ImagePreviewModal.tsx
+++ b/src/components/ImagePreviewModal.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { AttachedImage } from "@/agent/types";
+
+interface ImagePreviewModalProps {
+  image: AttachedImage;
+  onClose: () => void;
+}
+
+export default function ImagePreviewModal({
+  image,
+  onClose,
+}: ImagePreviewModalProps) {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="image-preview-backdrop"
+      onClick={onClose}
+      role="dialog"
+      aria-modal
+      aria-label={image.name}
+    >
+      <div
+        className="image-preview-shell"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="image-preview-header">
+          <span className="image-preview-name">{image.name}</span>
+          <button
+            className="image-preview-close"
+            onClick={onClose}
+            title="Close (Esc)"
+            aria-label="Close"
+          >
+            <span className="material-symbols-outlined text-lg">close</span>
+          </button>
+        </div>
+        <div className="image-preview-body">
+          <img
+            src={image.previewUrl}
+            alt={image.name}
+            className="image-preview-img"
+          />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/MentionTextarea.tsx
+++ b/src/components/MentionTextarea.tsx
@@ -50,6 +50,9 @@ export interface MentionTextareaProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onImageDrop?: (files: File[]) => void;
+  onImagePathDrop?: (paths: string[]) => void;
+  onDragActiveChange?: (active: boolean) => void;
   cwd?: string;
   slashCommands?: SlashCommandDefinition[];
   placeholder?: string;
@@ -156,6 +159,19 @@ function normalizePath(filePath: string, cwd?: string): string {
   }
 
   return normalizedPath;
+}
+
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"]);
+
+function isImageFile(file: File): boolean {
+  if (file.type.startsWith("image/")) return true;
+  const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+function isImagePath(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
 }
 
 function hasDraggedFiles(dataTransfer: DataTransfer | null): boolean {
@@ -310,6 +326,9 @@ export const MentionTextarea = forwardRef<
     value,
     onChange,
     onKeyDown,
+    onImageDrop,
+    onImagePathDrop,
+    onDragActiveChange,
     cwd,
     slashCommands = [],
     placeholder,
@@ -543,6 +562,15 @@ export const MentionTextarea = forwardRef<
     [applyControlledValue, cwd],
   );
 
+  const handleImageFiles = useCallback(
+    (files: File[]) => {
+      if (files.length > 0 && onImageDrop) {
+        onImageDrop(files);
+      }
+    },
+    [onImageDrop],
+  );
+
   const isPositionInsideEditor = useCallback((position: { x: number; y: number }) => {
     const element = editorElementRef.current;
     if (!element) return false;
@@ -668,22 +696,31 @@ export const MentionTextarea = forwardRef<
         TauriEvent.DRAG_ENTER,
         (event) => {
           if (!mounted) return;
+          onDragActiveChange?.(true);
           setIsDropTarget(isPositionInsideEditor(event.payload.position));
         },
       );
       const unlistenDragLeave = await listen(TauriEvent.DRAG_LEAVE, () => {
         if (!mounted) return;
+        onDragActiveChange?.(false);
         setIsDropTarget(false);
       });
       const unlistenDragDrop = await listen<TauriDragPayload>(
         TauriEvent.DRAG_DROP,
         (event) => {
           if (!mounted) return;
+          onDragActiveChange?.(false);
           setIsDropTarget(false);
           if (!isPositionInsideEditor(event.payload.position)) {
             return;
           }
-          insertDroppedPaths(event.payload.paths);
+          // Split: image paths go to onImagePathDrop, everything else inserts @path text.
+          const imagePaths = event.payload.paths.filter((p) => isImagePath(p));
+          const nonImagePaths = event.payload.paths.filter(
+            (p) => !isImagePath(p),
+          );
+          if (imagePaths.length > 0) onImagePathDrop?.(imagePaths);
+          insertDroppedPaths(nonImagePaths);
         },
       );
 
@@ -698,7 +735,7 @@ export const MentionTextarea = forwardRef<
         unlisten();
       }
     };
-  }, [insertDroppedPaths, isPositionInsideEditor]);
+  }, [insertDroppedPaths, isPositionInsideEditor, onImagePathDrop, onDragActiveChange]);
 
   const handleEditorRef = useCallback(
     (editor: LexicalEditor | null) => {
@@ -888,7 +925,13 @@ export const MentionTextarea = forwardRef<
       domDragDepthRef.current = 0;
       setIsDropTarget(false);
 
-      const paths = Array.from(event.dataTransfer.files)
+      const allFiles = Array.from(event.dataTransfer.files);
+      const imageFiles = allFiles.filter(isImageFile);
+      const nonImageFiles = allFiles.filter((f) => !isImageFile(f));
+
+      handleImageFiles(imageFiles);
+
+      const paths = nonImageFiles
         .map((file) => {
           const tauriFile = file as File & { path?: string };
           return tauriFile.path ?? file.name;
@@ -897,7 +940,7 @@ export const MentionTextarea = forwardRef<
 
       insertDroppedPaths(paths);
     },
-    [insertDroppedPaths],
+    [insertDroppedPaths, handleImageFiles],
   );
 
   const initialValueRef = useRef(value);

--- a/src/components/UserMessage.tsx
+++ b/src/components/UserMessage.tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
+import type { AttachedImage } from "@/agent/types";
+import ImagePreviewModal from "@/components/ImagePreviewModal";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    UserMessage — a message bubble from the human operator.
@@ -8,18 +11,51 @@ interface UserMessageProps {
   /** Display name shown in the header (default: "YOU") */
   name?: string;
   children: ReactNode;
+  images?: AttachedImage[];
 }
 
 export default function UserMessage({
   name = "YOU",
   children,
+  images,
 }: UserMessageProps) {
+  const [previewImage, setPreviewImage] = useState<AttachedImage | null>(null);
+
   return (
     <div className="msg animate-fade-up">
       <div className="msg-header">
         <span className="msg-role msg-role--user">{name}</span>
       </div>
-      <div className="msg-body">{children}</div>
+      <div className="msg-body">
+        {images && images.length > 0 && (
+          <div className="msg-image-row">
+            {images.map((img) => (
+              <button
+                key={img.id}
+                className="msg-image-chip"
+                onClick={() => setPreviewImage(img)}
+                title={img.name}
+                type="button"
+                aria-label={`View image: ${img.name}`}
+              >
+                <img
+                  src={img.previewUrl}
+                  alt={img.name}
+                  className="msg-image-thumb"
+                />
+                <span className="msg-image-name">{img.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        {children}
+      </div>
+      {previewImage && (
+        <ImagePreviewModal
+          image={previewImage}
+          onClose={() => setPreviewImage(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/artifact-pane/DebugPane.test.tsx
+++ b/src/components/artifact-pane/DebugPane.test.tsx
@@ -42,6 +42,15 @@ vi.mock("@/contexts/TabsContext", () => ({
   useTabs: () => tabsContextMock.value,
 }));
 
+const FAKE_PREVIEW_URL = `data:image/png;base64,${'Z'.repeat(8192)}`;
+
+const FAKE_ATTACHMENT = {
+  id: "img-1",
+  name: "screenshot.png",
+  previewUrl: FAKE_PREVIEW_URL,
+  mimeType: "image/png",
+};
+
 function buildFixture() {
   const longSystemPrompt = "system prompt ".repeat(600);
   const longUserMessage = `attach this screenshot data:image/png;base64,${"A".repeat(4096)}`;
@@ -69,6 +78,7 @@ function buildFixture() {
         role: "user",
         content: longChatMessage,
         timestamp: 1,
+        attachments: [{ ...FAKE_ATTACHMENT }],
       },
       {
         id: "chat-assistant",
@@ -100,6 +110,7 @@ function buildFixture() {
       {
         role: "user",
         content: longUserMessage,
+        attachments: [{ ...FAKE_ATTACHMENT }],
       },
       {
         role: "assistant",
@@ -248,6 +259,21 @@ describe("DebugPane copy bundle", () => {
     expect(bundle.agent.chatMessages[1].toolCalls?.[0]?.result).toEqual(
       state.chatMessages[1].toolCalls?.[0]?.result,
     );
+
+    // Attachments: previewUrl redacted, other fields preserved
+    const chatUserMsg = bundle.agent.chatMessages[0];
+    expect(chatUserMsg.attachments).toHaveLength(1);
+    expect(chatUserMsg.attachments?.[0]?.previewUrl).not.toContain("base64");
+    expect(chatUserMsg.attachments?.[0]?.previewUrl).toContain("redacted");
+    expect(chatUserMsg.attachments?.[0]?.name).toBe("screenshot.png");
+    expect(chatUserMsg.attachments?.[0]?.mimeType).toBe("image/png");
+
+    const apiUserMsg = bundle.agent.apiMessages[1];
+    if (apiUserMsg.role !== "user") throw new Error("Expected user api message");
+    expect(apiUserMsg.attachments).toHaveLength(1);
+    expect(apiUserMsg.attachments?.[0]?.previewUrl).not.toContain("base64");
+    expect(apiUserMsg.attachments?.[0]?.previewUrl).toContain("redacted");
+    expect(apiUserMsg.attachments?.[0]?.name).toBe("screenshot.png");
   });
 
   it("copies the full bundle when shrinking is disabled", async () => {
@@ -275,5 +301,14 @@ describe("DebugPane copy bundle", () => {
     expect(bundle.agent.apiMessages).toEqual(state.apiMessages);
     expect(bundle.agent.chatMessages).toEqual(state.chatMessages);
     expect(bundle.agent.streamingContent).toBe(state.streamingContent);
+
+    // Attachments preserved verbatim when shrinking is off
+    expect(bundle.agent.chatMessages[0].attachments?.[0]?.previewUrl).toBe(
+      FAKE_PREVIEW_URL,
+    );
+    const apiUserMsgFull = bundle.agent.apiMessages[1];
+    if (apiUserMsgFull.role !== "user")
+      throw new Error("Expected user api message");
+    expect(apiUserMsgFull.attachments?.[0]?.previewUrl).toBe(FAKE_PREVIEW_URL);
   });
 });

--- a/src/components/artifact-pane/DebugPane.tsx
+++ b/src/components/artifact-pane/DebugPane.tsx
@@ -6,7 +6,7 @@ import { getAllSubagents } from "@/agent/subagents";
 import CycleOptionSwitch from "@/components/CycleOptionSwitch";
 import { Button } from "@/components/ui";
 import { useTabs } from "@/contexts/TabsContext";
-import type { ApiMessage, ChatMessage } from "@/agent/types";
+import type { ApiMessage, AttachedImage, ChatMessage } from "@/agent/types";
 import { cn } from "@/utils/cn";
 import pkg from "../../../package.json";
 
@@ -125,14 +125,28 @@ function shrinkDebugMessageText(value: string): string {
   ].join("");
 }
 
+function redactAttachedImages(attachments: AttachedImage[]): AttachedImage[] {
+  return attachments.map((img) => ({
+    ...img,
+    previewUrl: `[redacted ${img.mimeType}, ${img.previewUrl.length} chars]`,
+  }));
+}
+
 function shrinkApiMessages(messages: ApiMessage[]): ApiMessage[] {
   return messages.map((message) => {
     switch (message.role) {
       case "system":
+        return {
+          ...message,
+          content: shrinkDebugMessageText(message.content),
+        };
       case "user":
         return {
           ...message,
           content: shrinkDebugMessageText(message.content),
+          ...(message.attachments
+            ? { attachments: redactAttachedImages(message.attachments) }
+            : {}),
         };
       case "assistant":
         return {
@@ -156,6 +170,9 @@ function shrinkChatMessages(messages: ChatMessage[]): ChatMessage[] {
       typeof message.reasoning === "string"
         ? shrinkDebugMessageText(message.reasoning)
         : message.reasoning,
+    ...(message.attachments
+      ? { attachments: redactAttachedImages(message.attachments) }
+      : {}),
   }));
 }
 

--- a/src/styles/components-messages.css
+++ b/src/styles/components-messages.css
@@ -351,6 +351,51 @@
   color: var(--color-muted);
 }
 
+/* ── Image attachments in user messages ──────────────────────────────────── */
+.msg-image-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.msg-image-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  overflow: hidden;
+  max-width: 80px;
+  transition:
+    border-color var(--t-fast),
+    opacity var(--t-fast);
+}
+.msg-image-chip:hover {
+  border-color: var(--color-primary);
+  opacity: 0.9;
+}
+.msg-image-thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  display: block;
+  flex-shrink: 0;
+}
+.msg-image-name {
+  width: 100%;
+  padding: 2px 4px 4px;
+  font-size: var(--text-xxs);
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+}
+
 .md-inline-code {
   background: var(--color-subtle);
   color: var(--color-primary);

--- a/src/styles/components-modals.css
+++ b/src/styles/components-modals.css
@@ -251,6 +251,84 @@
   -webkit-backdrop-filter: blur(2px);
 }
 
+/* ── Image preview modal ─────────────────────────────────────────────────── */
+.image-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 99900;
+  background: rgba(0, 0, 0, 0.86);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: fadeIn 0.12s ease;
+}
+.image-preview-shell {
+  display: flex;
+  flex-direction: column;
+  max-width: min(90vw, 1100px);
+  max-height: 90vh;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-mid);
+  background: var(--color-surface);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  animation: slideUp 0.15s ease;
+}
+.image-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  gap: 12px;
+  flex-shrink: 0;
+}
+.image-preview-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+}
+.image-preview-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color var(--t-fast), background var(--t-fast);
+}
+.image-preview-close:hover {
+  color: var(--color-text);
+  background: var(--color-subtle);
+}
+.image-preview-body {
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  min-height: 0;
+}
+.image-preview-img {
+  max-width: 100%;
+  max-height: calc(90vh - 80px);
+  object-fit: contain;
+  border-radius: 4px;
+  display: block;
+}
+
 .error-modal {
   position: relative;
   width: 100%;

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -254,6 +254,67 @@
   border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
 }
 
+/* ── Pending image attachment strip (inside chat-input-shell) ──────────── */
+.chat-attachment-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 0 8px 0;
+}
+.chat-attachment-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px 3px 4px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-subtle);
+  background: color-mix(in srgb, var(--color-elevated) 70%, transparent);
+  max-width: 180px;
+  min-width: 0;
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast);
+}
+.chat-attachment-chip:hover {
+  border-color: var(--color-border-mid);
+  background: var(--color-elevated);
+}
+.chat-attachment-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+  display: block;
+}
+.chat-attachment-name {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-xxs);
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-attachment-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  border-radius: 3px;
+  padding: 0;
+  transition: color var(--t-fast);
+}
+.chat-attachment-remove:hover {
+  color: var(--color-error);
+}
+
 .workspace-error-details-btn:hover:not(:disabled) {
   color: var(--color-error);
   border-color: color-mix(in srgb, var(--color-error) 45%, transparent);
@@ -574,11 +635,45 @@
   content: "";
   position: absolute;
   inset: -10px -60px -10px -12px;
-  border: 1px solid color-mix(in srgb, var(--color-primary) 45%, transparent);
+  border: 1.5px dashed color-mix(in srgb, var(--color-primary) 55%, transparent);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 6%, transparent);
   pointer-events: none;
   z-index: 0;
+}
+
+.chat-drop-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  border: 1.5px dashed color-mix(in srgb, var(--color-primary) 60%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 10%, var(--color-surface) 85%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--color-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  pointer-events: none;
+  z-index: 10;
+  animation: chat-drop-overlay-in 0.12s ease both;
+}
+
+.chat-drop-overlay .material-symbols-outlined {
+  font-size: 18px;
+  opacity: 0.85;
+}
+
+@keyframes chat-drop-overlay-in {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .mention-textarea__editor {


### PR DESCRIPTION
## Summary

Adds full image attachment support to the chat input.

## Changes

### UI
- Drag-and-drop images onto the chat input — works with both Tauri native OS drags (file paths via `read_file_base64`) and DOM file drops
- Animated drop zone overlay appears as soon as a file enters the window
- Thumbnail strip above the textarea shows pending attachments with name and a remove button
- Sent user messages render clickable image chips; clicking opens a fullscreen lightbox modal

### AI integration
- User messages with attachments are sent to the model as multimodal content (`ImagePart` + `TextPart`) via the Vercel AI SDK — compatible with OpenAI and Anthropic vision models
- Images are stored as base64 data URLs, so they survive session restore

### Debug pane
- Copy context bundle redacts `previewUrl` from attachments when "Shrink long messages" is enabled, replacing it with `[redacted image/png, N chars]`
- Tests added for both the redact-on and preserve-off paths

Co-Authored-By: Oz <oz-agent@warp.dev>