### PR TITLE
fix(runner): preserve user message in chatMessages during retry

### DIFF
--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -2725,7 +2725,9 @@ describe("runner", () => {
       const state = states[tabId];
       expect(state.status).toBe("idle");
       expect(state.error).toBeNull();
-      // Should have user + assistant in chat (re-added by runAgent)
+      // User message is kept throughout (never removed), stale assistant
+      // placeholder from the failed turn is stripped. runAgent streams the
+      // fresh assistant response without re-appending a duplicate user bubble.
       expect(state.chatMessages).toHaveLength(2);
       expect(state.chatMessages[0]).toMatchObject({
         role: "user",
@@ -2736,6 +2738,43 @@ describe("runner", () => {
         content: "Done!",
         streaming: false,
       });
+    });
+
+    it("never removes the user message from chatMessages — no duplicate and no flash", async () => {
+      const tabId = "tab-retry-no-flash";
+
+      // Simulate the exact post-error state: user bubble + stale empty
+      // assistant bubble left by the failed streaming turn.
+      setState(tabId, {
+        status: "error",
+        error: "network timeout",
+        apiMessages: [
+          { role: "system", content: "system prompt" },
+          { role: "user", content: "fix the bug" },
+        ],
+        chatMessages: [
+          { role: "user", content: "fix the bug", id: "u1", timestamp: 1 },
+          { role: "assistant", content: "", id: "a1", timestamp: 2, streaming: false },
+        ],
+      });
+
+      turns.push({ deltas: ["Fixed!"], toolCalls: [] });
+      await retryAgent(tabId);
+
+      const state = states[tabId];
+      // Exactly one user message — no duplicate, no gap
+      const userMsgs = state.chatMessages.filter((m) => m.role === "user");
+      expect(userMsgs).toHaveLength(1);
+      expect(userMsgs[0]).toMatchObject({ content: "fix the bug" });
+
+      // Stale empty assistant bubble is gone; only the new response remains
+      const assistantMsgs = state.chatMessages.filter((m) => m.role === "assistant");
+      expect(assistantMsgs).toHaveLength(1);
+      expect(assistantMsgs[0]).toMatchObject({ content: "Fixed!", streaming: false });
+
+      expect(state.chatMessages).toHaveLength(2);
+      expect(state.status).toBe("idle");
+      expect(state.error).toBeNull();
     });
 
     it("preserves earlier conversation turns and only retries the last user message", async () => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1886,8 +1886,9 @@ async function runSubagentLoop(
 
 /**
  * Retry the last user message after an error.
- * Strips the last user message (and any partial assistant turn) from both the
- * API and chat message histories, then calls runAgent with the same message.
+ * Strips the failed assistant turn from both histories but keeps the user chat
+ * message visible throughout, then calls runAgent which re-adds it to the API
+ * history and streams a fresh assistant response.
  */
 export async function retryAgent(tabId: string): Promise<void> {
   const state = getAgentState(tabId);
@@ -1910,7 +1911,9 @@ export async function retryAgent(tabId: string): Promise<void> {
   // Strip apiMessages back to before the last user message
   const strippedApiMessages = state.apiMessages.slice(0, lastUserIndex);
 
-  // Strip chatMessages back to before the last user chat message
+  // Keep the last user chat message visible so the UI never shows a blank
+  // gap between the strip and runAgent re-appending it. Only strip the
+  // failed assistant turn(s) that follow it.
   let lastUserChatIndex = -1;
   for (let i = state.chatMessages.length - 1; i >= 0; i--) {
     if (state.chatMessages[i].role === "user") {
@@ -1920,10 +1923,11 @@ export async function retryAgent(tabId: string): Promise<void> {
   }
   const strippedChatMessages =
     lastUserChatIndex >= 0
-      ? state.chatMessages.slice(0, lastUserChatIndex)
+      ? state.chatMessages.slice(0, lastUserChatIndex + 1)
       : state.chatMessages;
 
-  // Reset state to before the last user message so runAgent can re-add it cleanly
+  // Reset state — the user message stays in chatMessages so it remains
+  // visible. runAgent is told not to re-append it to avoid a duplicate.
   patchAgentState(tabId, {
     apiMessages: strippedApiMessages,
     chatMessages: strippedChatMessages,
@@ -1932,7 +1936,7 @@ export async function retryAgent(tabId: string): Promise<void> {
     errorAction: null,
   });
 
-  await runAgent(tabId, lastUserMessage);
+  await runAgent(tabId, lastUserMessage, undefined, { skipUserChatAppend: true });
 }
 
 /**
@@ -1944,6 +1948,7 @@ export async function runAgent(
   tabId: string,
   userMessage: string,
   attachments?: AttachedImage[],
+  options?: { skipUserChatAppend?: boolean },
 ): Promise<void> {
   // Cancel any in-flight run for this tab
   stopAgent(tabId);
@@ -1975,7 +1980,9 @@ export async function runAgent(
       error: null,
       errorAction: null,
       errorDetails: null,
-      chatMessages: [...prev.chatMessages, triggerUserMsg],
+      chatMessages: options?.skipUserChatAppend
+        ? prev.chatMessages
+        : [...prev.chatMessages, triggerUserMsg],
       streamingContent: null,
     }));
 
@@ -2171,7 +2178,9 @@ export async function runAgent(
     error: null,
     errorAction: null,
     errorDetails: null,
-    chatMessages: [...prev.chatMessages, userChatMsg],
+    chatMessages: options?.skipUserChatAppend
+      ? prev.chatMessages
+      : [...prev.chatMessages, userChatMsg],
     apiMessages: newApiMessages,
     streamingContent: null,
   }));


### PR DESCRIPTION
Fix #15 
`retryAgent` now slices `chatMessages` inclusively (keeping the last user bubble) and passes `skipUserChatAppend` to `runAgent`, preventing the transient gap where the user message disappeared between the state reset and the re-appen.
