### PR TITLE
fix: add busy-state queueing and steering

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -39,6 +39,10 @@ pub struct PersistedSession {
     pub todos: String,
     /// JSON-serialised ReviewEdit[]
     pub review_edits: String,
+    /// JSON-serialised QueuedUserMessage[]
+    pub queued_messages: String,
+    /// Queue drain state for persisted follow-ups
+    pub queue_state: String,
     pub archived: bool,
     pub created_at: i64,
     pub updated_at: i64,
@@ -673,6 +677,8 @@ pub fn init_db() -> Result<Connection, String> {
             chat_messages    TEXT    NOT NULL DEFAULT '[]',
             api_messages     TEXT    NOT NULL DEFAULT '[]',
             todos            TEXT    NOT NULL DEFAULT '[]',
+            queued_messages  TEXT    NOT NULL DEFAULT '[]',
+            queue_state      TEXT    NOT NULL DEFAULT 'idle',
             archived         INTEGER NOT NULL DEFAULT 0,
             created_at       INTEGER NOT NULL,
             updated_at       INTEGER NOT NULL,
@@ -694,6 +700,10 @@ pub fn init_db() -> Result<Connection, String> {
     );
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN show_debug INTEGER NOT NULL DEFAULT 0;");
+    let _ = conn
+        .execute_batch("ALTER TABLE sessions ADD COLUMN queued_messages TEXT NOT NULL DEFAULT '[]';");
+    let _ = conn
+        .execute_batch("ALTER TABLE sessions ADD COLUMN queue_state TEXT NOT NULL DEFAULT 'idle';");
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS artifact_blobs (
@@ -779,6 +789,7 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
                 "SELECT id, label, icon, mode, tab_title, cwd, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
+                queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug,
                 advanced_options
@@ -805,14 +816,16 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
                     api_messages: row.get(11)?,
                     todos: row.get(12)?,
                     review_edits: row.get(13)?,
-                    archived: row.get::<_, i64>(14)? != 0,
-                    created_at: row.get(15)?,
-                    updated_at: row.get(16)?,
-                    worktree_path: row.get(17)?,
-                    worktree_branch: row.get(18)?,
-                    worktree_declined: row.get::<_, i64>(19)? != 0,
-                    show_debug: row.get::<_, i64>(20)? != 0,
-                    advanced_options: row.get::<_, String>(21).unwrap_or_default(),
+                    queued_messages: row.get(14)?,
+                    queue_state: row.get(15)?,
+                    archived: row.get::<_, i64>(16)? != 0,
+                    created_at: row.get(17)?,
+                    updated_at: row.get(18)?,
+                    worktree_path: row.get(19)?,
+                    worktree_branch: row.get(20)?,
+                    worktree_declined: row.get::<_, i64>(21)? != 0,
+                    show_debug: row.get::<_, i64>(22)? != 0,
+                    advanced_options: row.get::<_, String>(23).unwrap_or_default(),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -868,9 +881,10 @@ pub fn db_upsert_session(
             id, label, icon, mode, tab_title, cwd, model,
             plan_markdown, plan_version, plan_updated_at,
             chat_messages, api_messages, todos, review_edits,
+            queued_messages, queue_state,
             archived, created_at, updated_at,
             worktree_path, worktree_branch, worktree_declined, show_debug, advanced_options
-         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24)
          ON CONFLICT(id) DO UPDATE SET
             label             = excluded.label,
             icon              = excluded.icon,
@@ -885,13 +899,15 @@ pub fn db_upsert_session(
             api_messages      = excluded.api_messages,
             todos             = excluded.todos,
             review_edits      = excluded.review_edits,
+            queued_messages   = excluded.queued_messages,
+            queue_state       = excluded.queue_state,
             archived          = excluded.archived,
             worktree_path     = excluded.worktree_path,
             worktree_branch   = excluded.worktree_branch,
             worktree_declined = excluded.worktree_declined,
             show_debug        = excluded.show_debug,
             advanced_options  = excluded.advanced_options,
-            updated_at        = ?17",
+            updated_at        = ?19",
             rusqlite::params![
                 session.id,
                 session.label,
@@ -907,6 +923,8 @@ pub fn db_upsert_session(
                 session.api_messages,
                 session.todos,
                 session.review_edits,
+                session.queued_messages,
+                session.queue_state,
                 session.archived as i64,
                 session.created_at,
                 now,
@@ -989,6 +1007,7 @@ pub fn db_load_archived_sessions(
                 "SELECT id, label, icon, mode, tab_title, cwd, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
+                queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug,
                 advanced_options
@@ -1015,14 +1034,16 @@ pub fn db_load_archived_sessions(
                     api_messages: row.get(11)?,
                     todos: row.get(12)?,
                     review_edits: row.get(13)?,
-                    archived: row.get::<_, i64>(14)? != 0,
-                    created_at: row.get(15)?,
-                    updated_at: row.get(16)?,
-                    worktree_path: row.get(17)?,
-                    worktree_branch: row.get(18)?,
-                    worktree_declined: row.get::<_, i64>(19)? != 0,
-                    show_debug: row.get::<_, i64>(20)? != 0,
-                    advanced_options: row.get::<_, String>(21).unwrap_or_default(),
+                    queued_messages: row.get(14)?,
+                    queue_state: row.get(15)?,
+                    archived: row.get::<_, i64>(16)? != 0,
+                    created_at: row.get(17)?,
+                    updated_at: row.get(18)?,
+                    worktree_path: row.get(19)?,
+                    worktree_branch: row.get(20)?,
+                    worktree_declined: row.get::<_, i64>(21)? != 0,
+                    show_debug: row.get::<_, i64>(22)? != 0,
+                    advanced_options: row.get::<_, String>(23).unwrap_or_default(),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -1748,6 +1769,8 @@ mod tests {
                 chat_messages    TEXT    NOT NULL DEFAULT '[]',
                 api_messages     TEXT    NOT NULL DEFAULT '[]',
                 todos            TEXT    NOT NULL DEFAULT '[]',
+                queued_messages  TEXT    NOT NULL DEFAULT '[]',
+                queue_state      TEXT    NOT NULL DEFAULT 'idle',
                 archived         INTEGER NOT NULL DEFAULT 0,
                 created_at       INTEGER NOT NULL,
                 updated_at       INTEGER NOT NULL,
@@ -1789,6 +1812,8 @@ mod tests {
             api_messages: "[]".to_string(),
             todos: "[]".to_string(),
             review_edits: "[]".to_string(),
+            queued_messages: "[]".to_string(),
+            queue_state: "idle".to_string(),
             archived: false,
             created_at: 1000,
             updated_at: 1000,
@@ -1804,9 +1829,10 @@ mod tests {
                 id, label, icon, mode, tab_title, cwd, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
+                queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug
-             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23)",
             rusqlite::params![
                 session.id,
                 session.label,
@@ -1822,6 +1848,8 @@ mod tests {
                 session.api_messages,
                 session.todos,
                 session.review_edits,
+                session.queued_messages,
+                session.queue_state,
                 session.archived as i64,
                 session.created_at,
                 session.updated_at,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,11 +94,19 @@ function AutoSaveManager() {
       const tabAtom = agentAtomFamily(tab.id);
       let lastStatus: AgentStatus = jotaiStore.get(tabAtom).status;
       let lastShowDebug = jotaiStore.get(tabAtom).showDebug ?? false;
+      let lastQueueSnapshot = JSON.stringify({
+        queueState: jotaiStore.get(tabAtom).queueState,
+        queuedMessages: jotaiStore.get(tabAtom).queuedMessages,
+      });
 
       const unsub = jotaiStore.sub(tabAtom, () => {
         const state = jotaiStore.get(tabAtom);
         const newStatus = state.status;
         const newShowDebug = state.showDebug ?? false;
+        const newQueueSnapshot = JSON.stringify({
+          queueState: state.queueState,
+          queuedMessages: state.queuedMessages,
+        });
 
         const settled =
           newStatus !== lastStatus &&
@@ -106,11 +114,13 @@ function AutoSaveManager() {
             newStatus === "done" ||
             newStatus === "error");
         const debugToggled = newShowDebug !== lastShowDebug;
+        const queueChanged = newQueueSnapshot !== lastQueueSnapshot;
 
         lastStatus = newStatus;
         lastShowDebug = newShowDebug;
+        lastQueueSnapshot = newQueueSnapshot;
 
-        if (settled || debugToggled) {
+        if (settled || debugToggled || queueChanged) {
           const currentTab = tabs.find((t) => t.id === tab.id);
           if (currentTab && currentTab.mode === "workspace") {
             upsertSession(currentTab);

--- a/src/ThemePreview.tsx
+++ b/src/ThemePreview.tsx
@@ -5,6 +5,8 @@ import CompactToolCall from "@/components/CompactToolCall";
 import PatchPreview from "@/components/PatchPreview";
 import ReasoningThought from "@/components/ReasoningThought";
 import ToolCallApproval from "@/components/ToolCallApproval";
+import ChatControls from "@/components/ChatControls";
+import BusyComposerTray from "@/components/BusyComposerTray";
 import UserMessage from "@/components/UserMessage";
 import type { DiffFile } from "@/components/DiffViewer";
 import {
@@ -187,6 +189,17 @@ const STATUS_VARIANTS: Array<{
   { status: "done", badgeVariant: "success" },
   { status: "error", badgeVariant: "danger" },
 ];
+
+const PREVIEW_QUEUE_ITEMS = [
+  {
+    id: "preview-queue-1",
+    content: "Add the missing repro steps before you keep running.",
+  },
+  {
+    id: "preview-queue-2",
+    content: "After that, summarize only the UI changes for approval.",
+  },
+] as const;
 
 export default function ThemePreview() {
   const [themeName, setThemeName] = useState<ThemeName>("rakh");
@@ -378,6 +391,89 @@ export default function ThemePreview() {
               <Panel variant="inset" className="ds-tool-panel">
                 <h3 className="ds-item-label">Error</h3>
                 <CompactToolCall tc={TOOL_ERROR} onInspect={() => {}} showDebug cwd="src" />
+              </Panel>
+            </div>
+          </section>
+
+          <section className="ds-section ds-section--full">
+            <h2 className="ds-section-title">Composer States</h2>
+            <div className="ds-tool-grid">
+              <Panel variant="inset" className="ds-tool-panel">
+                <h3 className="ds-item-label">Queued note</h3>
+                <div className="chat-input-wrap ds-composer-preview">
+                  <BusyComposerTray
+                    queuedItems={[PREVIEW_QUEUE_ITEMS[0]]}
+                    queueState="draining"
+                    onSendQueuedNow={() => {}}
+                    onRemoveQueuedItem={() => {}}
+                  />
+                  <ChatControls
+                    autoApproveEdits={false}
+                    autoApproveCommands="agent"
+                    onChangeAutoApproveEdits={() => {}}
+                    onChangeAutoApproveCommands={() => {}}
+                    contextWindowPct={28}
+                    contextCurrentKb={9.5}
+                    contextMaxKb={32}
+                  />
+                  <div className="chat-input-shell">
+                    <div className="ds-composer-draft ds-composer-draft--muted">
+                      Type a message…
+                    </div>
+                    <div className="chat-input-actions">
+                      <IconButton title="Voice input">
+                        <span className="material-symbols-outlined text-lg">
+                          mic
+                        </span>
+                      </IconButton>
+                    </div>
+                  </div>
+                  <div className="chat-input-meta">
+                    <span>Model: openai/gpt-5.2</span>
+                    <span>•</span>
+                    <span className="font-mono text-xs">/workspace/eve</span>
+                  </div>
+                </div>
+              </Panel>
+
+              <Panel variant="inset" className="ds-tool-panel">
+                <h3 className="ds-item-label">Paused queue</h3>
+                <div className="chat-input-wrap ds-composer-preview">
+                  <BusyComposerTray
+                    queuedItems={[...PREVIEW_QUEUE_ITEMS]}
+                    queueState="paused"
+                    onSendQueuedNow={() => {}}
+                    onResumeQueue={() => {}}
+                    onClearQueuedItems={() => {}}
+                    onRemoveQueuedItem={() => {}}
+                  />
+                  <ChatControls
+                    autoApproveEdits={true}
+                    autoApproveCommands="no"
+                    onChangeAutoApproveEdits={() => {}}
+                    onChangeAutoApproveCommands={() => {}}
+                    contextWindowPct={71}
+                    contextCurrentKb={22.8}
+                    contextMaxKb={32}
+                  />
+                  <div className="chat-input-shell">
+                    <div className="ds-composer-draft ds-composer-draft--muted">
+                      Draft another follow-up while the agent is still working...
+                    </div>
+                    <div className="chat-input-actions">
+                      <IconButton title="Voice input">
+                        <span className="material-symbols-outlined text-lg">
+                          mic
+                        </span>
+                      </IconButton>
+                    </div>
+                  </div>
+                  <div className="chat-input-meta">
+                    <span>Model: openai/gpt-5.2</span>
+                    <span>•</span>
+                    <span className="font-mono text-xs">/workspace/eve</span>
+                  </div>
+                </div>
               </Panel>
             </div>
           </section>

--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -14,6 +14,11 @@ import WorkspacePage from "./WorkspacePage";
 
 const workspaceMocks = vi.hoisted(() => ({
   sendMessageMock: vi.fn<(message: string) => void>(),
+  queueMessageMock: vi.fn<(message: string) => void>(),
+  steerMessageMock: vi.fn<(message: string, queuedMessageId?: string) => void>(),
+  resumeQueueMock: vi.fn(),
+  removeQueuedMessageMock: vi.fn<(messageId: string) => void>(),
+  clearQueuedMessagesMock: vi.fn(),
   stopMock: vi.fn(),
   setConfigMock: vi.fn(),
   setAutoApproveEditsMock: vi.fn(),
@@ -40,12 +45,19 @@ const workspaceMocks = vi.hoisted(() => ({
           section: "providers";
           label: string;
         },
+    clearQueuedMessages: null as null | (() => void),
     errorDetails: null as unknown,
+    queueMessage: null as null | ((message: string) => void),
+    queueState: "idle" as "idle" | "draining" | "paused",
+    queuedMessages: [] as Array<{ id: string; content: string; createdAtMs: number }>,
+    removeQueuedMessage: null as null | ((messageId: string) => void),
+    resumeQueue: null as null | (() => void),
     sendMessage: null as null | ((message: string) => void),
     setAutoApproveCommands: null as null | ((value: "no" | "agent" | "yes") => void),
     setAutoApproveEdits: null as null | ((value: boolean) => void),
     setConfig: null as null | ((config: unknown) => void),
     showDebug: false,
+    steerMessage: null as null | ((message: string, queuedMessageId?: string) => void),
     status: "idle" as "idle" | "thinking" | "working" | "done" | "error",
     stop: null as null | (() => void),
     tabTitle: "",
@@ -214,13 +226,24 @@ vi.mock("@/components/ReasoningThought", () => ({
 }));
 
 vi.mock("@/components/ui", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   Button: ({
     children,
     onClick,
+    disabled,
+    title,
+    "aria-label": ariaLabel,
   }: {
     children: ReactNode;
     onClick?: () => void;
-  }) => <button onClick={onClick}>{children}</button>,
+    disabled?: boolean;
+    title?: string;
+    "aria-label"?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} title={title} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock("@/components/voice-input/VoiceInputUi", () => ({
@@ -380,6 +403,11 @@ describe("WorkspacePage chat input", () => {
     });
     installSelectionGeometryPolyfills();
     workspaceMocks.sendMessageMock.mockReset();
+    workspaceMocks.queueMessageMock.mockReset();
+    workspaceMocks.steerMessageMock.mockReset();
+    workspaceMocks.resumeQueueMock.mockReset();
+    workspaceMocks.removeQueuedMessageMock.mockReset();
+    workspaceMocks.clearQueuedMessagesMock.mockReset();
     workspaceMocks.stopMock.mockReset();
     workspaceMocks.setConfigMock.mockReset();
     workspaceMocks.setAutoApproveEditsMock.mockReset();
@@ -409,14 +437,21 @@ describe("WorkspacePage chat input", () => {
       },
       contextWindowKb: null,
       contextWindowPct: null,
+      clearQueuedMessages: workspaceMocks.clearQueuedMessagesMock,
       error: null,
       errorAction: null,
       errorDetails: null,
+      queueMessage: workspaceMocks.queueMessageMock,
+      queueState: "idle",
+      queuedMessages: [],
+      removeQueuedMessage: workspaceMocks.removeQueuedMessageMock,
+      resumeQueue: workspaceMocks.resumeQueueMock,
       sendMessage: workspaceMocks.sendMessageMock,
       setAutoApproveCommands: workspaceMocks.setAutoApproveCommandsMock,
       setAutoApproveEdits: workspaceMocks.setAutoApproveEditsMock,
       setConfig: workspaceMocks.setConfigMock,
       showDebug: false,
+      steerMessage: workspaceMocks.steerMessageMock,
       status: "idle",
       stop: workspaceMocks.stopMock,
       tabTitle: "",
@@ -638,6 +673,141 @@ describe("WorkspacePage chat input", () => {
       showDebug: false,
     });
     expect(nextState.showDebug).toBe(true);
+  });
+
+  it("does not show the queue strip while the agent is busy with no submitted follow-up", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      status: "working",
+    };
+
+    await act(async () => {
+      render(<WorkspacePage />);
+    });
+
+    expect(screen.queryByRole("button", { name: "Queue" })).toBeNull();
+    expect(screen.queryByText("Working")).toBeNull();
+  });
+
+  it("does not show a queued row while the user is only typing during a busy run", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      status: "working",
+    };
+
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("Need the repro steps before phase 2.");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("Need the repro steps before phase 2.");
+    });
+
+    expect(screen.queryByText("Queued 1")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
+    expect(workspaceMocks.queueMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("uses Enter to queue a real follow-up while busy", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      status: "thinking",
+    };
+
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("Pause after the UI slice for review.");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("Pause after the UI slice for review.");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.queueMessageMock).toHaveBeenCalledWith(
+      "Pause after the UI slice for review.",
+    );
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("lets the user remove a queued follow-up", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      queuedMessages: [
+        {
+          id: "queued-1",
+          content: "First queued follow-up item.",
+          createdAtMs: 100,
+        },
+      ],
+      queueState: "draining",
+    };
+
+    render(<WorkspacePage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Remove queued note 1" }));
+    });
+
+    expect(workspaceMocks.removeQueuedMessageMock).toHaveBeenCalledWith("queued-1");
+  });
+
+  it("sends a queued follow-up immediately when Send now is pressed", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      queuedMessages: [
+        {
+          id: "queued-1",
+          content: "Interrupt this run and use the corrected title.",
+          createdAtMs: 100,
+        },
+      ],
+      queueState: "draining",
+    };
+
+    render(<WorkspacePage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    });
+
+    expect(workspaceMocks.steerMessageMock).toHaveBeenCalledWith(
+      "Interrupt this run and use the corrected title.",
+      "queued-1",
+    );
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("renders paused queue controls in the fixed input area", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      queueState: "paused",
+      queuedMessages: [
+        {
+          id: "queued-1",
+          content: "Wait for approval before changing the runner behavior.",
+          createdAtMs: 100,
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<WorkspacePage />);
+    });
+
+    expect(screen.getByText("Paused")).not.toBeNull();
+    expect(
+      screen.getByText("Wait for approval before changing the runner behavior."),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Resume" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Clear" })).not.toBeNull();
+    expect(screen.getByText("Paused")?.closest(".chat-input-wrap")).not.toBeNull();
   });
 
   it("opens AI Providers from the error banner action", async () => {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -21,6 +21,7 @@ import Markdown from "@/components/Markdown";
 import NewSession from "@/components/NewSession";
 import ChatControls from "@/components/ChatControls";
 import AutoScrollArea from "@/components/AutoScrollArea";
+import BusyComposerTray from "@/components/BusyComposerTray";
 import ErrorDetailsModal, {
   type ErrorModalState,
 } from "@/components/ErrorDetailsModal";
@@ -293,6 +294,37 @@ export default function WorkspacePage() {
     onTranscript: appendTranscriptToInput,
   });
 
+  const queueBusyComposerMessage = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+
+    agent.queueMessage(text);
+    setInput("");
+
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  }, [agent, input, setInput]);
+
+  const handleQueuedItemSendNow = useCallback(
+    (itemId: string) => {
+      const item = agent.queuedMessages.find((entry) => entry.id === itemId);
+      if (!item) return;
+      agent.steerMessage(item.content, item.id);
+    },
+    [agent],
+  );
+
+  const handleRemoveQueuedItem = useCallback(
+    (itemId: string) => {
+      agent.removeQueuedMessage(itemId);
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    },
+    [agent],
+  );
+
   const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     isDragging.current = true;
@@ -417,7 +449,12 @@ export default function WorkspacePage() {
       return;
     }
 
-    if (isAgentBusy || voiceInput.busy) return;
+    if (isAgentBusy) {
+      queueBusyComposerMessage();
+      return;
+    }
+
+    if (voiceInput.busy) return;
 
     const currentAttachments = attachedImages.slice();
     voiceInput.clearError();
@@ -440,6 +477,7 @@ export default function WorkspacePage() {
     setInput,
     models,
     injectAssistantMessage,
+    queueBusyComposerMessage,
     slashCommands,
   ]);
 
@@ -504,6 +542,7 @@ export default function WorkspacePage() {
   const hasSendableText = input.trim().length > 0;
   const canSend = hasSendableText || attachedImages.length > 0;
   const voiceBusy = voiceInput.busy;
+  const showBusyComposerTray = agent.queuedMessages.length > 0;
   const sendTitle = voiceInput.isPreparingModel
     ? "Downloading Whisper model..."
     : voiceInput.isTranscribing
@@ -705,6 +744,16 @@ export default function WorkspacePage() {
             className="chat-input-wrap"
             onClick={() => textareaRef.current?.focus()}
           >
+            {showBusyComposerTray ? (
+              <BusyComposerTray
+                queuedItems={agent.queuedMessages}
+                queueState={agent.queueState}
+                onSendQueuedNow={handleQueuedItemSendNow}
+                onResumeQueue={agent.resumeQueue}
+                onClearQueuedItems={agent.clearQueuedMessages}
+                onRemoveQueuedItem={handleRemoveQueuedItem}
+              />
+            ) : null}
             <ChatControls
               autoApproveEdits={agent.autoApproveEdits}
               autoApproveCommands={agent.autoApproveCommands}
@@ -719,7 +768,9 @@ export default function WorkspacePage() {
               contextMaxKb={contextWindowKb?.maxKb ?? null}
             />
             <VoiceInputStateProvider value={voiceInput}>
-              <div className="chat-input-shell">
+              <div
+                className={`chat-input-shell${isAgentBusy ? " chat-input-shell--busy" : ""}`}
+              >
                 {isChatDropActive && (
                   <div className="chat-drop-overlay" aria-hidden="true">
                     <span className="material-symbols-outlined">upload_file</span>
@@ -767,17 +818,7 @@ export default function WorkspacePage() {
                 />
                 <div className="chat-input-actions">
                   <VoiceInputToggleButton />
-                  {isAgentBusy ? (
-                    <button
-                      title="Stop agent"
-                      aria-label="Stop agent"
-                      onClick={agent.stop}
-                    >
-                      <span className="material-symbols-outlined text-lg">
-                        stop_circle
-                      </span>
-                    </button>
-                  ) : (
+                  {isAgentBusy ? null : (
                     <button
                       title={sendTitle}
                       aria-label="Send"

--- a/src/agent/atoms.ts
+++ b/src/agent/atoms.ts
@@ -134,6 +134,8 @@ function makeDefaultAgentState(): AgentState {
     reviewEdits: [],
     autoApproveEdits: false,
     autoApproveCommands: "no",
+    queuedMessages: [],
+    queueState: "idle",
     showDebug: import.meta.env.DEV,
   };
 }
@@ -214,6 +216,16 @@ export const agentAutoApproveEditsAtomFamily = atomFamily((tabId: string) =>
 /** Auto-approve commands for a tab */
 export const agentAutoApproveCommandsAtomFamily = atomFamily((tabId: string) =>
   atom((get) => get(agentAtomFamily(tabId)).autoApproveCommands),
+);
+
+/** Queued user follow-ups for a tab */
+export const agentQueuedMessagesAtomFamily = atomFamily((tabId: string) =>
+  atom((get) => get(agentAtomFamily(tabId)).queuedMessages),
+);
+
+/** Queue drain / paused state for a tab */
+export const agentQueueStateAtomFamily = atomFamily((tabId: string) =>
+  atom((get) => get(agentAtomFamily(tabId)).queueState),
 );
 
 /** Debug UI mode for a tab */

--- a/src/agent/persistence.test.ts
+++ b/src/agent/persistence.test.ts
@@ -82,6 +82,8 @@ describe("persistence", () => {
       apiMessages: [{ role: "user", content: "hello" }],
       todos: [{ id: "a" }],
       reviewEdits: [{ filePath: "a.ts" }],
+      queuedMessages: [{ id: "q1", content: "follow up", createdAtMs: 42 }],
+      queueState: "paused",
     } as unknown as Parameters<typeof buildPersistedSession>[1];
 
     const session = buildPersistedSession(tab, state);
@@ -91,6 +93,8 @@ describe("persistence", () => {
     expect(session.apiMessages).toBe(JSON.stringify(state.apiMessages));
     expect(session.todos).toBe(JSON.stringify(state.todos));
     expect(session.reviewEdits).toBe(JSON.stringify(state.reviewEdits));
+    expect(session.queuedMessages).toBe(JSON.stringify(state.queuedMessages));
+    expect(session.queueState).toBe("paused");
     expect(session.worktreePath).toBe("");
     expect(session.worktreeBranch).toBe("");
     expect(session.worktreeDeclined).toBe(false);
@@ -103,6 +107,7 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
       tabTitle: "",
       plan: { markdown: "", version: 0, updatedAtMs: 0 },
       error: null,
@@ -117,6 +122,7 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
       tabTitle: "",
       plan: { markdown: "", version: 0, updatedAtMs: 0 },
       error: null,
@@ -126,6 +132,7 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
       tabTitle: "",
       plan: { markdown: "Plan", version: 1, updatedAtMs: 123 },
       error: null,
@@ -135,14 +142,26 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
       tabTitle: "",
       plan: { markdown: "", version: 0, updatedAtMs: 0 },
       error: "boom",
+    } as unknown as Parameters<typeof isSessionEmpty>[0];
+    const withQueued = {
+      chatMessages: [],
+      apiMessages: [],
+      todos: [],
+      reviewEdits: [],
+      queuedMessages: [{ id: "q1" }],
+      tabTitle: "",
+      plan: { markdown: "", version: 0, updatedAtMs: 0 },
+      error: null,
     } as unknown as Parameters<typeof isSessionEmpty>[0];
 
     expect(isSessionEmpty(withChat)).toBe(false);
     expect(isSessionEmpty(withPlan)).toBe(false);
     expect(isSessionEmpty(withError)).toBe(false);
+    expect(isSessionEmpty(withQueued)).toBe(false);
   });
 
   it("loadSessions returns [] when not running in Tauri", async () => {
@@ -178,6 +197,8 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
+      queueState: "idle",
     };
 
     await upsertSession({
@@ -214,6 +235,8 @@ describe("persistence", () => {
       apiMessages: [{ role: "user", content: "hi" }],
       todos: [{ id: "t1" }],
       reviewEdits: [{ filePath: "a.ts" }],
+      queuedMessages: [{ id: "q1", content: "check logs", createdAtMs: 10 }],
+      queueState: "paused",
       showDebug: true,
     };
 
@@ -234,6 +257,10 @@ describe("persistence", () => {
     expect(payload.session.worktreePath).toBe("/wt");
     expect(payload.session.worktreeBranch).toBe("codex/branch");
     expect(payload.session.worktreeDeclined).toBe(true);
+    expect(payload.session.queuedMessages).toBe(
+      JSON.stringify([{ id: "q1", content: "check logs", createdAtMs: 10 }]),
+    );
+    expect(payload.session.queueState).toBe("paused");
     expect(payload.session.showDebug).toBe(true);
   });
 
@@ -247,6 +274,8 @@ describe("persistence", () => {
       apiMessages: [],
       todos: [],
       reviewEdits: [],
+      queuedMessages: [],
+      queueState: "idle",
     };
 
     await upsertWorkspaceSessions([
@@ -298,6 +327,8 @@ describe("persistence", () => {
       apiMessages: "[]",
       todos: "[]",
       reviewEdits: "[]",
+      queuedMessages: "[]",
+      queueState: "idle",
       archived: true,
       createdAt: 1,
       updatedAt: 1,

--- a/src/agent/persistence.ts
+++ b/src/agent/persistence.ts
@@ -20,7 +20,7 @@
  */
 
 import type { Tab } from "@/contexts/TabsContext";
-import type { AgentState } from "./types";
+import type { AgentQueueState, AgentState } from "./types";
 import { getAgentState } from "./atoms";
 import { DEFAULT_MODEL } from "./atoms";
 
@@ -48,6 +48,10 @@ export interface PersistedSession {
   todos: string;
   /** JSON string — ReviewEdit[] */
   reviewEdits: string;
+  /** JSON string — QueuedUserMessage[] */
+  queuedMessages: string;
+  /** Queue drain state for persisted follow-ups */
+  queueState: AgentQueueState;
   archived: boolean;
   createdAt: number;
   updatedAt: number;
@@ -115,6 +119,8 @@ export function buildPersistedSession(
     apiMessages: JSON.stringify(state.apiMessages),
     todos: JSON.stringify(state.todos),
     reviewEdits: JSON.stringify(state.reviewEdits),
+    queuedMessages: JSON.stringify(state.queuedMessages),
+    queueState: state.queueState,
     archived: false,
     worktreePath: state.config.worktreePath ?? "",
     worktreeBranch: state.config.worktreeBranch ?? "",
@@ -137,6 +143,7 @@ export function buildPersistedSession(
 export function isSessionEmpty(state: AgentState): boolean {
   if (state.chatMessages.length > 0 || state.apiMessages.length > 0) return false;
   if (state.todos.length > 0 || state.reviewEdits.length > 0) return false;
+  if (state.queuedMessages.length > 0) return false;
   if (state.tabTitle.trim().length > 0) return false;
   if (state.plan.markdown.trim().length > 0) return false;
   if (state.plan.version > 0 || state.plan.updatedAtMs > 0) return false;

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -27,6 +27,8 @@ type MockAgentState = {
   streamingContent: string | null;
   plan: { markdown: string; updatedAtMs: number; version: number };
   todos: unknown[];
+  queuedMessages: Array<Record<string, unknown>>;
+  queueState: "idle" | "draining" | "paused";
   error: string | null;
   errorDetails: unknown;
   tabTitle: string;
@@ -138,9 +140,11 @@ vi.mock("./tools/exec", () => ({
 
 import {
   buildProviderOptions,
+  resumeQueue,
   runAgent,
   retryAgent,
   serializeError,
+  steerMessage,
   stopAgent,
   stopRunningExecToolCall,
 } from "./runner";
@@ -157,6 +161,8 @@ function makeState(overrides: Partial<MockAgentState> = {}): MockAgentState {
     streamingContent: null,
     plan: { markdown: "", updatedAtMs: 0, version: 0 },
     todos: [],
+    queuedMessages: [],
+    queueState: "idle",
     error: null,
     errorDetails: null,
     tabTitle: "",
@@ -1063,6 +1069,138 @@ describe("runner", () => {
           "User aborted the execution of this command. No stdout/stderr will be returned.",
       },
     });
+  });
+
+  it("stopAgent pauses queued work instead of draining it", () => {
+    const tabId = "tab-stop-pauses-queue";
+    setState(tabId, {
+      status: "working",
+      queueState: "draining",
+      queuedMessages: [
+        { id: "queued-1", content: "follow up later", createdAtMs: 10 },
+      ],
+    });
+
+    stopAgent(tabId);
+
+    expect(states[tabId].status).toBe("idle");
+    expect(states[tabId].queueState).toBe("paused");
+    expect(states[tabId].queuedMessages).toEqual([
+      { id: "queued-1", content: "follow up later", createdAtMs: 10 },
+    ]);
+  });
+
+  it("drains queued messages sequentially after a clean idle", async () => {
+    const tabId = "tab-queue-drain";
+    setState(tabId, {
+      queueState: "paused",
+      queuedMessages: [
+        { id: "queued-1", content: "first queued note", createdAtMs: 10 },
+        { id: "queued-2", content: "second queued note", createdAtMs: 20 },
+      ],
+    });
+
+    turns.push(
+      { deltas: ["First done"], toolCalls: [] },
+      { deltas: ["Second done"], toolCalls: [] },
+    );
+
+    resumeQueue(tabId);
+    await flushAsyncWork(12);
+
+    expect(states[tabId].queueState).toBe("idle");
+    expect(states[tabId].queuedMessages).toEqual([]);
+    expect(states[tabId].chatMessages[0]).toMatchObject({
+      role: "user",
+      content: "first queued note",
+    });
+    expect(states[tabId].chatMessages[2]).toMatchObject({
+      role: "user",
+      content: "second queued note",
+    });
+  });
+
+  it("preserves queued items when steering a new message", async () => {
+    const tabId = "tab-steer-preserves-queue";
+    setState(tabId, {
+      queuedMessages: [
+        { id: "queued-1", content: "stay queued", createdAtMs: 10 },
+      ],
+      queueState: "draining",
+    });
+
+    let releaseFirstRun: (() => void) | undefined;
+    let releaseSecondRun: (() => void) | undefined;
+    let secondRunAborted = false;
+
+    streamTextMock
+      .mockReset()
+      .mockImplementationOnce((args: { abortSignal: AbortSignal }) => {
+        const waitForAbort = new Promise<void>((resolve) => {
+          args.abortSignal.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+        const hold = new Promise<void>((resolve) => {
+          releaseFirstRun = resolve;
+        });
+        const fullStream = (async function* () {
+          await Promise.race([waitForAbort, hold]);
+        })();
+        const textStream = (async function* () {
+          await Promise.race([waitForAbort, hold]);
+        })();
+        return {
+          textStream,
+          fullStream,
+          toolCalls: Promise.resolve([]),
+        };
+      })
+      .mockImplementationOnce((args: { abortSignal: AbortSignal }) => {
+        const waitForAbort = new Promise<void>((resolve) => {
+          args.abortSignal.addEventListener(
+            "abort",
+            () => {
+              secondRunAborted = true;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        const hold = new Promise<void>((resolve) => {
+          releaseSecondRun = resolve;
+        });
+        const fullStream = (async function* () {
+          await Promise.race([waitForAbort, hold]);
+        })();
+        const textStream = (async function* () {
+          await Promise.race([waitForAbort, hold]);
+        })();
+        return {
+          textStream,
+          fullStream,
+          toolCalls: Promise.resolve([]),
+        };
+      });
+
+    const firstRun = runAgent(tabId, "original run");
+    await flushAsyncWork(4);
+
+    const steeringRun = steerMessage(tabId, "urgent correction");
+    await flushAsyncWork(6);
+
+    stopAgent(tabId);
+    await flushAsyncWork(6);
+
+    expect(secondRunAborted).toBe(true);
+    expect(states[tabId].queuedMessages).toEqual([
+      { id: "queued-1", content: "stay queued", createdAtMs: 10 },
+    ]);
+    expect(states[tabId].queueState).toBe("paused");
+
+    releaseFirstRun?.();
+    releaseSecondRun?.();
+    await Promise.all([firstRun, steeringRun]);
   });
 
   it("stopRunningExecToolCall stops a running exec without aborting the whole agent", async () => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -45,6 +45,7 @@ import {
 } from "./approvals";
 import type {
   AttachedImage,
+  AgentQueueState,
   ConversationCard,
   SerializedConversationCard,
   AdvancedModelOptions,
@@ -52,6 +53,7 @@ import type {
   ApiToolCall,
   AssistantApiMessage,
   ChatMessage,
+  QueuedUserMessage,
   ToolResult,
   ToolCallDisplay,
   ToolApiMessage,
@@ -88,7 +90,15 @@ import { buildConversationCard, type CardAddInput } from "./tools/agentControl";
    Abort controller registry — one per running agent
 ───────────────────────────────────────────────────────────────────────────── */
 
-const controllers = new Map<string, AbortController>();
+type AgentAbortReason = "user_stop" | "steer" | "superseded";
+
+interface ActiveRun {
+  runId: string;
+  controller: AbortController;
+  abortReason: AgentAbortReason | null;
+}
+
+const activeRuns = new Map<string, ActiveRun>();
 const runCounters = new Map<string, number>();
 
 function nextRunId(tabId: string): string {
@@ -96,6 +106,24 @@ function nextRunId(tabId: string): string {
   runCounters.set(tabId, next);
   const iso = new Date().toISOString().replace(/[:.]/g, "-");
   return `run_${iso}_${String(next).padStart(4, "0")}`;
+}
+
+function hasActiveRun(tabId: string): boolean {
+  return activeRuns.has(tabId);
+}
+
+function isActiveRunOwner(tabId: string, activeRun: ActiveRun): boolean {
+  return activeRuns.get(tabId) === activeRun;
+}
+
+function clearActiveRun(tabId: string, activeRun: ActiveRun): void {
+  if (isActiveRunOwner(tabId, activeRun)) {
+    activeRuns.delete(tabId);
+  }
+}
+
+function isCurrentRunId(tabId: string, runId: string): boolean {
+  return activeRuns.get(tabId)?.runId === runId;
 }
 
 interface SystemPromptRuntimeContext {
@@ -509,14 +537,56 @@ function buildSystemPromptRuntimeContext(
   };
 }
 
-export function stopAgent(tabId: string): void {
+function normalizeQueueState(
+  queuedMessages: QueuedUserMessage[],
+  queueState: AgentQueueState,
+): AgentQueueState {
+  if (queuedMessages.length === 0) return "idle";
+  return queueState === "paused" ? "paused" : "draining";
+}
+
+function pauseQueueState(
+  queuedMessages: QueuedUserMessage[],
+  queueState: AgentQueueState,
+): AgentQueueState {
+  if (queuedMessages.length === 0) return "idle";
+  return queueState === "draining" || queueState === "paused"
+    ? "paused"
+    : "paused";
+}
+
+function setAgentErrorState(
+  tabId: string,
+  error: string,
+  errorDetails?: unknown,
+  errorAction: { type: "open-settings-section"; section: "providers"; label: string } | null = null,
+): void {
+  patchAgentState(tabId, (prev) => ({
+    ...prev,
+    status: "error",
+    error,
+    errorAction,
+    errorDetails: errorDetails ?? null,
+    streamingContent: null,
+    queueState: pauseQueueState(prev.queuedMessages, prev.queueState),
+  }));
+}
+
+function interruptActiveRun(
+  tabId: string,
+  reason: AgentAbortReason,
+  options: { pauseQueue: boolean },
+): void {
   const stoppedAtMs = Date.now();
   const runningExecIds = findRunningExecToolCallIds(tabId);
-  for (const runId of runningExecIds) {
-    void execAbort(runId);
+  for (const toolCallId of runningExecIds) {
+    void execAbort(toolCallId);
   }
-  controllers.get(tabId)?.abort();
-  controllers.delete(tabId);
+  const activeRun = activeRuns.get(tabId);
+  if (activeRun) {
+    activeRun.abortReason = reason;
+    activeRun.controller.abort();
+  }
 
   // Find incomplete tool calls and synthesize error results for them
   const incompleteToolCalls = findIncompleteToolCalls(tabId);
@@ -545,6 +615,9 @@ export function stopAgent(tabId: string): void {
     ...prev,
     status: "idle",
     streamingContent: null,
+    queueState: options.pauseQueue
+      ? pauseQueueState(prev.queuedMessages, prev.queueState)
+      : normalizeQueueState(prev.queuedMessages, prev.queueState),
     // Append synthesized tool results to apiMessages
     apiMessages:
       synthesizedToolMessages.length > 0
@@ -592,6 +665,93 @@ export function stopAgent(tabId: string): void {
     }),
   }));
   cancelAllApprovals(tabId);
+}
+
+async function maybeStartQueuedRun(tabId: string): Promise<void> {
+  const state = getAgentState(tabId);
+  if (state.queueState !== "draining") return;
+  if (hasActiveRun(tabId)) return;
+
+  const nextQueuedMessage = state.queuedMessages[0];
+  if (!nextQueuedMessage) {
+    patchAgentState(tabId, (prev) =>
+      prev.queueState === "draining" ? { ...prev, queueState: "idle" } : prev,
+    );
+    return;
+  }
+
+  await runAgentTurn(tabId, nextQueuedMessage.content, undefined, {
+    queuedMessageId: nextQueuedMessage.id,
+  });
+}
+
+export function queueMessage(tabId: string, userMessage: string): void {
+  const content = userMessage.trim();
+  if (!content) return;
+
+  patchAgentState(tabId, (prev) => ({
+    ...prev,
+    queuedMessages: [
+      ...prev.queuedMessages,
+      {
+        id: msgId(),
+        content,
+        createdAtMs: Date.now(),
+      },
+    ],
+    queueState: prev.queueState === "paused" ? "paused" : "draining",
+  }));
+
+  void maybeStartQueuedRun(tabId).catch(console.error);
+}
+
+export async function steerMessage(
+  tabId: string,
+  userMessage: string,
+  queuedMessageId?: string,
+): Promise<void> {
+  const content = userMessage.trim();
+  if (!content) return;
+
+  if (hasActiveRun(tabId)) {
+    interruptActiveRun(tabId, "steer", { pauseQueue: false });
+  }
+
+  await runAgentTurn(tabId, content, undefined, { queuedMessageId });
+}
+
+export function resumeQueue(tabId: string): void {
+  patchAgentState(tabId, (prev) => ({
+    ...prev,
+    queueState: prev.queuedMessages.length > 0 ? "draining" : "idle",
+  }));
+  void maybeStartQueuedRun(tabId).catch(console.error);
+}
+
+export function removeQueuedMessage(tabId: string, messageId: string): void {
+  patchAgentState(tabId, (prev) => {
+    const queuedMessages = prev.queuedMessages.filter(
+      (message) => message.id !== messageId,
+    );
+    return {
+      ...prev,
+      queuedMessages,
+      queueState:
+        queuedMessages.length === 0 ? "idle" : prev.queueState,
+    };
+  });
+}
+
+export function clearQueuedMessages(tabId: string): void {
+  patchAgentState(tabId, (prev) => ({
+    ...prev,
+    queuedMessages: [],
+    queueState: "idle",
+  }));
+}
+
+export function stopAgent(tabId: string): void {
+  interruptActiveRun(tabId, "user_stop", { pauseQueue: true });
 }
 
 /**
@@ -1614,6 +1774,7 @@ async function runSubagentLoop(
         const tcId = tc.id;
 
         function updateToolCallById(patch: Partial<ToolCallDisplay>): void {
+          if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
           patchAgentState(tabId, (prev) => ({
             ...prev,
             chatMessages: prev.chatMessages.map((m) =>
@@ -1824,6 +1985,11 @@ async function runSubagentLoop(
         return { tool_call_id: tcId, result: toolResult };
       }),
     );
+    if (signal.aborted || !isCurrentRunId(tabId, runId)) {
+      const abortError = new Error("Subagent run aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }
 
     // Append tool results to local API history.
     const toolApiMessages: ApiMessage[] = toolResults.map(
@@ -1939,6 +2105,30 @@ export async function retryAgent(tabId: string): Promise<void> {
   await runAgent(tabId, lastUserMessage, undefined, { skipUserChatAppend: true });
 }
 
+interface RunAgentTurnOptions {
+  queuedMessageId?: string;
+  skipUserChatAppend?: boolean;
+}
+
+function dequeueQueuedMessage(
+  tabId: string,
+  queuedMessageId: string | undefined,
+): void {
+  if (!queuedMessageId) return;
+
+  patchAgentState(tabId, (prev) => {
+    const queuedMessages = prev.queuedMessages.filter(
+      (message) => message.id !== queuedMessageId,
+    );
+    return queuedMessages.length === prev.queuedMessages.length
+      ? prev
+      : {
+          ...prev,
+          queuedMessages,
+        };
+  });
+}
+
 /**
  * Start (or continue) an agent conversation for a tab.
  * Multiple calls for different tabIds run concurrently.
@@ -1950,12 +2140,29 @@ export async function runAgent(
   attachments?: AttachedImage[],
   options?: { skipUserChatAppend?: boolean },
 ): Promise<void> {
-  // Cancel any in-flight run for this tab
-  stopAgent(tabId);
+  if (hasActiveRun(tabId)) {
+    interruptActiveRun(tabId, "superseded", { pauseQueue: false });
+  }
 
+  await runAgentTurn(tabId, userMessage, attachments, options);
+}
+
+async function runAgentTurn(
+  tabId: string,
+  userMessage: string,
+  attachments?: AttachedImage[],
+  options: RunAgentTurnOptions = {},
+): Promise<void> {
   const controller = new AbortController();
-  controllers.set(tabId, controller);
   const runId = nextRunId(tabId);
+  const activeRun: ActiveRun = {
+    runId,
+    controller,
+    abortReason: null,
+  };
+  activeRuns.set(tabId, activeRun);
+
+  let completedCleanly = false;
 
   // ── Trigger command detection ──────────────────────────────────────────────
   // If the message starts with a registered subagent trigger (e.g. "/plan …"),
@@ -1974,6 +2181,7 @@ export async function runAgent(
       timestamp: Date.now(),
       ...(attachments && attachments.length > 0 ? { attachments } : {}),
     };
+    dequeueQueuedMessage(tabId, options.queuedMessageId);
     patchAgentState(tabId, (prev) => ({
       ...prev,
       status: "working",
@@ -1998,37 +2206,34 @@ export async function runAgent(
         debugEnabled: triggerDebug,
       });
       if (!triggerResult.ok) {
-        patchAgentState(tabId, {
-          status: "error",
-          error: triggerResult.error.message,
-          errorAction: null,
-          errorDetails: triggerResult.error,
-          streamingContent: null,
-        });
+        setAgentErrorState(
+          tabId,
+          triggerResult.error.message,
+          triggerResult.error,
+        );
+      } else {
+        completedCleanly = true;
       }
     } catch (err) {
-      if ((err as Error).name !== "AbortError") {
-        const msg = err instanceof Error ? err.message : String(err);
-        patchAgentState(tabId, {
-          status: "error",
-          error: msg,
-          errorAction: null,
-          errorDetails: serializeError(err),
-          streamingContent: null,
-        });
-        updateLastChatMessage(tabId, (m) =>
-          m.role === "assistant" ? { ...m, streaming: false } : m,
-        );
-        controllers.delete(tabId);
-        return;
-      }
-    } finally {
-      patchAgentState(tabId, (prev) =>
-        prev.status !== "error"
-          ? { ...prev, status: "idle", streamingContent: null }
-          : prev,
+      if ((err as Error).name === "AbortError") return;
+      const msg = err instanceof Error ? err.message : String(err);
+      setAgentErrorState(tabId, msg, serializeError(err));
+      updateLastChatMessage(tabId, (m) =>
+        m.role === "assistant" ? { ...m, streaming: false } : m,
       );
-      controllers.delete(tabId);
+      return;
+    } finally {
+      clearActiveRun(tabId, activeRun);
+      if (activeRun.abortReason !== null) return;
+      if (completedCleanly) {
+        patchAgentState(tabId, (prev) => ({
+          ...prev,
+          status: "idle",
+          streamingContent: null,
+          queueState: normalizeQueueState(prev.queuedMessages, prev.queueState),
+        }));
+        void maybeStartQueuedRun(tabId).catch(console.error);
+      }
     }
     return;
   }
@@ -2045,20 +2250,20 @@ export async function runAgent(
   );
 
   if (!modelEntry || !provider) {
-    patchAgentState(tabId, {
-      status: "error",
-      error: "Unknown model. Please choose a model from the New Session list.",
-      errorAction: null,
-    });
+    setAgentErrorState(
+      tabId,
+      "Unknown model. Please choose a model from the New Session list.",
+    );
+    clearActiveRun(tabId, activeRun);
     return;
   }
 
   if (!modelEntry.sdk_id.trim()) {
-    patchAgentState(tabId, {
-      status: "error",
-      error: `Selected model is missing sdk_id. Please update src/agent/models.catalog.json for ${modelEntry.id}.`,
-      errorAction: null,
-    });
+    setAgentErrorState(
+      tabId,
+      `Selected model is missing sdk_id. Please update src/agent/models.catalog.json for ${modelEntry.id}.`,
+    );
+    clearActiveRun(tabId, activeRun);
     return;
   }
 
@@ -2066,39 +2271,41 @@ export async function runAgent(
     (p) => p.id === modelEntry.providerId,
   );
   if (!providerInstance) {
-    patchAgentState(tabId, {
-      status: "error",
-      error: `Model "${modelEntry.id}" references an unknown provider.`,
-      errorAction: null,
-    });
+    setAgentErrorState(
+      tabId,
+      `Model "${modelEntry.id}" references an unknown provider.`,
+    );
+    clearActiveRun(tabId, activeRun);
     return;
   }
 
   if (provider === "openai" && !providerInstance.apiKey) {
-    patchAgentState(tabId, {
-      status: "error",
-      error:
-        "No OpenAI API key. Please open the settings to enter your OpenAI API key.",
-      errorAction: {
+    setAgentErrorState(
+      tabId,
+      "No OpenAI API key. Please open the settings to enter your OpenAI API key.",
+      null,
+      {
         type: "open-settings-section",
         section: "providers",
         label: "Open AI Providers",
       },
-    });
+    );
+    clearActiveRun(tabId, activeRun);
     return;
   }
 
   if (provider === "anthropic" && !providerInstance.apiKey) {
-    patchAgentState(tabId, {
-      status: "error",
-      error:
-        "No Claude API key. Please open the settings to enter your Claude (Anthropic) API key.",
-      errorAction: {
+    setAgentErrorState(
+      tabId,
+      "No Claude API key. Please open the settings to enter your Claude (Anthropic) API key.",
+      null,
+      {
         type: "open-settings-section",
         section: "providers",
         label: "Open AI Providers",
       },
-    });
+    );
+    clearActiveRun(tabId, activeRun);
     return;
   }
 
@@ -2110,6 +2317,7 @@ export async function runAgent(
     timestamp: Date.now(),
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
+  dequeueQueuedMessage(tabId, options.queuedMessageId);
 
   // Detect git repo on first turn so the system prompt can include the GIT ISOLATION section.
   let isGitRepo = false;
@@ -2194,21 +2402,31 @@ export async function runAgent(
       debugEnabled,
       runId,
     );
+    completedCleanly = !controller.signal.aborted;
   } catch (err) {
-    if ((err as Error).name === "AbortError") return; // user cancelled
+    if ((err as Error).name === "AbortError") return;
     const msg = err instanceof Error ? err.message : String(err);
-    patchAgentState(tabId, {
-      status: "error",
-      error: msg,
-      errorAction: null,
-      errorDetails: serializeError(err),
-      streamingContent: null,
-    });
+    setAgentErrorState(tabId, msg, serializeError(err));
     updateLastChatMessage(tabId, (m) =>
       m.role === "assistant" ? { ...m, streaming: false } : m,
     );
   } finally {
-    controllers.delete(tabId);
+    clearActiveRun(tabId, activeRun);
+    if (activeRun.abortReason !== null) return;
+    if (!completedCleanly) return;
+    if (getAgentState(tabId).status === "error") return;
+
+    patchAgentState(tabId, (prev) =>
+      prev.status === "error"
+        ? prev
+        : {
+            ...prev,
+            status: "idle",
+            streamingContent: null,
+            queueState: normalizeQueueState(prev.queuedMessages, prev.queueState),
+          },
+    );
+    void maybeStartQueuedRun(tabId).catch(console.error);
   }
 }
 
@@ -2519,6 +2737,7 @@ async function agentLoop(
 
         /** Update this specific tool call (by id) regardless of which message hosts it. */
         function updateToolCallById(patch: Partial<ToolCallDisplay>): void {
+          if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
           patchAgentState(tabId, (prev) => ({
             ...prev,
             chatMessages: prev.chatMessages.map((m) =>
@@ -2780,6 +2999,7 @@ async function agentLoop(
         return { tool_call_id: tcId, result };
       }),
     );
+    if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
 
     // Append tool result messages to API history
     const toolApiMessages: ApiMessage[] = toolResults.map(
@@ -2803,10 +3023,7 @@ async function agentLoop(
   }
 
   // Safety: hit iteration cap
-  patchAgentState(tabId, {
-    status: "done",
-    error: "Reached maximum iteration limit (50 turns)",
-  });
+  setAgentErrorState(tabId, "Reached maximum iteration limit (50 turns)");
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────

--- a/src/agent/sessionRestore.test.ts
+++ b/src/agent/sessionRestore.test.ts
@@ -45,6 +45,10 @@ function makeSession(
     apiMessages: JSON.stringify([{ role: "assistant", content: "world" }]),
     todos: JSON.stringify([{ id: "todo-1", text: "ship", status: "todo" }]),
     reviewEdits: JSON.stringify([{ filePath: "src/App.tsx" }]),
+    queuedMessages: JSON.stringify([
+      { id: "queue-1", content: "follow up after restart", createdAtMs: 123 },
+    ]),
+    queueState: "draining",
     archived: true,
     createdAt: 1,
     updatedAt: 2,
@@ -108,6 +112,10 @@ describe("sessionRestore", () => {
     expect(state.apiMessages).toEqual([{ role: "assistant", content: "world" }]);
     expect(state.todos).toEqual([{ id: "todo-1", text: "ship", status: "todo" }]);
     expect(state.reviewEdits).toEqual([{ filePath: "src/App.tsx" }]);
+    expect(state.queuedMessages).toEqual([
+      { id: "queue-1", content: "follow up after restart", createdAtMs: 123 },
+    ]);
+    expect(state.queueState).toBe("paused");
     expect(state.showDebug).toBe(true);
   });
 

--- a/src/agent/sessionRestore.ts
+++ b/src/agent/sessionRestore.ts
@@ -5,7 +5,11 @@ import {
   restoreSession,
   type PersistedSession,
 } from "./persistence";
-import type { AdvancedModelOptions } from "./types";
+import type {
+  AdvancedModelOptions,
+  AgentQueueState,
+  QueuedUserMessage,
+} from "./types";
 
 interface HydratePersistedSessionOptions {
   restoreError?: string | null;
@@ -45,11 +49,37 @@ function buildTabFromSession(session: PersistedSession): Tab {
   };
 }
 
+function parseQueuedMessages(queuedMessages: string): QueuedUserMessage[] {
+  try {
+    const parsed = queuedMessages
+      ? (JSON.parse(queuedMessages) as QueuedUserMessage[])
+      : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseQueueState(
+  queueState: string,
+  queuedMessages: QueuedUserMessage[],
+): AgentQueueState {
+  if (queuedMessages.length === 0) return "idle";
+  if (queueState === "paused") return "paused";
+  if (queueState === "draining" && queuedMessages.length > 0) {
+    // Restored sessions must never auto-resume queued follow-ups.
+    return "paused";
+  }
+  return "paused";
+}
+
 export function hydratePersistedSession(
   session: PersistedSession,
   options: HydratePersistedSessionOptions = {},
 ): void {
   const restoreError = options.restoreError ?? null;
+  const queuedMessages = parseQueuedMessages(session.queuedMessages);
+  const queueState = parseQueueState(session.queueState, queuedMessages);
 
   patchAgentState(session.id, {
     status: restoreError ? "error" : "idle",
@@ -71,6 +101,8 @@ export function hydratePersistedSession(
     apiMessages: JSON.parse(session.apiMessages),
     todos: JSON.parse(session.todos),
     reviewEdits: JSON.parse(session.reviewEdits ?? "[]"),
+    queuedMessages,
+    queueState,
     streamingContent: null,
     error: restoreError,
     showDebug: session.showDebug ?? false,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -230,6 +230,12 @@ export interface ChatMessage {
   cards?: ConversationCard[];
 }
 
+export interface QueuedUserMessage {
+  id: string;
+  content: string;
+  createdAtMs: number;
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    Advanced model / provider options (set at session creation time)
 ─────────────────────────────────────────────────────────────────────────── */
@@ -279,6 +285,7 @@ export interface AgentConfig {
 
 export type AgentStatus = "idle" | "thinking" | "working" | "done" | "error";
 export type AutoApproveCommandsMode = "no" | "agent" | "yes";
+export type AgentQueueState = "idle" | "draining" | "paused";
 export type AgentErrorAction = {
   type: "open-settings-section";
   section: "providers";
@@ -316,6 +323,10 @@ export interface AgentState {
   autoApproveEdits: boolean;
   /** Auto-approve commands for this tab */
   autoApproveCommands: AutoApproveCommandsMode;
+  /** Follow-up user notes queued while the agent is busy. */
+  queuedMessages: QueuedUserMessage[];
+  /** Whether queued follow-ups will auto-drain, stay paused, or are empty. */
+  queueState: AgentQueueState;
   /** Controls debug-only UI surfaces for this tab */
   showDebug?: boolean;
 }

--- a/src/agent/useAgents.ts
+++ b/src/agent/useAgents.ts
@@ -27,11 +27,18 @@ import {
   agentReviewEditsAtomFamily,
   agentAutoApproveEditsAtomFamily,
   agentAutoApproveCommandsAtomFamily,
+  agentQueuedMessagesAtomFamily,
+  agentQueueStateAtomFamily,
   agentShowDebugAtomFamily,
   patchAgentState,
 } from "./atoms";
 import {
   runAgent,
+  queueMessage as _queueMessage,
+  steerMessage as _steerMessage,
+  resumeQueue as _resumeQueue,
+  removeQueuedMessage as _removeQueuedMessage,
+  clearQueuedMessages as _clearQueuedMessages,
   retryAgent as _retryAgent,
   stopAgent as _stopAgent,
   stopRunningExecToolCall as _stopRunningExecToolCall,
@@ -146,6 +153,14 @@ export function useAgentAutoApproveCommands(tabId: string) {
   return useAtomValue(agentAutoApproveCommandsAtomFamily(tabId));
 }
 
+export function useAgentQueuedMessages(tabId: string) {
+  return useAtomValue(agentQueuedMessagesAtomFamily(tabId));
+}
+
+export function useAgentQueueState(tabId: string) {
+  return useAtomValue(agentQueueStateAtomFamily(tabId));
+}
+
 export function useAgentShowDebug(tabId: string) {
   return useAtomValue(agentShowDebugAtomFamily(tabId));
 }
@@ -175,6 +190,36 @@ export function useStopAgent() {
 export function useRetryAgent() {
   return useCallback((tabId: string) => {
     _retryAgent(tabId).catch(console.error);
+  }, []);
+}
+
+export function useQueueMessage() {
+  return useCallback((tabId: string, message: string) => {
+    _queueMessage(tabId, message);
+  }, []);
+}
+
+export function useSteerMessage() {
+  return useCallback((tabId: string, message: string, queuedMessageId?: string) => {
+    _steerMessage(tabId, message, queuedMessageId).catch(console.error);
+  }, []);
+}
+
+export function useResumeQueue() {
+  return useCallback((tabId: string) => {
+    _resumeQueue(tabId);
+  }, []);
+}
+
+export function useRemoveQueuedMessage() {
+  return useCallback((tabId: string, messageId: string) => {
+    _removeQueuedMessage(tabId, messageId);
+  }, []);
+}
+
+export function useClearQueuedMessages() {
+  return useCallback((tabId: string) => {
+    _clearQueuedMessages(tabId);
   }, []);
 }
 
@@ -214,6 +259,8 @@ export function useResetAgent() {
       reviewEdits: [],
       autoApproveEdits: false,
       autoApproveCommands: "no",
+      queuedMessages: [],
+      queueState: "idle",
       showDebug: false,
     }));
   }, []);
@@ -268,8 +315,15 @@ export function useAgent(tabId: string) {
   const tabTitle = useAgentTabTitle(tabId);
   const autoApproveEdits = useAgentAutoApproveEdits(tabId);
   const autoApproveCommands = useAgentAutoApproveCommands(tabId);
+  const queuedMessages = useAgentQueuedMessages(tabId);
+  const queueState = useAgentQueueState(tabId);
   const showDebug = useAgentShowDebug(tabId);
   const sendMessage = useSendMessage();
+  const queueMessage = useQueueMessage();
+  const steerMessage = useSteerMessage();
+  const resumeQueue = useResumeQueue();
+  const removeQueuedMessage = useRemoveQueuedMessage();
+  const clearQueuedMessages = useClearQueuedMessages();
   const stopAgent = useStopAgent();
   const setConfig = useSetAgentConfig();
   const resetAgent = useResetAgent();
@@ -292,11 +346,31 @@ export function useAgent(tabId: string) {
     contextWindowKb,
     autoApproveEdits,
     autoApproveCommands,
+    queuedMessages,
+    queueState,
     showDebug,
     sendMessage: useCallback(
       (msg: string, attachments?: AttachedImage[]) =>
         sendMessage(tabId, msg, attachments),
       [tabId, sendMessage],
+    ),
+    queueMessage: useCallback(
+      (msg: string) => queueMessage(tabId, msg),
+      [tabId, queueMessage],
+    ),
+    steerMessage: useCallback(
+      (msg: string, queuedMessageId?: string) =>
+        steerMessage(tabId, msg, queuedMessageId),
+      [tabId, steerMessage],
+    ),
+    resumeQueue: useCallback(() => resumeQueue(tabId), [tabId, resumeQueue]),
+    removeQueuedMessage: useCallback(
+      (messageId: string) => removeQueuedMessage(tabId, messageId),
+      [tabId, removeQueuedMessage],
+    ),
+    clearQueuedMessages: useCallback(
+      () => clearQueuedMessages(tabId),
+      [tabId, clearQueuedMessages],
     ),
     stop: useCallback(() => stopAgent(tabId), [tabId, stopAgent]),
     setConfig: useCallback(

--- a/src/components/AgentNotificationManager.test.tsx
+++ b/src/components/AgentNotificationManager.test.tsx
@@ -38,6 +38,8 @@ function makeSession(id: string, label: string): PersistedSession {
     apiMessages: "[]",
     todos: "[]",
     reviewEdits: "[]",
+    queuedMessages: "[]",
+    queueState: "idle",
     archived: false,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/BusyComposerTray.tsx
+++ b/src/components/BusyComposerTray.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui";
+import type { AgentQueueState } from "@/agent/types";
+
+export interface BusyComposerQueueItem {
+  id: string;
+  content: string;
+}
+
+interface BusyComposerTrayProps {
+  queuedItems: BusyComposerQueueItem[];
+  queueState: AgentQueueState;
+  onSendQueuedNow?: (id: string) => void;
+  onResumeQueue?: () => void;
+  onClearQueuedItems?: () => void;
+  onRemoveQueuedItem?: (id: string) => void;
+}
+
+interface BusyComposerRowProps {
+  label: string;
+  preview: string;
+  actions: ReactNode;
+}
+
+function BusyComposerRow({ label, preview, actions }: BusyComposerRowProps) {
+  return (
+    <div className="busy-composer-row">
+      <div className="busy-composer-row__label-wrap">
+        <span className="busy-composer-row__label">{label}</span>
+      </div>
+
+      <div className="busy-composer-row__preview-wrap">
+        <span className="busy-composer-row__preview">{preview}</span>
+      </div>
+
+      <div className="busy-composer-row__actions">{actions}</div>
+    </div>
+  );
+}
+
+export default function BusyComposerTray({
+  queuedItems,
+  queueState,
+  onSendQueuedNow,
+  onResumeQueue,
+  onClearQueuedItems,
+  onRemoveQueuedItem,
+}: BusyComposerTrayProps) {
+  const showRows = queuedItems.length > 0;
+
+  if (!showRows) return null;
+
+  return (
+    <div className="busy-composer-strip">
+      {queueState === "paused" && queuedItems.length > 0 ? (
+        <BusyComposerRow
+          label="Paused"
+          preview={
+            queuedItems.length === 1
+              ? "1 queued note is waiting."
+              : `${queuedItems.length} queued notes are waiting.`
+          }
+          actions={
+            <>
+              {onResumeQueue ? (
+                <Button variant="secondary" size="xxs" onClick={onResumeQueue}>
+                  Resume
+                </Button>
+              ) : null}
+              {onClearQueuedItems ? (
+                <Button variant="ghost" size="xxs" onClick={onClearQueuedItems}>
+                  Clear
+                </Button>
+              ) : null}
+            </>
+          }
+        />
+      ) : null}
+
+      {queuedItems.map((item, index) => (
+        <BusyComposerRow
+          key={item.id}
+          label={`Queued ${index + 1}`}
+          preview={item.content}
+          actions={
+            <>
+              {onSendQueuedNow ? (
+                <Button
+                  variant="secondary"
+                  size="xxs"
+                  onClick={() => onSendQueuedNow(item.id)}
+                >
+                  Send now
+                </Button>
+              ) : null}
+              {onRemoveQueuedItem ? (
+                <button
+                  type="button"
+                  className="busy-composer-row__dismiss"
+                  aria-label={`Remove queued note ${index + 1}`}
+                  onClick={() => onRemoveQueuedItem(item.id)}
+                >
+                  <span className="material-symbols-outlined text-base" aria-hidden="true">
+                    close
+                  </span>
+                </button>
+              ) : null}
+            </>
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/artifact-pane/DebugPane.test.tsx
+++ b/src/components/artifact-pane/DebugPane.test.tsx
@@ -146,6 +146,8 @@ function buildFixture() {
     reviewEdits: [],
     autoApproveEdits: false,
     autoApproveCommands: "no",
+    queuedMessages: [],
+    queueState: "idle",
     showDebug: true,
   };
 

--- a/src/styles/components-showcase.css
+++ b/src/styles/components-showcase.css
@@ -196,6 +196,28 @@
   gap: 8px;
 }
 
+.ds-composer-preview {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border-top: none;
+  background: transparent;
+}
+
+.ds-composer-draft {
+  min-height: 24px;
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ds-composer-draft--muted {
+  color: var(--color-muted);
+}
+
 .ds-patch-panel {
   padding: 10px;
 }

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -91,6 +91,9 @@
     border-color var(--t-base),
     background var(--t-base);
 }
+.chat-input-shell--busy {
+  padding-right: 46px;
+}
 .chat-input-shell:focus-within {
   border-color: color-mix(in srgb, var(--color-primary) 35%, transparent);
   background: color-mix(in srgb, var(--color-subtle) 50%, transparent);
@@ -143,6 +146,103 @@
 .chat-input-actions button:hover {
   color: var(--color-primary);
   background: color-mix(in srgb, var(--color-subtle) 60%, transparent);
+}
+
+.busy-composer-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 2px 10px;
+}
+
+.busy-composer-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 32px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-inset) 92%, transparent);
+}
+
+.busy-composer-row__label-wrap {
+  display: flex;
+  align-items: center;
+  min-width: 64px;
+  flex-shrink: 0;
+}
+
+.busy-composer-row__label {
+  display: inline-block;
+  white-space: nowrap;
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.busy-composer-row__preview-wrap {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  direction: rtl;
+  text-align: left;
+  mask-image: linear-gradient(to right, transparent 0%, #000 18%, #000 100%);
+}
+
+.busy-composer-row__preview {
+  display: inline-block;
+  white-space: nowrap;
+  direction: ltr;
+  unicode-bidi: plaintext;
+  font-size: var(--text-xxs);
+  color: color-mix(in srgb, var(--color-text) 84%, transparent);
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 18%,
+    #000 100%
+  );
+}
+
+.busy-composer-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.busy-composer-row__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-muted);
+  transition:
+    color var(--t-fast),
+    background var(--t-fast);
+}
+
+.busy-composer-row__dismiss:hover {
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-subtle) 70%, transparent);
+}
+
+.busy-composer-strip__status {
+  padding: 0 10px;
+  font-size: var(--text-xxs);
+  color: var(--color-muted);
 }
 
 .chat-voice-btn--recording {


### PR DESCRIPTION
## Summary
- add real queued follow-up state, steering actions, and safe active-run ownership in the agent runtime
- persist queued messages and queue state across session saves, while restoring pending queues in a paused state
- keep queued follow-ups in the fixed composer controls area, only showing submitted items and paused queue controls

## Testing
- npm run test -- --run src/WorkspacePage.test.tsx src/agent/runner.test.ts src/agent/persistence.test.ts src/agent/sessionRestore.test.ts src/components/AgentNotificationManager.test.tsx src/components/artifact-pane/DebugPane.test.tsx
- npm run typecheck
- npx eslint src/WorkspacePage.tsx src/components/BusyComposerTray.tsx src/ThemePreview.tsx src/agent/runner.ts src/agent/useAgents.ts src/agent/persistence.ts src/agent/sessionRestore.ts src/App.tsx src/WorkspacePage.test.tsx src/agent/runner.test.ts src/agent/persistence.test.ts src/agent/sessionRestore.test.ts src/components/AgentNotificationManager.test.tsx src/components/artifact-pane/DebugPane.test.tsx
- cargo test test_db_session_lifecycle

Fixes #72