### PR TITLE
feat: add communication profiles for steering agent behavior

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -56,6 +56,7 @@ pub struct PersistedSession {
     pub show_debug: bool,
     /// JSON-serialised AdvancedModelOptions (empty string / '{}' = use defaults)
     pub advanced_options: String,
+    pub communication_profile: String,
 }
 
 /* ── Artifact models ─────────────────────────────────────────────────────── */
@@ -683,7 +684,8 @@ pub fn init_db() -> Result<Connection, String> {
             created_at       INTEGER NOT NULL,
             updated_at       INTEGER NOT NULL,
             show_debug          INTEGER NOT NULL DEFAULT 0,
-            advanced_options    TEXT    NOT NULL DEFAULT '{}'
+            advanced_options    TEXT    NOT NULL DEFAULT '{}',
+            communication_profile TEXT  NOT NULL DEFAULT 'pragmatic'
         );
     ",
     )
@@ -704,6 +706,8 @@ pub fn init_db() -> Result<Connection, String> {
         .execute_batch("ALTER TABLE sessions ADD COLUMN queued_messages TEXT NOT NULL DEFAULT '[]';");
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN queue_state TEXT NOT NULL DEFAULT 'idle';");
+    let _ = conn
+        .execute_batch("ALTER TABLE sessions ADD COLUMN communication_profile TEXT NOT NULL DEFAULT 'pragmatic';");
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS artifact_blobs (
@@ -792,7 +796,7 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
                 queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug,
-                advanced_options
+                advanced_options, communication_profile
          FROM sessions
          WHERE archived = 0
          ORDER BY updated_at DESC",
@@ -826,6 +830,7 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
                     worktree_declined: row.get::<_, i64>(21)? != 0,
                     show_debug: row.get::<_, i64>(22)? != 0,
                     advanced_options: row.get::<_, String>(23).unwrap_or_default(),
+                    communication_profile: row.get::<_, String>(24).unwrap_or_else(|_| "pragmatic".to_string()),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -883,8 +888,8 @@ pub fn db_upsert_session(
             chat_messages, api_messages, todos, review_edits,
             queued_messages, queue_state,
             archived, created_at, updated_at,
-            worktree_path, worktree_branch, worktree_declined, show_debug, advanced_options
-         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24)
+            worktree_path, worktree_branch, worktree_declined, show_debug, advanced_options, communication_profile
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25)
          ON CONFLICT(id) DO UPDATE SET
             label             = excluded.label,
             icon              = excluded.icon,
@@ -907,6 +912,7 @@ pub fn db_upsert_session(
             worktree_declined = excluded.worktree_declined,
             show_debug        = excluded.show_debug,
             advanced_options  = excluded.advanced_options,
+            communication_profile = excluded.communication_profile,
             updated_at        = ?19",
             rusqlite::params![
                 session.id,
@@ -933,6 +939,7 @@ pub fn db_upsert_session(
                 session.worktree_declined as i64,
                 session.show_debug as i64,
                 session.advanced_options,
+                session.communication_profile,
             ],
         )
         .map_err(|e| e.to_string())?;
@@ -1010,7 +1017,7 @@ pub fn db_load_archived_sessions(
                 queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug,
-                advanced_options
+                advanced_options, communication_profile
          FROM sessions
          WHERE archived = 1
          ORDER BY updated_at DESC",
@@ -1044,6 +1051,7 @@ pub fn db_load_archived_sessions(
                     worktree_declined: row.get::<_, i64>(21)? != 0,
                     show_debug: row.get::<_, i64>(22)? != 0,
                     advanced_options: row.get::<_, String>(23).unwrap_or_default(),
+                    communication_profile: row.get::<_, String>(24).unwrap_or_else(|_| "pragmatic".to_string()),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -1634,6 +1642,84 @@ pub fn providers_save(providers: Vec<ProviderRecord>) -> Result<(), String> {
     Ok(())
 }
 
+/* ── Communication Profiles (disk-backed) ────────────────────────────────── */
+
+fn profiles_config_path() -> Result<PathBuf, String> {
+    Ok(app_store_root()?.join("config").join("profiles.json"))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunicationProfileRecord {
+    pub id: String,
+    pub name: String,
+    pub prompt_snippet: String,
+}
+
+#[tauri::command]
+pub fn profiles_load() -> Result<Vec<CommunicationProfileRecord>, String> {
+    tool_log("profiles_load", "start", json!({}));
+    let path = profiles_config_path()?;
+    if !path.exists() {
+        let default_profiles = vec![
+            CommunicationProfileRecord {
+                id: "pragmatic".to_string(),
+                name: "Pragmatic".to_string(),
+                prompt_snippet: "You are a pragmatic, highly competent pair programming assistant. Focus on correctness, conciseness, and delivering working code efficiently. Avoid unnecessary pleasantries and jump straight to the technical solution.".to_string(),
+            },
+            CommunicationProfileRecord {
+                id: "friendly".to_string(),
+                name: "Friendly".to_string(),
+                prompt_snippet: "You are a friendly, encouraging pair programming assistant. Be supportive and use an approachable tone. Take time to explain your thought process clearly and ensure the user feels comfortable asking questions.".to_string(),
+            },
+            CommunicationProfileRecord {
+                id: "kevin".to_string(),
+                name: "Kevin Malone".to_string(),
+                prompt_snippet: "You speak like Kevin Malone from The Office. Why waste time say lot word when few word do trick? Keep reply very short. but coherent. it okay to make mistake if still true and correct. no bs. fast.".to_string(),
+            },
+        ];
+        // We will do a full population of the snippets in the next step
+        tool_log("profiles_load", "ok", json!({ "count": default_profiles.len(), "reason": "defaults_created" }));
+        
+        let _ = profiles_save(default_profiles.clone());
+        
+        return Ok(default_profiles);
+    }
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("INTERNAL: cannot read profiles: {}", e))?;
+    let records: Vec<CommunicationProfileRecord> = serde_json::from_str(&raw)
+        .map_err(|e| format!("INTERNAL: cannot parse profiles: {}", e))?;
+    tool_log("profiles_load", "ok", json!({ "count": records.len() }));
+    Ok(records)
+}
+
+#[tauri::command]
+pub fn profiles_save(profiles: Vec<CommunicationProfileRecord>) -> Result<(), String> {
+    tool_log("profiles_save", "start", json!({ "count": profiles.len() }));
+    let path = profiles_config_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("INTERNAL: cannot create config dir: {}", e))?;
+    }
+    let raw = serde_json::to_string_pretty(&profiles)
+        .map_err(|e| format!("INTERNAL: cannot serialise profiles: {}", e))?;
+    let tmp = path.with_extension(format!("json.tmp-{}", now_ms()));
+    fs::write(&tmp, raw.as_bytes())
+        .map_err(|e| format!("INTERNAL: cannot write profiles tmp: {}", e))?;
+    match fs::rename(&tmp, &path) {
+        Ok(()) => {}
+        Err(e) => {
+            if path.exists() {
+                let _ = fs::remove_file(&tmp);
+            } else {
+                return Err(format!("INTERNAL: cannot rename profiles file: {}", e));
+            }
+        }
+    }
+    tool_log("profiles_save", "ok", json!({ "count": profiles.len() }));
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1779,7 +1865,8 @@ mod tests {
                 worktree_branch  TEXT    NOT NULL DEFAULT '',
                 worktree_declined INTEGER NOT NULL DEFAULT 0,
                 show_debug       INTEGER NOT NULL DEFAULT 0,
-                advanced_options TEXT    NOT NULL DEFAULT '{}'
+                advanced_options TEXT    NOT NULL DEFAULT '{}',
+                communication_profile TEXT NOT NULL DEFAULT 'pragmatic'
             );
         ",
         )
@@ -1822,6 +1909,7 @@ mod tests {
             worktree_declined: false,
             show_debug: false,
             advanced_options: "{}".to_string(),
+            communication_profile: "pragmatic".to_string(),
         };
 
         db.execute(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,8 @@ pub fn run() {
             db::db_artifact_list,
             db::providers_load,
             db::providers_save,
+            db::profiles_load,
+            db::profiles_save,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
   themeNameAtom,
   agentAtomFamily,
 } from "@/agent/atoms";
-import { loadProviders, providersAtom } from "@/agent/db";
+import { loadProviders, providersAtom, loadProfiles, profilesAtom } from "@/agent/db";
 import { hydratePersistedSession } from "@/agent/sessionRestore";
 import WorkspacePage from "@/WorkspacePage";
 import SettingsPage from "@/components/settings/SettingsPage";
@@ -171,10 +171,11 @@ export default function App() {
     // Prime provider env keys at startup so settings opens without waiting on backend reads.
     void preloadEnvProviderKeys();
 
-    Promise.all([loadSessions(), loadProviders()]).then(
-      ([sessions, providers]) => {
-        // Load providers into global store early so useModels works instantly on mount
+    Promise.all([loadSessions(), loadProviders(), loadProfiles()]).then(
+      ([sessions, providers, profiles]) => {
+        // Load providers and profiles into global store early
         jotaiStore.set(providersAtom, providers);
+        jotaiStore.set(profilesAtom, profiles);
 
         // Hydrate Jotai atoms before first render of agent components
         for (const s of sessions) {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -524,8 +524,8 @@ export default function WorkspacePage() {
   if (isNewSession) {
     return (
       <NewSession
-        onSubmit={(message, cwd, model, contextLength, advancedOptions) => {
-          agent.setConfig({ cwd, model, contextLength, advancedOptions });
+        onSubmit={(message, cwd, model, contextLength, advancedOptions, communicationProfile) => {
+          agent.setConfig({ cwd, model, contextLength, advancedOptions, communicationProfile });
           // Rename tab to folder basename
           const folder =
             (cwd.split("/").filter(Boolean).pop() ?? cwd) || "New Tab";
@@ -961,14 +961,14 @@ export default function WorkspacePage() {
         />
       )}
 
-      {/* Model picker modal */}
       {modelPickerOpen && (
         <ModelPickerModal
           models={models}
           currentModelId={agent.config.model ?? ""}
-          onSelect={(id) => {
+          currentProfile={agent.config.communicationProfile}
+          onSelect={(id, profile) => {
             if (!isAgentBusy) {
-              agent.setConfig({ model: id });
+              agent.setConfig({ model: id, communicationProfile: profile });
             }
             setModelPickerOpen(false);
           }}

--- a/src/agent/atoms.ts
+++ b/src/agent/atoms.ts
@@ -24,6 +24,14 @@ export const themeModeAtom = atomWithStorage<"dark" | "light">(
   "dark",
 );
 
+/** Global fallback communication profile */
+export const globalCommunicationProfileAtom = atomWithStorage<string>(
+  "rakh.communication-profile",
+  "pragmatic",
+);
+
+
+
 /** Specific theme name applied over the mode — persisted in localStorage */
 const themeNameStorage = {
   getItem(key: string, initialValue: ThemeName): ThemeName {

--- a/src/agent/db.ts
+++ b/src/agent/db.ts
@@ -27,3 +27,27 @@ export async function deleteProvider(id: string): Promise<void> {
 }
 
 export const providersAtom = atom<ProviderInstance[]>([]);
+
+export interface CommunicationProfileRecord {
+  id: string;
+  name: string;
+  promptSnippet: string;
+}
+
+export async function loadProfiles(): Promise<CommunicationProfileRecord[]> {
+  return invoke<CommunicationProfileRecord[]>("profiles_load");
+}
+
+export async function saveProfile(profile: CommunicationProfileRecord): Promise<void> {
+  const current = await loadProfiles();
+  const updated = [...current.filter((p) => p.id !== profile.id), profile];
+  await invoke("profiles_save", { profiles: updated });
+}
+
+export async function deleteProfile(id: string): Promise<void> {
+  const current = await loadProfiles();
+  const updated = current.filter((p) => p.id !== id);
+  await invoke("profiles_save", { profiles: updated });
+}
+
+export const profilesAtom = atom<CommunicationProfileRecord[]>([]);

--- a/src/agent/persistence.test.ts
+++ b/src/agent/persistence.test.ts
@@ -336,6 +336,7 @@ describe("persistence", () => {
       worktreeBranch: "",
       worktreeDeclined: false,
       showDebug: false,
+      communicationProfile: "pragmatic",
       advancedOptions: "{}",
     });
     await deleteSession("s-del");

--- a/src/agent/persistence.ts
+++ b/src/agent/persistence.ts
@@ -65,6 +65,7 @@ export interface PersistedSession {
   showDebug: boolean;
   /** JSON string — AdvancedModelOptions (empty string / '{}' = use defaults) */
   advancedOptions: string;
+  communicationProfile: string;
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -129,6 +130,7 @@ export function buildPersistedSession(
     advancedOptions: state.config.advancedOptions
       ? JSON.stringify(state.config.advancedOptions)
       : "{}",
+    communicationProfile: state.config.communicationProfile || "global",
     // created_at is only used on the initial INSERT; the DB preserves the
     // original value on subsequent upserts (not included in ON CONFLICT SET).
     createdAt: now,

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -41,6 +41,8 @@ type MockAgentState = {
 const {
   states,
   providersAtomMock,
+  globalCommunicationProfileAtomMock,
+  profilesAtomMock,
   jotaiStoreMock,
   dispatchToolMock,
   validateToolMock,
@@ -58,6 +60,8 @@ const {
 } = vi.hoisted(() => ({
   states: {} as Record<string, MockAgentState>,
   providersAtomMock: { kind: "providers-atom" },
+  globalCommunicationProfileAtomMock: { kind: "global-communication-profile-atom" },
+  profilesAtomMock: { kind: "profiles-atom" },
   jotaiStoreMock: {
     get: vi.fn(),
   },
@@ -87,10 +91,12 @@ vi.mock("./atoms", () => ({
       typeof patch === "function" ? patch(prev) : { ...prev, ...patch };
   },
   jotaiStore: jotaiStoreMock,
+  globalCommunicationProfileAtom: globalCommunicationProfileAtomMock,
 }));
 
 vi.mock("./db", () => ({
   providersAtom: providersAtomMock,
+  profilesAtom: profilesAtomMock,
 }));
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
@@ -301,6 +307,12 @@ describe("runner", () => {
             baseUrl: "http://localhost:11434",
           },
         ];
+      }
+      if (atom === profilesAtomMock) {
+        return [];
+      }
+      if (atom === globalCommunicationProfileAtomMock) {
+        return "global-test-profile";
       }
       return undefined;
     });

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -10,7 +10,12 @@
  *   → if no tool calls: done
  */
 
-import { getAgentState, patchAgentState, jotaiStore } from "./atoms";
+import {
+  getAgentState,
+  patchAgentState,
+  jotaiStore,
+  globalCommunicationProfileAtom,
+} from "./atoms";
 import { providersAtom } from "./db";
 import {
   TOOL_DEFINITIONS,
@@ -77,7 +82,7 @@ import type {
   EditFileChange,
   SearchFilesOutput,
 } from "@/agent/tools/workspace";
-import type { ProviderInstance } from "./db";
+import { profilesAtom, type ProviderInstance } from "./db";
 import {
   artifactGet,
   getArtifactFrameworkMetadata,
@@ -770,12 +775,21 @@ export async function stopRunningExecToolCall(
    System prompt
 ───────────────────────────────────────────────────────────────────────────── */
 
+function getCommunicationInstruction(profile: string | undefined): string | null {
+  const targetId = !profile || profile === "global" ? jotaiStore.get(globalCommunicationProfileAtom) : profile;
+  if (!targetId) return null;
+  const profiles = jotaiStore.get(profilesAtom);
+  const match = profiles.find((p) => p.id === targetId);
+  return match ? match.promptSnippet : null;
+}
+
 function buildSystemPrompt(
   cwd: string,
   isGitRepo: boolean,
   hasAgentsFile: boolean,
   hasSkillsDir: boolean,
   runtimeContext: SystemPromptRuntimeContext,
+  communicationProfile: string | undefined,
 ): string {
   const gitSection = isGitRepo
     ? `
@@ -887,7 +901,12 @@ Use agent_subagent_call when delegating to a specialist is appropriate.
 When a subagent returns cards, those cards are already visible to the user.
 Read them, but do not recreate the same cards with agent_card_add.
 
-Be concise. Act like a focused senior engineer.`;
+Be concise. Act like a focused senior engineer.${
+  (() => {
+    const inst = getCommunicationInstruction(communicationProfile);
+    return inst ? `\n\nCOMMUNICATION STYLE\n${inst}` : "";
+  })()
+}`;
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -1152,7 +1171,7 @@ function serializeConversationCardForParent(
 }
 
 /** Build the full system prompt for a subagent (base + output section). */
-function buildSubagentSystemPrompt(def: SubagentDefinition): string {
+function buildSubagentSystemPrompt(def: SubagentDefinition, communicationProfile?: string): string {
   const prompt = def.systemPrompt.trim();
   if (!def.output) return prompt;
 
@@ -1184,6 +1203,11 @@ function buildSubagentSystemPrompt(def: SubagentDefinition): string {
   outputSections.push(
     ["FINAL MESSAGE", def.output.finalMessageInstructions.trim()].join("\n"),
   );
+
+  const commInstruction = getCommunicationInstruction(communicationProfile);
+  if (commInstruction) {
+    outputSections.push(["COMMUNICATION STYLE", commInstruction].join("\n"));
+  }
 
   return `${prompt}\n\n${outputSections.join("\n\n")}`;
 }
@@ -1281,7 +1305,8 @@ async function runSubagentLoop(
   }
 
   const toolDefs = getToolDefinitionsByNames(subagentDef.tools);
-  const systemPromptText = buildSubagentSystemPrompt(subagentDef);
+  const communicationProfile = getAgentState(tabId).config.communicationProfile;
+  const systemPromptText = buildSubagentSystemPrompt(subagentDef, communicationProfile);
 
   // Local API message history — not merged into the parent tab's apiMessages.
   const localApiMessages: ApiMessage[] = [
@@ -2368,6 +2393,7 @@ async function runAgentTurn(
               hasAgentsFile,
               hasSkillsDir,
               buildSystemPromptRuntimeContext(),
+              state.config.communicationProfile,
             ),
           },
         ]

--- a/src/agent/sessionRestore.test.ts
+++ b/src/agent/sessionRestore.test.ts
@@ -61,6 +61,7 @@ function makeSession(
       reasoningEffort: "high",
       latencyCostProfile: "fast",
     }),
+    communicationProfile: "pragmatic",
     ...overrides,
   };
 }

--- a/src/agent/sessionRestore.ts
+++ b/src/agent/sessionRestore.ts
@@ -91,6 +91,7 @@ export function hydratePersistedSession(
       worktreeBranch: session.worktreeBranch || undefined,
       worktreeDeclined: session.worktreeDeclined || undefined,
       advancedOptions: parseAdvancedOptions(session.advancedOptions),
+      communicationProfile: session.communicationProfile === "global" ? undefined : session.communicationProfile,
     },
     plan: {
       markdown: session.planMarkdown,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -263,6 +263,7 @@ export const DEFAULT_ADVANCED_OPTIONS: AdvancedModelOptions = {
    Per-agent configuration (each tab has its own)
 ─────────────────────────────────────────────────────────────────────────── */
 
+export type CommunicationProfileId = "pragmatic" | "friendly" | "kevin" | string;
 export interface AgentConfig {
   /** Absolute path to the workspace root */
   cwd: string;
@@ -277,6 +278,8 @@ export interface AgentConfig {
   worktreeDeclined?: boolean;
   /** Provider-level advanced options chosen at session creation time. */
   advancedOptions?: AdvancedModelOptions;
+  /** Chosen communication profile. If omitted or "global", falls back to global setting. */
+  communicationProfile?: string;
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────

--- a/src/components/AdvancedModelOptions.tsx
+++ b/src/components/AdvancedModelOptions.tsx
@@ -10,25 +10,33 @@ import type {
 
 /* ─────────────────────────────────────────────────────────────────────────────
    AdvancedModelOptionsButton
-   - Only renders for openai / anthropic providers
    - Manages its own open/close state and click-outside dismissal
+   - Allows choosing communication profile & provider-specific advanced options
 ───────────────────────────────────────────────────────────────────────────── */
+
+import { profilesAtom } from "@/agent/db";
+import { useAtomValue } from "jotai";
 
 interface AdvancedModelOptionsButtonProps {
   provider: string | null;
   value: AdvancedModelOptions;
   onChange: (opts: AdvancedModelOptions) => void;
+  communicationProfile?: string;
+  onCommunicationProfileChange?: (profile: string) => void;
 }
 
 export function AdvancedModelOptionsButton({
   provider,
   value,
   onChange,
+  communicationProfile,
+  onCommunicationProfileChange,
 }: AdvancedModelOptionsButtonProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
   const showAdvanced = provider === "openai" || provider === "anthropic";
+  const profiles = useAtomValue(profilesAtom);
 
   /* Close when clicking outside */
   useEffect(() => {
@@ -46,8 +54,6 @@ export function AdvancedModelOptionsButton({
     (patch: Partial<AdvancedModelOptions>) => onChange({ ...value, ...patch }),
     [value, onChange],
   );
-
-  if (!showAdvanced) return null;
 
   return (
     <div className="ns-advanced-wrap" ref={wrapRef}>
@@ -68,52 +74,87 @@ export function AdvancedModelOptionsButton({
 
       {open && (
         <div className="ns-advanced-panel">
-          {/* Reasoning visibility */}
-          <div className="ns-advanced-row">
-            <span className="ns-advanced-label">Reasoning visibility</span>
-            <SegmentedControl<ReasoningVisibility>
-              className="ns-segment-control"
-              options={[
-                { value: "off", label: "Off" },
-                { value: "auto", label: "Auto" },
-                { value: "detailed", label: "Detailed" },
-              ]}
-              value={value.reasoningVisibility}
-              onChange={(v) => update({ reasoningVisibility: v })}
-            />
-          </div>
+          {/* Profile Override */}
+          {communicationProfile !== undefined && onCommunicationProfileChange && (
+            <div className="ns-advanced-row">
+              <span className="ns-advanced-label">Communication Profile</span>
+              <select
+                className="w-full bg-transparent border border-border-subtle rounded px-2 py-1 text-sm focus:outline-none focus:border-border cursor-pointer appearance-none text-right placeholder-muted pr-6 relative"
+                value={communicationProfile}
+                onChange={(e) => onCommunicationProfileChange(e.target.value)}
+                style={{
+                  backgroundImage: `url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%239ba1a6%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E")`,
+                  backgroundRepeat: "no-repeat",
+                  backgroundPosition: "right 0.5rem top 50%",
+                  backgroundSize: "0.65rem auto",
+                }}
+              >
+                <option value="global" className="bg-popover text-popover-foreground">
+                  Default (Global)
+                </option>
+                {profiles.map((p) => (
+                  <option
+                    key={p.id}
+                    value={p.id}
+                    className="bg-popover text-popover-foreground"
+                  >
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
-          {/* Reasoning effort */}
-          <div className="ns-advanced-row">
-            <span className="ns-advanced-label">Reasoning effort</span>
-            <SegmentedControl<ReasoningEffort>
-              className="ns-segment-control"
-              options={[
-                { value: "low", label: "Low" },
-                { value: "medium", label: "Medium" },
-                { value: "high", label: "High" },
-              ]}
-              value={value.reasoningEffort}
-              onChange={(v) => update({ reasoningEffort: v })}
-            />
-          </div>
+          {showAdvanced && (
+            <>
+              {/* Reasoning visibility */}
+              <div className="ns-advanced-row">
+                <span className="ns-advanced-label">Reasoning visibility</span>
+                <SegmentedControl<ReasoningVisibility>
+                  className="ns-segment-control"
+                  options={[
+                    { value: "off", label: "Off" },
+                    { value: "auto", label: "Auto" },
+                    { value: "detailed", label: "Detailed" },
+                  ]}
+                  value={value.reasoningVisibility}
+                  onChange={(v) => update({ reasoningVisibility: v })}
+                />
+              </div>
 
-          {/* Latency / cost profile */}
-          <div className="ns-advanced-row">
-            <span className="ns-advanced-label">Latency / cost</span>
-            <SegmentedControl<LatencyCostProfile>
-              className="ns-segment-control"
-              options={[
-                { value: "balanced", label: "Balanced" },
-                { value: "fast", label: "Fast" },
-                ...(provider === "openai"
-                  ? [{ value: "cheap" as LatencyCostProfile, label: "Cheap" }]
-                  : []),
-              ]}
-              value={value.latencyCostProfile}
-              onChange={(v) => update({ latencyCostProfile: v })}
-            />
-          </div>
+              {/* Reasoning effort */}
+              <div className="ns-advanced-row">
+                <span className="ns-advanced-label">Reasoning effort</span>
+                <SegmentedControl<ReasoningEffort>
+                  className="ns-segment-control"
+                  options={[
+                    { value: "low", label: "Low" },
+                    { value: "medium", label: "Medium" },
+                    { value: "high", label: "High" },
+                  ]}
+                  value={value.reasoningEffort}
+                  onChange={(v) => update({ reasoningEffort: v })}
+                />
+              </div>
+
+              {/* Latency / cost profile */}
+              <div className="ns-advanced-row">
+                <span className="ns-advanced-label">Latency / cost</span>
+                <SegmentedControl<LatencyCostProfile>
+                  className="ns-segment-control"
+                  options={[
+                    { value: "balanced", label: "Balanced" },
+                    { value: "fast", label: "Fast" },
+                    ...(provider === "openai"
+                      ? [{ value: "cheap" as LatencyCostProfile, label: "Cheap" }]
+                      : []),
+                  ]}
+                  value={value.latencyCostProfile}
+                  onChange={(v) => update({ latencyCostProfile: v })}
+                />
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/AgentNotificationManager.test.tsx
+++ b/src/components/AgentNotificationManager.test.tsx
@@ -47,6 +47,7 @@ function makeSession(id: string, label: string): PersistedSession {
     worktreeBranch: "",
     worktreeDeclined: false,
     showDebug: false,
+    communicationProfile: "pragmatic",
     advancedOptions: "{}",
   };
 }

--- a/src/components/ModelPickerModal.tsx
+++ b/src/components/ModelPickerModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
-import { Button, Badge, ModalShell } from "@/components/ui";
+import { Button, Badge, ModalShell, SelectField } from "@/components/ui";
 import { TextField } from "@/components/ui";
 import {
   useFilteredModels,
@@ -8,11 +8,10 @@ import {
   fmtPrice,
   type GatewayModel,
 } from "@/agent/useModels";
+import { profilesAtom } from "@/agent/db";
+import { useAtomValue } from "jotai";
 
 /* ─────────────────────────────────────────────────────────────────────────────
-   ModelPickerModal — modal with searchable/keyboard-navigable model list.
-
-   Usage:
      const [open, setOpen] = useState(false);
      {open && (
        <ModelPickerModal
@@ -41,17 +40,21 @@ function providerLabel(ownedBy: string): string {
 interface ModelPickerModalProps {
   models: GatewayModel[];
   currentModelId: string;
-  onSelect: (modelId: string) => void;
+  currentProfile?: string;
+  onSelect: (modelId: string, profile?: string) => void;
   onClose: () => void;
 }
 
 export default function ModelPickerModal({
   models,
   currentModelId,
+  currentProfile,
   onSelect,
   onClose,
 }: ModelPickerModalProps) {
   const [query, setQuery] = useState("");
+  const [profile, setProfile] = useState<string | undefined>(currentProfile);
+  const profiles = useAtomValue(profilesAtom);
   const filtered = useFilteredModels(models, query);
 
   const initialIndex = Math.max(
@@ -106,10 +109,10 @@ export default function ModelPickerModal({
       if (e.key === "Enter") {
         e.preventDefault();
         const model = filtered[focusedIndex];
-        if (model) onSelect(model.id);
+        if (model) onSelect(model.id, profile);
       }
     },
-    [filtered, focusedIndex, onClose, onSelect],
+    [filtered, focusedIndex, onClose, onSelect, profile],
   );
 
   return createPortal(
@@ -144,8 +147,8 @@ export default function ModelPickerModal({
           </Button>
         </div>
 
-        {/* ── Search ──────────────────────────────────────────────────── */}
-        <div className="model-picker-search">
+        {/* ── Search & Profile ────────────────────────────────────────── */}
+        <div className="model-picker-search flex flex-col gap-2">
           <TextField
             ref={searchRef}
             placeholder="Search models…"
@@ -160,6 +163,24 @@ export default function ModelPickerModal({
               </span>
             }
           />
+          <div className="flex flex-col gap-1.5 mt-2 px-1">
+            <span className="text-xs text-muted font-medium">Communication Profile (Override)</span>
+            <SelectField
+              value={profile ?? "global"}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setProfile(
+                  e.target.value === "global" ? undefined : e.target.value,
+                )
+              }
+            >
+              <option value="global">Use Global Default</option>
+              {profiles.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </SelectField>
+          </div>
         </div>
 
         {/* ── Model list ──────────────────────────────────────────────── */}
@@ -175,7 +196,7 @@ export default function ModelPickerModal({
                 model={m}
                 isActive={m.id === currentModelId}
                 isFocused={idx === focusedIndex}
-                onClick={() => onSelect(m.id)}
+                onClick={() => onSelect(m.id, profile)}
                 onMouseEnter={() => setFocusedIndex(idx)}
               />
             ))

--- a/src/components/NewSession.tsx
+++ b/src/components/NewSession.tsx
@@ -103,6 +103,7 @@ interface NewSessionProps {
     model: string,
     contextLength?: number,
     advancedOptions?: AdvancedModelOptions,
+    communicationProfile?: string,
   ) => void;
 }
 
@@ -114,6 +115,9 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [focused, setFocused] = useState(false);
   const [advancedOptions, setAdvancedOptions] = useState<AdvancedModelOptions>(loadAdvancedOptions);
+  
+  // Note: the global default profile handles the fallback later if not provided, but we map it locally if they change it.
+  const [communicationProfile, setCommunicationProfile] = useState<string>("global");
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -167,9 +171,9 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
       const text = input.trim();
       const ctxLen = selectedModelObj?.context_length;
       if (text) {
-        onSubmit(text, selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions);
+        onSubmit(text, selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions, communicationProfile);
       } else {
-        onSubmit("", selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions);
+        onSubmit("", selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions, communicationProfile);
       }
     }
   };
@@ -392,6 +396,8 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
             hasAnyProviderKey={hasAnyProviderKey}
             advancedOptions={advancedOptions}
             onAdvancedOptionsChange={updateAdvancedOptions}
+            communicationProfile={communicationProfile}
+            onCommunicationProfileChange={setCommunicationProfile}
           />
         </div>
         {/* end ns-selectors-row */}

--- a/src/components/NewSessionModelSelector.tsx
+++ b/src/components/NewSessionModelSelector.tsx
@@ -20,6 +20,8 @@ interface NewSessionModelSelectorProps {
   hasAnyProviderKey: boolean;
   advancedOptions?: AdvancedModelOptions;
   onAdvancedOptionsChange?: (opts: AdvancedModelOptions) => void;
+  communicationProfile?: string;
+  onCommunicationProfileChange?: (profile: string) => void;
 }
 
 type ProviderBadgeProps = {
@@ -68,6 +70,8 @@ export default function NewSessionModelSelector({
   hasAnyProviderKey,
   advancedOptions,
   onAdvancedOptionsChange,
+  communicationProfile,
+  onCommunicationProfileChange,
 }: NewSessionModelSelectorProps) {
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
@@ -114,6 +118,8 @@ export default function NewSessionModelSelector({
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
   }, [modelDropdownOpen]);
+
+
 
   useEffect(() => {
     if (!modelDropdownOpen) return;
@@ -309,11 +315,14 @@ export default function NewSessionModelSelector({
           </div>
         )}
       </div>
+
       {advancedOptions && onAdvancedOptionsChange && (
         <AdvancedModelOptionsButton
           provider={selectedProvider}
           value={advancedOptions}
           onChange={onAdvancedOptionsChange}
+          communicationProfile={communicationProfile}
+          onCommunicationProfileChange={onCommunicationProfileChange}
         />
       )}
     </div>

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -16,6 +16,7 @@ import {
   deleteProvider,
   saveProvider,
   type ProviderInstance,
+  type CommunicationProfileRecord,
 } from "@/agent/db";
 import { cn } from "@/utils/cn";
 import {
@@ -30,6 +31,7 @@ import {
   Panel,
   SelectField,
   TextField,
+  TextareaField,
   ToggleSwitch,
 } from "@/components/ui";
 import {
@@ -306,10 +308,11 @@ function AppearanceSection({
   controller: SettingsControllerValue;
 }) {
   return (
-    <SectionCard
-      title="Theme & Mode"
-      description="Choose the visual theme and whether the UI uses dark or light mode."
-    >
+    <div className="settings-page__section-stack">
+      <SectionCard
+        title="Theme & Mode"
+        description="Choose the visual theme and whether the UI uses dark or light mode."
+      >
       <div className="settings-row">
         <div className="settings-row-info">
           <span className="settings-row-label">Theme</span>
@@ -353,7 +356,192 @@ function AppearanceSection({
           <span>{controller.themeMode === "dark" ? "Light" : "Dark"}</span>
         </Button>
       </div>
-    </SectionCard>
+      </SectionCard>
+
+      <SectionCard
+        title="Communication Profile"
+        description="Choose the agent's default conversational style and personality."
+        actions={
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => {
+              controller.setIsAddingProfile(true);
+              controller.setEditingProfileId(null);
+            }}
+            className="text-nowrap"
+          >
+            Add Custom Profile
+          </Button>
+        }
+      >
+
+
+        <div className="settings-provider-list mt-8">
+          {controller.customProfiles.length === 0 && !controller.isAddingProfile ? (
+            <Panel variant="inset" className="settings-empty-panel">
+              <span className="material-symbols-outlined settings-empty-panel__icon">
+                forum
+              </span>
+              <div className="settings-empty-panel__copy">
+                <span className="settings-empty-panel__title">
+                  No custom profiles
+                </span>
+                <span className="settings-empty-panel__description">
+                  Add a custom profile to tailor the agent to your needs.
+                </span>
+              </div>
+            </Panel>
+          ) : null}
+
+          {controller.customProfiles.map((profile) => {
+            return controller.editingProfileId === profile.id ? (
+              <ProfileConfigurator
+                key={profile.id}
+                profile={profile}
+                onSave={async (p) => {
+                  await controller.saveProfile(p);
+                  controller.setIsAddingProfile(false);
+                  controller.setEditingProfileId(null);
+                }}
+                onCancel={() => controller.setEditingProfileId(null)}
+              />
+            ) : (
+              <Panel
+                key={profile.id}
+                className={cn(
+                  "settings-provider-card cursor-pointer transition-colors relative border",
+                  controller.globalCommunicationProfile === profile.id
+                    ? "border-primary bg-primary/5"
+                    : "border-transparent hover:border-primary/50"
+                )}
+                onClick={() => controller.setGlobalCommunicationProfile(profile.id)}
+              >
+                {controller.globalCommunicationProfile === profile.id && (
+                  <div className="absolute top-0 left-0 w-1 h-full bg-primary rounded-l-md" />
+                )}
+                <div className="flex flex-row items-center gap-3 min-w-0 flex-1 pl-2">
+                  <span className="settings-provider-card__title shrink-0">
+                    {profile.name}
+                  </span>
+                  <span className="settings-provider-card__meta text-ellipsis overflow-hidden whitespace-nowrap" title={profile.promptSnippet}>
+                    {profile.promptSnippet}
+                  </span>
+                </div>
+                <div className="settings-provider-card__actions">
+                  <IconButton
+                    className="settings-provider-card__icon-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      controller.setEditingProfileId(profile.id);
+                    }}
+                    title={`Edit ${profile.name}`}
+                    aria-label={`Edit ${profile.name}`}
+                  >
+                    <span className="material-symbols-outlined text-sm">
+                      edit
+                    </span>
+                  </IconButton>
+                  <IconButton
+                    className="settings-provider-card__icon-btn settings-provider-card__icon-btn--danger"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void controller.deleteProfile(profile.id);
+                    }}
+                    title={`Delete ${profile.name}`}
+                    aria-label={`Delete ${profile.name}`}
+                  >
+                    <span className="material-symbols-outlined text-sm">
+                      delete
+                    </span>
+                  </IconButton>
+                </div>
+              </Panel>
+            );
+          })}
+
+          {controller.isAddingProfile ? (
+            <ProfileConfigurator
+              onSave={async (p) => {
+                await controller.saveProfile(p);
+                controller.setIsAddingProfile(false);
+                controller.setEditingProfileId(null);
+              }}
+              onCancel={() => controller.setIsAddingProfile(false)}
+            />
+          ) : null}
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
+function ProfileConfigurator({
+  profile,
+  onSave,
+  onCancel,
+}: {
+  profile?: CommunicationProfileRecord;
+  onSave: (profile: CommunicationProfileRecord) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(profile?.name ?? "");
+  const [promptSnippet, setPromptSnippet] = useState(profile?.promptSnippet ?? "");
+
+  const handleSaveClick = () => {
+    if (!name.trim() || !promptSnippet.trim()) return;
+    onSave({
+      id: profile?.id ?? uuidv4(),
+      name: name.trim(),
+      promptSnippet: promptSnippet.trim(),
+    });
+  };
+
+  return (
+    <Panel className="settings-provider-form">
+      <div className="settings-profile-form__grid">
+        <div className="settings-field">
+          <label className="settings-field-label">Profile Name</label>
+          <TextField
+            autoFocus
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Code Reviewer"
+            wrapClassName="settings-input-wrap"
+          />
+        </div>
+
+        <div className="settings-field">
+          <label className="settings-field-label">Prompt Snippet</label>
+          <TextareaField
+            value={promptSnippet}
+            onChange={(e) => setPromptSnippet(e.target.value)}
+            placeholder="You are an expert software engineer reviewing code..."
+            wrapClassName="settings-input-wrap"
+            rows={4}
+          />
+        </div>
+      </div>
+
+      <div className="settings-provider-form__footer">
+        <div className="settings-provider-form__status" aria-live="polite"></div>
+
+        <div className="settings-provider-form__actions">
+          <Button type="button" variant="ghost" size="xs" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            onClick={handleSaveClick}
+            disabled={!name.trim() || !promptSnippet.trim()}
+          >
+            Save Profile
+          </Button>
+        </div>
+      </div>
+    </Panel>
   );
 }
 

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -6,13 +6,16 @@ import {
   notifyOnAttentionAtom,
   themeModeAtom,
   themeNameAtom,
+  globalCommunicationProfileAtom,
   voiceInputEnabledAtom,
   voiceModelPathAtom,
   type AppUpdaterState,
 } from "@/agent/atoms";
 import {
   providersAtom,
+  profilesAtom,
   type ProviderInstance,
+  type CommunicationProfileRecord,
 } from "@/agent/db";
 import { ensureNotificationPermission } from "@/notifications";
 import { upsertWorkspaceSessions } from "@/agent/persistence";
@@ -54,6 +57,16 @@ export interface SettingsControllerValue {
   toggleThemeMode: () => void;
   themeName: ThemeName;
   setThemeName: (name: ThemeName) => void;
+  globalCommunicationProfile: string;
+  setGlobalCommunicationProfile: (profile: string) => void;
+  customProfiles: CommunicationProfileRecord[];
+  setCustomProfiles: (profiles: CommunicationProfileRecord[]) => void;
+  isAddingProfile: boolean;
+  setIsAddingProfile: (adding: boolean) => void;
+  editingProfileId: string | null;
+  setEditingProfileId: (id: string | null) => void;
+  saveProfile: (profile: CommunicationProfileRecord) => Promise<void>;
+  deleteProfile: (id: string) => Promise<void>;
   notifyOnAttention: boolean;
   toggleNotifyOnAttention: () => Promise<void>;
   voiceInputEnabled: boolean;
@@ -71,6 +84,10 @@ export function useSettingsController(): SettingsControllerValue {
   const [providers, setProviders] = useAtom(providersAtom);
   const [themeMode, setThemeMode] = useAtom(themeModeAtom);
   const [themeName, setThemeName] = useAtom(themeNameAtom);
+  const [globalCommunicationProfile, setGlobalCommunicationProfile] = useAtom(
+    globalCommunicationProfileAtom,
+  );
+  const [customProfiles, setCustomProfiles] = useAtom(profilesAtom);
   const [appUpdater] = useAtom(appUpdaterStateAtom);
   const [notifyOnAttention, setNotifyOnAttention] = useAtom(
     notifyOnAttentionAtom,
@@ -83,6 +100,27 @@ export function useSettingsController(): SettingsControllerValue {
     useState<VoiceDownloadStatus>("idle");
   const [voiceDownloadError, setVoiceDownloadError] = useState<string | null>(
     null,
+  );
+
+  const [isAddingProfile, setIsAddingProfile] = useState(false);
+  const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
+
+  const handleSaveProfile = useCallback(
+    async (profile: CommunicationProfileRecord) => {
+      const { saveProfile, loadProfiles } = await import("@/agent/db");
+      await saveProfile(profile);
+      setCustomProfiles(await loadProfiles());
+    },
+    [setCustomProfiles],
+  );
+
+  const handleDeleteProfile = useCallback(
+    async (id: string) => {
+      const { deleteProfile, loadProfiles } = await import("@/agent/db");
+      await deleteProfile(id);
+      setCustomProfiles(await loadProfiles());
+    },
+    [setCustomProfiles],
   );
 
   const envKeysAvailable = useEnvProviderKeys();
@@ -179,6 +217,16 @@ export function useSettingsController(): SettingsControllerValue {
     toggleThemeMode,
     themeName,
     setThemeName,
+    globalCommunicationProfile,
+    setGlobalCommunicationProfile,
+    customProfiles,
+    setCustomProfiles,
+    isAddingProfile,
+    setIsAddingProfile,
+    editingProfileId,
+    setEditingProfileId,
+    saveProfile: handleSaveProfile,
+    deleteProfile: handleDeleteProfile,
     notifyOnAttention,
     toggleNotifyOnAttention,
     voiceInputEnabled,

--- a/src/styles/components-settings.css
+++ b/src/styles/components-settings.css
@@ -624,6 +624,12 @@
   gap: 14px;
 }
 
+.settings-profile-form__grid {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  gap: 14px;
+}
+
 .settings-provider-form__select {
   min-height: 38px;
 }
@@ -739,7 +745,8 @@
     max-height: 240px;
   }
 
-  .settings-provider-form__grid {
+  .settings-provider-form__grid,
+  .settings-profile-form__grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Overview
This PR introduces **Communication Profiles** to Rakh, allowing users to define and select custom personas/prompts that steer the agent's behavior.

## High-Level Changes
* **Persistence (Backend)**: Added Rust `db.rs` schema tracking and commands for loading, saving, and deleting `CommunicationProfileRecord`s. Added seeded default profiles (Pragmatic, Kevin).
* **Settings UI**: Added a new "Communication Profiles" tab in the Settings surface where users can create, edit, and delete custom agent personas.
* **Session Lifecycle**: Integrated the profile selector into the `AdvancedModelOptions` popup on the New Session page. The selected profile propagates to the workspace tab's `AgentState`.
* **Agent Runner**: The agent runtime now fetches the active profile and resolves its instruction snippet during `buildSystemPrompt()`, altering the AI's core behavior on a per-tab basis.
* **Tests**: Added comprehensive test coverage for profile state restoration and runner injection logic.

Fix #37 