### PR TITLE
feat: add project setup config workflows

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -27,6 +27,8 @@ pub struct PersistedSession {
     pub mode: String,
     pub tab_title: String,
     pub cwd: String,
+    pub project_path: String,
+    pub setup_command: String,
     pub model: String,
     pub plan_markdown: String,
     pub plan_version: i64,
@@ -671,6 +673,8 @@ pub fn init_db() -> Result<Connection, String> {
             mode             TEXT    NOT NULL,
             tab_title        TEXT    NOT NULL DEFAULT '',
             cwd              TEXT    NOT NULL DEFAULT '',
+            project_path     TEXT    NOT NULL DEFAULT '',
+            setup_command    TEXT    NOT NULL DEFAULT '',
             model            TEXT    NOT NULL DEFAULT '',
             plan_markdown    TEXT    NOT NULL DEFAULT '',
             plan_version     INTEGER NOT NULL DEFAULT 0,
@@ -695,6 +699,10 @@ pub fn init_db() -> Result<Connection, String> {
         .execute_batch("ALTER TABLE sessions ADD COLUMN review_edits TEXT NOT NULL DEFAULT '[]';");
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN worktree_path TEXT NOT NULL DEFAULT '';");
+    let _ = conn
+        .execute_batch("ALTER TABLE sessions ADD COLUMN project_path TEXT NOT NULL DEFAULT '';");
+    let _ = conn
+        .execute_batch("ALTER TABLE sessions ADD COLUMN setup_command TEXT NOT NULL DEFAULT '';");
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN worktree_branch TEXT NOT NULL DEFAULT '';");
     let _ = conn.execute_batch(
@@ -790,7 +798,7 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
         let db = state.db.lock().unwrap();
         let mut stmt = db
             .prepare(
-                "SELECT id, label, icon, mode, tab_title, cwd, model,
+                "SELECT id, label, icon, mode, tab_title, cwd, project_path, setup_command, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
                 queued_messages, queue_state,
@@ -812,25 +820,29 @@ pub fn db_load_sessions(state: State<'_, AppState>) -> Result<Vec<PersistedSessi
                     mode: row.get(3)?,
                     tab_title: row.get(4)?,
                     cwd: row.get(5)?,
-                    model: row.get(6)?,
-                    plan_markdown: row.get(7)?,
-                    plan_version: row.get(8)?,
-                    plan_updated_at: row.get(9)?,
-                    chat_messages: row.get(10)?,
-                    api_messages: row.get(11)?,
-                    todos: row.get(12)?,
-                    review_edits: row.get(13)?,
-                    queued_messages: row.get(14)?,
-                    queue_state: row.get(15)?,
-                    archived: row.get::<_, i64>(16)? != 0,
-                    created_at: row.get(17)?,
-                    updated_at: row.get(18)?,
-                    worktree_path: row.get(19)?,
-                    worktree_branch: row.get(20)?,
-                    worktree_declined: row.get::<_, i64>(21)? != 0,
-                    show_debug: row.get::<_, i64>(22)? != 0,
-                    advanced_options: row.get::<_, String>(23).unwrap_or_default(),
-                    communication_profile: row.get::<_, String>(24).unwrap_or_else(|_| "pragmatic".to_string()),
+                    project_path: row.get(6)?,
+                    setup_command: row.get(7)?,
+                    model: row.get(8)?,
+                    plan_markdown: row.get(9)?,
+                    plan_version: row.get(10)?,
+                    plan_updated_at: row.get(11)?,
+                    chat_messages: row.get(12)?,
+                    api_messages: row.get(13)?,
+                    todos: row.get(14)?,
+                    review_edits: row.get(15)?,
+                    queued_messages: row.get(16)?,
+                    queue_state: row.get(17)?,
+                    archived: row.get::<_, i64>(18)? != 0,
+                    created_at: row.get(19)?,
+                    updated_at: row.get(20)?,
+                    worktree_path: row.get(21)?,
+                    worktree_branch: row.get(22)?,
+                    worktree_declined: row.get::<_, i64>(23)? != 0,
+                    show_debug: row.get::<_, i64>(24)? != 0,
+                    advanced_options: row.get::<_, String>(25).unwrap_or_default(),
+                    communication_profile: row
+                        .get::<_, String>(26)
+                        .unwrap_or_else(|_| "pragmatic".to_string()),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -883,19 +895,21 @@ pub fn db_upsert_session(
         let now = now_ms();
         db.execute(
             "INSERT INTO sessions (
-            id, label, icon, mode, tab_title, cwd, model,
+            id, label, icon, mode, tab_title, cwd, project_path, setup_command, model,
             plan_markdown, plan_version, plan_updated_at,
             chat_messages, api_messages, todos, review_edits,
             queued_messages, queue_state,
             archived, created_at, updated_at,
             worktree_path, worktree_branch, worktree_declined, show_debug, advanced_options, communication_profile
-         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25)
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26)
          ON CONFLICT(id) DO UPDATE SET
             label             = excluded.label,
             icon              = excluded.icon,
             mode              = excluded.mode,
             tab_title         = excluded.tab_title,
             cwd               = excluded.cwd,
+            project_path      = excluded.project_path,
+            setup_command     = excluded.setup_command,
             model             = excluded.model,
             plan_markdown     = excluded.plan_markdown,
             plan_version      = excluded.plan_version,
@@ -913,7 +927,7 @@ pub fn db_upsert_session(
             show_debug        = excluded.show_debug,
             advanced_options  = excluded.advanced_options,
             communication_profile = excluded.communication_profile,
-            updated_at        = ?19",
+            updated_at        = ?21",
             rusqlite::params![
                 session.id,
                 session.label,
@@ -921,6 +935,8 @@ pub fn db_upsert_session(
                 session.mode,
                 session.tab_title,
                 session.cwd,
+                session.project_path,
+                session.setup_command,
                 session.model,
                 session.plan_markdown,
                 session.plan_version,
@@ -1011,7 +1027,7 @@ pub fn db_load_archived_sessions(
         let db = state.db.lock().unwrap();
         let mut stmt = db
             .prepare(
-                "SELECT id, label, icon, mode, tab_title, cwd, model,
+                "SELECT id, label, icon, mode, tab_title, cwd, project_path, setup_command, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
                 queued_messages, queue_state,
@@ -1033,25 +1049,29 @@ pub fn db_load_archived_sessions(
                     mode: row.get(3)?,
                     tab_title: row.get(4)?,
                     cwd: row.get(5)?,
-                    model: row.get(6)?,
-                    plan_markdown: row.get(7)?,
-                    plan_version: row.get(8)?,
-                    plan_updated_at: row.get(9)?,
-                    chat_messages: row.get(10)?,
-                    api_messages: row.get(11)?,
-                    todos: row.get(12)?,
-                    review_edits: row.get(13)?,
-                    queued_messages: row.get(14)?,
-                    queue_state: row.get(15)?,
-                    archived: row.get::<_, i64>(16)? != 0,
-                    created_at: row.get(17)?,
-                    updated_at: row.get(18)?,
-                    worktree_path: row.get(19)?,
-                    worktree_branch: row.get(20)?,
-                    worktree_declined: row.get::<_, i64>(21)? != 0,
-                    show_debug: row.get::<_, i64>(22)? != 0,
-                    advanced_options: row.get::<_, String>(23).unwrap_or_default(),
-                    communication_profile: row.get::<_, String>(24).unwrap_or_else(|_| "pragmatic".to_string()),
+                    project_path: row.get(6)?,
+                    setup_command: row.get(7)?,
+                    model: row.get(8)?,
+                    plan_markdown: row.get(9)?,
+                    plan_version: row.get(10)?,
+                    plan_updated_at: row.get(11)?,
+                    chat_messages: row.get(12)?,
+                    api_messages: row.get(13)?,
+                    todos: row.get(14)?,
+                    review_edits: row.get(15)?,
+                    queued_messages: row.get(16)?,
+                    queue_state: row.get(17)?,
+                    archived: row.get::<_, i64>(18)? != 0,
+                    created_at: row.get(19)?,
+                    updated_at: row.get(20)?,
+                    worktree_path: row.get(21)?,
+                    worktree_branch: row.get(22)?,
+                    worktree_declined: row.get::<_, i64>(23)? != 0,
+                    show_debug: row.get::<_, i64>(24)? != 0,
+                    advanced_options: row.get::<_, String>(25).unwrap_or_default(),
+                    communication_profile: row
+                        .get::<_, String>(26)
+                        .unwrap_or_else(|_| "pragmatic".to_string()),
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -1848,6 +1868,8 @@ mod tests {
                 mode             TEXT    NOT NULL,
                 tab_title        TEXT    NOT NULL DEFAULT '',
                 cwd              TEXT    NOT NULL DEFAULT '',
+                project_path     TEXT    NOT NULL DEFAULT '',
+                setup_command    TEXT    NOT NULL DEFAULT '',
                 model            TEXT    NOT NULL DEFAULT '',
                 plan_markdown    TEXT    NOT NULL DEFAULT '',
                 plan_version     INTEGER NOT NULL DEFAULT 0,
@@ -1891,6 +1913,8 @@ mod tests {
             mode: "test-mode".to_string(),
             tab_title: "Tab 1".to_string(),
             cwd: "/tmp".to_string(),
+            project_path: "/tmp".to_string(),
+            setup_command: "npm install".to_string(),
             model: "test-model".to_string(),
             plan_markdown: "".to_string(),
             plan_version: 0,
@@ -1914,13 +1938,13 @@ mod tests {
 
         db.execute(
             "INSERT INTO sessions (
-                id, label, icon, mode, tab_title, cwd, model,
+                id, label, icon, mode, tab_title, cwd, project_path, setup_command, model,
                 plan_markdown, plan_version, plan_updated_at,
                 chat_messages, api_messages, todos, review_edits,
                 queued_messages, queue_state,
                 archived, created_at, updated_at,
                 worktree_path, worktree_branch, worktree_declined, show_debug
-             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23)",
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25)",
             rusqlite::params![
                 session.id,
                 session.label,
@@ -1928,6 +1952,8 @@ mod tests {
                 session.mode,
                 session.tab_title,
                 session.cwd,
+                session.project_path,
+                session.setup_command,
                 session.model,
                 session.plan_markdown,
                 session.plan_version,

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -25,6 +25,9 @@ import BusyComposerTray from "@/components/BusyComposerTray";
 import ErrorDetailsModal, {
   type ErrorModalState,
 } from "@/components/ErrorDetailsModal";
+import ProjectSettingsModal, {
+  type ProjectSettingsSavePayload,
+} from "@/components/ProjectSettingsModal";
 import ToolCallDetailsModal from "@/components/ToolCallDetailsModal";
 import ModelPickerModal from "@/components/ModelPickerModal";
 import CompactToolCall from "@/components/CompactToolCall";
@@ -55,6 +58,14 @@ import { groupChatMessagesForBubbles } from "@/agent/chatBubbleGroups";
 import { useArtifactContentCache } from "@/components/artifact-pane/useSessionArtifacts";
 import { AnimatePresence, motion } from "framer-motion";
 import type { ToolCallDisplay } from "@/agent/types";
+import {
+  findSavedProject,
+  inferProjectName,
+  resolveSavedProject,
+  upsertSavedProject,
+  type SavedProject,
+} from "@/projects";
+import { writeProjectScriptsConfig } from "@/projectScripts";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Page
@@ -184,6 +195,8 @@ export default function WorkspacePage() {
   const [toolDetailsModal, setToolDetailsModal] =
     useState<ToolCallDisplay | null>(null);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [projectSettingsProject, setProjectSettingsProject] =
+    useState<SavedProject | null>(null);
   const [reasoningExpandedById, setReasoningExpandedById] = useState<
     Record<string, boolean>
   >({});
@@ -351,6 +364,86 @@ export default function WorkspacePage() {
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
   }, []);
+
+  const openCurrentProjectSettings = useCallback(() => {
+    const projectPath = agent.config.projectPath?.trim();
+    if (!projectPath) return;
+
+    const savedProject =
+      findSavedProject(projectPath) ?? {
+        path: projectPath,
+        name: inferProjectName(projectPath),
+        ...(agent.config.setupCommand
+          ? { setupCommand: agent.config.setupCommand }
+          : {}),
+      };
+
+    void resolveSavedProject(savedProject).then((resolvedProject) => {
+      setProjectSettingsProject(resolvedProject);
+    });
+  }, [agent.config.projectPath, agent.config.setupCommand]);
+
+  const handleSaveProjectSettings = useCallback(
+    async ({ project, writeProjectConfig }: ProjectSettingsSavePayload) => {
+      const nextProject: SavedProject = {
+        path: project.path,
+        name: project.name,
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      };
+
+      if (writeProjectConfig) {
+        await writeProjectScriptsConfig(project.path, {
+          ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+          ...(project.commands?.length ? { commands: project.commands } : {}),
+        });
+      }
+
+      const resolvedProject = await resolveSavedProject(
+        upsertSavedProject(nextProject).find(
+          (entry) => entry.path === nextProject.path,
+        ) ?? nextProject,
+      );
+      agent.setConfig({
+        projectPath: resolvedProject.path,
+        ...(resolvedProject.setupCommand
+          ? { setupCommand: resolvedProject.setupCommand }
+          : { setupCommand: undefined }),
+      });
+      setProjectSettingsProject(null);
+    },
+    [agent],
+  );
+
+  const handleCreateProjectConfig = useCallback(
+    async ({ project }: ProjectSettingsSavePayload) => {
+      const nextProject: SavedProject = {
+        path: project.path,
+        name: project.name,
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      };
+
+      await writeProjectScriptsConfig(project.path, {
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      });
+
+      const resolvedProject = await resolveSavedProject(
+        upsertSavedProject(nextProject).find(
+          (entry) => entry.path === nextProject.path,
+        ) ?? nextProject,
+      );
+      agent.setConfig({
+        projectPath: resolvedProject.path,
+        ...(resolvedProject.setupCommand
+          ? { setupCommand: resolvedProject.setupCommand }
+          : { setupCommand: undefined }),
+      });
+      setProjectSettingsProject(resolvedProject);
+    },
+    [agent],
+  );
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
@@ -524,8 +617,24 @@ export default function WorkspacePage() {
   if (isNewSession) {
     return (
       <NewSession
-        onSubmit={(message, cwd, model, contextLength, advancedOptions, communicationProfile) => {
-          agent.setConfig({ cwd, model, contextLength, advancedOptions, communicationProfile });
+        onSubmit={(
+          message,
+          project,
+          model,
+          contextLength,
+          advancedOptions,
+          communicationProfile,
+        ) => {
+          const cwd = project?.path ?? "";
+          agent.setConfig({
+            cwd,
+            model,
+            contextLength,
+            advancedOptions,
+            communicationProfile,
+            projectPath: project?.path,
+            setupCommand: project?.setupCommand,
+          });
           // Rename tab to folder basename
           const folder =
             (cwd.split("/").filter(Boolean).pop() ?? cwd) || "New Tab";
@@ -654,6 +763,9 @@ export default function WorkspacePage() {
                                   <UserInputCard key={tc.id} toolCall={tc} tabId={activeTabId} />
                                 ) : tc.status === "awaiting_approval" ||
                                   tc.status === "awaiting_worktree" ||
+                                  tc.status === "awaiting_setup_action" ||
+                                  (tc.tool === "git_worktree_init" &&
+                                    tc.status === "running") ||
                                   (tc.tool === "exec_run" &&
                                     tc.status === "running") ? (
                                   <ToolCallApproval
@@ -661,6 +773,7 @@ export default function WorkspacePage() {
                                     toolCall={tc}
                                     cwd={agent.config.cwd}
                                     tabId={activeTabId}
+                                    onOpenProjectSettings={openCurrentProjectSettings}
                                   />
                                 ) : (
                                   <CompactToolCall
@@ -950,6 +1063,16 @@ export default function WorkspacePage() {
         <ErrorDetailsModal
           {...errorModal}
           onClose={() => setErrorModal(null)}
+        />
+      )}
+
+      {projectSettingsProject && (
+        <ProjectSettingsModal
+          key={projectSettingsProject.path}
+          project={projectSettingsProject}
+          onClose={() => setProjectSettingsProject(null)}
+          onSave={handleSaveProjectSettings}
+          onCreateProjectConfig={handleCreateProjectConfig}
         />
       )}
 

--- a/src/agent/approvals.test.ts
+++ b/src/agent/approvals.test.ts
@@ -3,9 +3,11 @@ import {
   cancelAllApprovals,
   consumeApprovalReason,
   requestApproval,
+  requestWorktreeSetupAction,
   requestWorktreeApproval,
   requiresApproval,
   resolveApproval,
+  resolveWorktreeSetupAction,
   resolveWorktreeApproval,
   setApprovalReason,
 } from "./approvals";
@@ -144,6 +146,16 @@ describe("approvals - resolver lifecycle", () => {
     });
   });
 
+  it("supports worktree setup actions and cancellation fallback", async () => {
+    const retry = requestWorktreeSetupAction("tabA", "setup-1");
+    resolveWorktreeSetupAction("tabA", "setup-1", "retry");
+    await expect(retry).resolves.toEqual({ action: "retry" });
+
+    const canceled = requestWorktreeSetupAction("tabA", "setup-2");
+    cancelAllApprovals();
+    await expect(canceled).resolves.toEqual({ action: "abort" });
+  });
+
   it("only cancels approvals for the specified tab", async () => {
     const pendingA = requestApproval("tabA", "call-a");
     const pendingB = requestApproval("tabB", "call-b");
@@ -158,4 +170,3 @@ describe("approvals - resolver lifecycle", () => {
     await expect(pendingB).resolves.toBe(true);
   });
 });
-

--- a/src/agent/approvals.ts
+++ b/src/agent/approvals.ts
@@ -220,6 +220,13 @@ export function cancelAllApprovals(tabId?: string): void {
       userInputResolvers.delete(key);
     }
   }
+
+  for (const [key, resolve] of worktreeSetupActionResolvers.entries()) {
+    if (key.startsWith(prefix)) {
+      resolve({ action: "abort" });
+      worktreeSetupActionResolvers.delete(key);
+    }
+  }
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -300,5 +307,38 @@ export function resolveWorktreeApproval(
   if (resolve) {
     worktreeApprovalResolvers.delete(key);
     resolve({ approved, branchName });
+  }
+}
+
+export type WorktreeSetupAction = "retry" | "continue" | "abort";
+
+export interface WorktreeSetupActionResult {
+  action: WorktreeSetupAction;
+}
+
+const worktreeSetupActionResolvers = new Map<
+  string,
+  (result: WorktreeSetupActionResult) => void
+>();
+
+export function requestWorktreeSetupAction(
+  tabId: string,
+  id: string,
+): Promise<WorktreeSetupActionResult> {
+  return new Promise<WorktreeSetupActionResult>((resolve) => {
+    worktreeSetupActionResolvers.set(`${tabId}:${id}`, resolve);
+  });
+}
+
+export function resolveWorktreeSetupAction(
+  tabId: string,
+  id: string,
+  action: WorktreeSetupAction,
+): void {
+  const key = `${tabId}:${id}`;
+  const resolve = worktreeSetupActionResolvers.get(key);
+  if (resolve) {
+    worktreeSetupActionResolvers.delete(key);
+    resolve({ action });
   }
 }

--- a/src/agent/persistence.test.ts
+++ b/src/agent/persistence.test.ts
@@ -73,6 +73,8 @@ describe("persistence", () => {
       tabTitle: "Task",
       config: {
         cwd: "/repo",
+        projectPath: undefined,
+        setupCommand: undefined,
         model: "",
         worktreePath: undefined,
         worktreeBranch: undefined,
@@ -97,6 +99,8 @@ describe("persistence", () => {
     expect(session.queueState).toBe("paused");
     expect(session.worktreePath).toBe("");
     expect(session.worktreeBranch).toBe("");
+    expect(session.projectPath).toBe("");
+    expect(session.setupCommand).toBe("");
     expect(session.worktreeDeclined).toBe(false);
     expect(session.showDebug).toBe(false);
   });
@@ -225,6 +229,8 @@ describe("persistence", () => {
       tabTitle: "Title",
       config: {
         cwd: "/repo",
+        projectPath: "/repo",
+        setupCommand: "npm install",
         model: "model-x",
         worktreePath: "/wt",
         worktreeBranch: "codex/branch",
@@ -254,6 +260,8 @@ describe("persistence", () => {
     };
     expect(payload.session.id).toBe("tab-w");
     expect(payload.session.cwd).toBe("/repo");
+    expect(payload.session.projectPath).toBe("/repo");
+    expect(payload.session.setupCommand).toBe("npm install");
     expect(payload.session.worktreePath).toBe("/wt");
     expect(payload.session.worktreeBranch).toBe("codex/branch");
     expect(payload.session.worktreeDeclined).toBe(true);
@@ -332,6 +340,8 @@ describe("persistence", () => {
       archived: true,
       createdAt: 1,
       updatedAt: 1,
+      projectPath: "",
+      setupCommand: "",
       worktreePath: "",
       worktreeBranch: "",
       worktreeDeclined: false,

--- a/src/agent/persistence.ts
+++ b/src/agent/persistence.ts
@@ -36,6 +36,8 @@ export interface PersistedSession {
   mode: string;
   tabTitle: string;
   cwd: string;
+  projectPath: string;
+  setupCommand: string;
   model: string;
   planMarkdown: string;
   planVersion: number;
@@ -112,6 +114,8 @@ export function buildPersistedSession(
     mode: tab.mode,
     tabTitle: state.tabTitle,
     cwd: state.config.cwd,
+    projectPath: state.config.projectPath ?? "",
+    setupCommand: state.config.setupCommand ?? "",
     model: state.config.model || DEFAULT_MODEL,
     planMarkdown: state.plan.markdown,
     planVersion: state.plan.version,

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -159,6 +159,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+class RunAbortedError extends Error {
+  constructor(message = "Agent run aborted") {
+    super(message);
+    this.name = "RunAbortedError";
+  }
+}
+
+function isRunAbortedToolResult(result: unknown): boolean {
+  return (
+    isRecord(result) &&
+    result.ok === false &&
+    isRecord(result.error) &&
+    result.error.code === "RUN_ABORTED"
+  );
+}
+
+function shouldStreamToolOutput(toolName: string): boolean {
+  return toolName === "exec_run" || toolName === "git_worktree_init";
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    buildProviderOptions — maps AdvancedModelOptions to AI SDK providerOptions
 ─────────────────────────────────────────────────────────────────────────── */
@@ -455,7 +475,11 @@ function findRunningExecToolCallIds(tabId: string): string[] {
   const ids: string[] = [];
   for (const msg of state.chatMessages) {
     for (const tc of msg.toolCalls ?? []) {
-      if (tc.tool === "exec_run" && tc.status === "running") {
+      const gitSetupRunning =
+        tc.tool === "git_worktree_init" &&
+        tc.status === "running" &&
+        tc.args.setupPhase === "running_setup";
+      if ((tc.tool === "exec_run" && tc.status === "running") || gitSetupRunning) {
         ids.push(tc.id);
       }
     }
@@ -469,8 +493,10 @@ function hasRunningExecToolCall(tabId: string, toolCallId: string): boolean {
     for (const tc of msg.toolCalls ?? []) {
       if (
         tc.id === toolCallId &&
-        tc.tool === "exec_run" &&
-        tc.status === "running"
+        tc.status === "running" &&
+        (tc.tool === "exec_run" ||
+          (tc.tool === "git_worktree_init" &&
+            tc.args.setupPhase === "running_setup"))
       ) {
         return true;
       }
@@ -614,6 +640,7 @@ function interruptActiveRun(
     status === "pending" ||
     status === "awaiting_approval" ||
     status === "awaiting_worktree" ||
+    status === "awaiting_setup_action" ||
     status === "running";
 
   patchAgentState(tabId, (prev) => ({
@@ -1965,7 +1992,7 @@ async function runSubagentLoop(
         const currentCwd = getAgentState(tabId).config.cwd;
         let streamBuf = "";
         const callbacks: DispatchCallbacks | undefined =
-          tc.function.name === "exec_run"
+          shouldStreamToolOutput(tc.function.name)
             ? {
                 onExecOutput: (_stream, data) => {
                   streamBuf += data;
@@ -2014,6 +2041,9 @@ async function runSubagentLoop(
       const abortError = new Error("Subagent run aborted");
       abortError.name = "AbortError";
       throw abortError;
+    }
+    if (toolResults.some(({ result }) => isRunAbortedToolResult(result))) {
+      throw new RunAbortedError();
     }
 
     // Append tool results to local API history.
@@ -2241,6 +2271,10 @@ async function runAgentTurn(
       }
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
+      if ((err as Error).name === "RunAbortedError") {
+        completedCleanly = true;
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       setAgentErrorState(tabId, msg, serializeError(err));
       updateLastChatMessage(tabId, (m) =>
@@ -2431,6 +2465,10 @@ async function runAgentTurn(
     completedCleanly = !controller.signal.aborted;
   } catch (err) {
     if ((err as Error).name === "AbortError") return;
+    if ((err as Error).name === "RunAbortedError") {
+      completedCleanly = true;
+      return;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     setAgentErrorState(tabId, msg, serializeError(err));
     updateLastChatMessage(tabId, (m) =>
@@ -2997,7 +3035,7 @@ async function agentLoop(
         // For exec_run, stream output chunks into the tool call display.
         let streamBuf = "";
         const callbacks: DispatchCallbacks | undefined =
-          tc.function.name === "exec_run"
+          shouldStreamToolOutput(tc.function.name)
             ? {
                 onExecOutput: (_stream, data) => {
                   streamBuf += data;
@@ -3026,6 +3064,9 @@ async function agentLoop(
       }),
     );
     if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
+    if (toolResults.some(({ result }) => isRunAbortedToolResult(result))) {
+      throw new RunAbortedError();
+    }
 
     // Append tool result messages to API history
     const toolApiMessages: ApiMessage[] = toolResults.map(

--- a/src/agent/sessionRestore.test.ts
+++ b/src/agent/sessionRestore.test.ts
@@ -37,6 +37,8 @@ function makeSession(
     mode: "workspace",
     tabTitle: "Ship tab restore",
     cwd: "/repo",
+    projectPath: "/repo",
+    setupCommand: "npm install",
     model: "openai/gpt-5.2",
     planMarkdown: "plan",
     planVersion: 2,
@@ -94,6 +96,8 @@ describe("sessionRestore", () => {
     expect(state.tabTitle).toBe(session.tabTitle);
     expect(state.config).toMatchObject({
       cwd: session.cwd,
+      projectPath: session.projectPath,
+      setupCommand: session.setupCommand,
       model: session.model,
       worktreePath: session.worktreePath,
       worktreeBranch: session.worktreeBranch,

--- a/src/agent/sessionRestore.ts
+++ b/src/agent/sessionRestore.ts
@@ -86,6 +86,8 @@ export function hydratePersistedSession(
     tabTitle: session.tabTitle,
     config: {
       cwd: session.cwd,
+      projectPath: session.projectPath || undefined,
+      setupCommand: session.setupCommand || undefined,
       model: session.model,
       worktreePath: session.worktreePath || undefined,
       worktreeBranch: session.worktreeBranch || undefined,

--- a/src/agent/tools/git.test.ts
+++ b/src/agent/tools/git.test.ts
@@ -4,6 +4,7 @@ type MockAgentState = {
   config: {
     cwd: string;
     model: string;
+    setupCommand?: string;
     worktreePath?: string;
     worktreeBranch?: string;
     worktreeDeclined?: boolean;
@@ -21,6 +22,7 @@ type MockAgentState = {
         | "pending"
         | "awaiting_approval"
         | "awaiting_worktree"
+        | "awaiting_setup_action"
         | "running"
         | "done"
         | "error"
@@ -43,12 +45,16 @@ type MockAgentState = {
 const {
   invokeMock,
   requestWorktreeApprovalMock,
+  requestWorktreeSetupActionMock,
+  execRunMock,
   states,
   getAgentStateMock,
   patchAgentStateMock,
 } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   requestWorktreeApprovalMock: vi.fn(),
+  requestWorktreeSetupActionMock: vi.fn(),
+  execRunMock: vi.fn(),
   states: {} as Record<string, MockAgentState>,
   getAgentStateMock: vi.fn(),
   patchAgentStateMock: vi.fn(),
@@ -61,6 +67,8 @@ vi.mock("@tauri-apps/api/core", () => ({
 vi.mock("../approvals", () => ({
   requestWorktreeApproval: (...args: unknown[]) =>
     requestWorktreeApprovalMock(...args),
+  requestWorktreeSetupAction: (...args: unknown[]) =>
+    requestWorktreeSetupActionMock(...args),
 }));
 
 vi.mock("../atoms", () => ({
@@ -68,7 +76,18 @@ vi.mock("../atoms", () => ({
   patchAgentState: (...args: unknown[]) => patchAgentStateMock(...args),
 }));
 
+vi.mock("./exec", () => ({
+  execRun: (...args: unknown[]) => execRunMock(...args),
+}));
+
 import { gitWorktreeInit } from "./git";
+
+function setNavigatorPlatform(value: string) {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { platform: value },
+  });
+}
 
 function makeState(overrides?: Partial<MockAgentState>): MockAgentState {
   return {
@@ -112,8 +131,11 @@ describe("gitWorktreeInit", () => {
   beforeEach(() => {
     invokeMock.mockReset();
     requestWorktreeApprovalMock.mockReset();
+    requestWorktreeSetupActionMock.mockReset();
+    execRunMock.mockReset();
     getAgentStateMock.mockReset();
     patchAgentStateMock.mockReset();
+    setNavigatorPlatform("MacIntel");
 
     for (const key of Object.keys(states)) {
       delete states[key];
@@ -263,6 +285,7 @@ describe("gitWorktreeInit", () => {
       data: {
         path: "/backend/worktrees/owner/repo/feature-name",
         branch: "feature-name",
+        setup: { status: "not_configured" },
       },
     });
     expect(invokeMock).toHaveBeenNthCalledWith(3, "git_worktree_add", {
@@ -320,11 +343,347 @@ describe("gitWorktreeInit", () => {
       data: {
         path: "/custom/root/worktrees/owner/repo/feature",
         branch: "feature",
+        setup: { status: "not_configured" },
       },
     });
     expect(states.tab.config.cwd).toBe(
       "/custom/root/worktrees/owner/repo/feature",
     );
+  });
+
+  it("runs the saved setup command inside the new worktree and returns success metadata", async () => {
+    setState("tab", {
+      config: {
+        cwd: "/repo",
+        model: "openai/gpt-5.2",
+        setupCommand: "npm install",
+      },
+    });
+
+    invokeMock
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "/tmp/repo\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "git@github.com:owner/repo.git\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        path: "/backend/worktrees/owner/repo/feature-name",
+        branch: "feature-name",
+      });
+    requestWorktreeApprovalMock.mockResolvedValueOnce({
+      approved: true,
+      branchName: "Feature Name!!",
+    });
+    execRunMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        command: "sh",
+        args: ["-lc", "npm install"],
+        cwd: "/backend/worktrees/owner/repo/feature-name",
+        exitCode: 0,
+        durationMs: 3210,
+        stdout: "installed",
+        stderr: "",
+        truncatedStdout: false,
+        truncatedStderr: false,
+      },
+    });
+
+    const result = await gitWorktreeInit("tab", "tc-1", "/repo", {
+      suggestedBranch: "ignored-on-approve",
+    });
+
+    expect(execRunMock).toHaveBeenCalledWith(
+      "/backend/worktrees/owner/repo/feature-name",
+      {
+        command: "sh",
+        args: ["-lc", "npm install"],
+        runId: "tc-1",
+      },
+      undefined,
+    );
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        path: "/backend/worktrees/owner/repo/feature-name",
+        branch: "feature-name",
+        setup: {
+          status: "success",
+          command: "npm install",
+          cwd: "/backend/worktrees/owner/repo/feature-name",
+          attemptCount: 1,
+          exitCode: 0,
+          durationMs: 3210,
+          stdout: "installed",
+          stderr: "",
+          truncatedStdout: false,
+          truncatedStderr: false,
+          terminatedByUser: undefined,
+        },
+      },
+    });
+  });
+
+  it("continues without setup when the command fails and the user chooses continue", async () => {
+    setState("tab", {
+      config: {
+        cwd: "/repo",
+        model: "openai/gpt-5.2",
+        setupCommand: "npm install",
+      },
+    });
+
+    invokeMock
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "/tmp/repo\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "git@github.com:owner/repo.git\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+      });
+    requestWorktreeApprovalMock.mockResolvedValueOnce({
+      approved: true,
+      branchName: "feature",
+    });
+    execRunMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        command: "sh",
+        args: ["-lc", "npm install"],
+        cwd: "/backend/worktrees/owner/repo/feature",
+        exitCode: 1,
+        durationMs: 1500,
+        stdout: "partial",
+        stderr: "install failed",
+        truncatedStdout: false,
+        truncatedStderr: false,
+      },
+    });
+    requestWorktreeSetupActionMock.mockResolvedValueOnce({ action: "continue" });
+
+    const result = await gitWorktreeInit("tab", "tc-1", "/repo", {
+      suggestedBranch: "feature",
+    });
+
+    expect(requestWorktreeSetupActionMock).toHaveBeenCalledWith("tab", "tc-1");
+    expect(states.tab.chatMessages[0].toolCalls?.[0]).toMatchObject({
+      status: "awaiting_setup_action",
+      args: {
+        setupPhase: "setup_failed",
+        setupAttemptCount: 1,
+      },
+      result: {
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+        setup: expect.objectContaining({
+          status: "failed_pending",
+          errorMessage: "Setup command exited with code 1.",
+        }),
+      },
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+        setup: {
+          status: "failed_continued",
+          command: "npm install",
+          cwd: "/backend/worktrees/owner/repo/feature",
+          attemptCount: 1,
+          exitCode: 1,
+          durationMs: 1500,
+          stdout: "partial",
+          stderr: "install failed",
+          truncatedStdout: false,
+          truncatedStderr: false,
+          terminatedByUser: undefined,
+          errorMessage: "Setup command exited with code 1.",
+        },
+      },
+    });
+  });
+
+  it("retries the setup command after a failure and returns the successful retry", async () => {
+    setState("tab", {
+      config: {
+        cwd: "/repo",
+        model: "openai/gpt-5.2",
+        setupCommand: "npm install",
+      },
+    });
+
+    invokeMock
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "/tmp/repo\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "git@github.com:owner/repo.git\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+      });
+    requestWorktreeApprovalMock.mockResolvedValueOnce({
+      approved: true,
+      branchName: "feature",
+    });
+    execRunMock
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          command: "sh",
+          args: ["-lc", "npm install"],
+          cwd: "/backend/worktrees/owner/repo/feature",
+          exitCode: 1,
+          durationMs: 1200,
+          stdout: "",
+          stderr: "first failure",
+          truncatedStdout: false,
+          truncatedStderr: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          command: "sh",
+          args: ["-lc", "npm install"],
+          cwd: "/backend/worktrees/owner/repo/feature",
+          exitCode: 0,
+          durationMs: 900,
+          stdout: "done",
+          stderr: "",
+          truncatedStdout: false,
+          truncatedStderr: false,
+        },
+      });
+    requestWorktreeSetupActionMock.mockResolvedValueOnce({ action: "retry" });
+
+    const onSetupOutput = vi.fn();
+    const result = await gitWorktreeInit(
+      "tab",
+      "tc-1",
+      "/repo",
+      { suggestedBranch: "feature" },
+      onSetupOutput,
+    );
+
+    expect(execRunMock).toHaveBeenCalledTimes(2);
+    expect(onSetupOutput).toHaveBeenCalledWith(
+      "stdout",
+      "\nRetrying setup command (attempt 2)...\n",
+    );
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+        setup: {
+          status: "success",
+          command: "npm install",
+          cwd: "/backend/worktrees/owner/repo/feature",
+          attemptCount: 2,
+          exitCode: 0,
+          durationMs: 900,
+          stdout: "done",
+          stderr: "",
+          truncatedStdout: false,
+          truncatedStderr: false,
+          terminatedByUser: undefined,
+        },
+      },
+    });
+  });
+
+  it("returns RUN_ABORTED when the user aborts after setup failure", async () => {
+    setState("tab", {
+      config: {
+        cwd: "/repo",
+        model: "openai/gpt-5.2",
+        setupCommand: "npm install",
+      },
+    });
+
+    invokeMock
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "/tmp/repo\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "git@github.com:owner/repo.git\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        path: "/backend/worktrees/owner/repo/feature",
+        branch: "feature",
+      });
+    requestWorktreeApprovalMock.mockResolvedValueOnce({
+      approved: true,
+      branchName: "feature",
+    });
+    execRunMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        command: "sh",
+        args: ["-lc", "npm install"],
+        cwd: "/backend/worktrees/owner/repo/feature",
+        exitCode: 2,
+        durationMs: 700,
+        stdout: "",
+        stderr: "bad state",
+        truncatedStdout: false,
+        truncatedStderr: false,
+      },
+    });
+    requestWorktreeSetupActionMock.mockResolvedValueOnce({ action: "abort" });
+
+    const result = await gitWorktreeInit("tab", "tc-1", "/repo", {
+      suggestedBranch: "feature",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "RUN_ABORTED",
+        message: "User aborted the agent run after setup failed.",
+        details: {
+          path: "/backend/worktrees/owner/repo/feature",
+          branch: "feature",
+          setup: {
+            status: "failed_pending",
+            command: "npm install",
+            cwd: "/backend/worktrees/owner/repo/feature",
+            attemptCount: 1,
+            exitCode: 2,
+            durationMs: 700,
+            stdout: "",
+            stderr: "bad state",
+            truncatedStdout: false,
+            truncatedStderr: false,
+            terminatedByUser: undefined,
+            errorMessage: "Setup command exited with code 2.",
+          },
+        },
+      },
+    });
   });
 
   it("returns INTERNAL when git_worktree_add fails", async () => {

--- a/src/agent/tools/git.ts
+++ b/src/agent/tools/git.ts
@@ -4,25 +4,57 @@
  * git_worktree_init: called by the agent before its first file write.
  * Presents a custom approval card to the user who can name the branch;
  * on approval, asks the backend to create a worktree under the active app
- * store root and updates AgentConfig.cwd to the returned path.
+ * store root, optionally runs the saved project setup command, and updates
+ * AgentConfig.cwd to the returned path.
  */
 import { invoke } from "@tauri-apps/api/core";
 import { getAgentState, patchAgentState } from "../atoms";
-import { requestWorktreeApproval } from "../approvals";
+import {
+  requestWorktreeApproval,
+  requestWorktreeSetupAction,
+} from "../approvals";
+import { execRun, type ExecRunOutput } from "./exec";
 import type { ToolResult } from "../types";
 
 export interface GitWorktreeInitInput {
   suggestedBranch: string;
 }
 
+export interface GitWorktreeSetupOutput {
+  status: "not_configured" | "success" | "failed_continued";
+  command?: string;
+  cwd?: string;
+  attemptCount?: number;
+  exitCode?: number;
+  durationMs?: number;
+  stdout?: string;
+  stderr?: string;
+  truncatedStdout?: boolean;
+  truncatedStderr?: boolean;
+  terminatedByUser?: boolean;
+  errorMessage?: string;
+}
+
+interface PendingGitWorktreeSetupOutput
+  extends Omit<GitWorktreeSetupOutput, "status"> {
+  status: "failed_pending";
+}
+
+type GitWorktreeSetupState =
+  | GitWorktreeSetupOutput
+  | PendingGitWorktreeSetupOutput;
+
 export interface GitWorktreeInitOutput {
   alreadyExists?: boolean;
   declined?: boolean;
   path?: string;
   branch?: string;
+  setup?: GitWorktreeSetupOutput;
 }
 
-/** Sanitise a branch name suggestion into something git-safe. */
+type OutputStream = "stdout" | "stderr";
+type OutputCallback = (stream: OutputStream, data: string) => void;
+
 function sanitiseBranch(raw: string): string {
   return raw
     .toLowerCase()
@@ -32,18 +64,10 @@ function sanitiseBranch(raw: string): string {
     .slice(0, 80) || "agent-branch";
 }
 
-/**
- * Parse a git remote URL into an "owner/repo" slug.
- * Handles HTTPS (https://github.com/owner/repo.git) and
- * SSH (git@github.com:owner/repo.git) formats.
- * Falls back to just the repo name if parsing fails.
- */
 function parseRemoteSlug(remoteUrl: string, fallbackName: string): string {
   const trimmed = remoteUrl.trim();
-  // HTTPS: https://host/owner/repo[.git]
   const httpsMatch = trimmed.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
   if (httpsMatch) return httpsMatch[1];
-  // SSH: git@host:owner/repo[.git]
   const sshMatch = trimmed.match(/[^@]+@[^:]+:(.+?)(?:\.git)?$/);
   if (sshMatch) return sshMatch[1];
   return fallbackName;
@@ -53,16 +77,177 @@ function trimEdgeSlashes(value: string): string {
   return value.replace(/^\/+|\/+$/g, "");
 }
 
+function updateWorktreeToolCall(
+  tabId: string,
+  toolCallId: string,
+  patch: {
+    status?: "awaiting_worktree" | "awaiting_setup_action" | "running";
+    result?: unknown;
+    streamingOutput?: string;
+    argPatch?: Record<string, unknown>;
+  },
+): void {
+  patchAgentState(tabId, (prev) => ({
+    ...prev,
+    chatMessages: prev.chatMessages.map((message) =>
+      message.toolCalls
+        ? {
+            ...message,
+            toolCalls: message.toolCalls.map((toolCall) =>
+              toolCall.id === toolCallId
+                ? {
+                    ...toolCall,
+                    ...(patch.status ? { status: patch.status } : {}),
+                    ...(patch.result !== undefined ? { result: patch.result } : {}),
+                    ...(patch.streamingOutput !== undefined
+                      ? { streamingOutput: patch.streamingOutput }
+                      : {}),
+                    ...(patch.argPatch
+                      ? { args: { ...toolCall.args, ...patch.argPatch } }
+                      : {}),
+                  }
+                : toolCall,
+            ),
+          }
+        : message,
+    ),
+  }));
+}
+
+function getSetupCommand(tabId: string): string {
+  return getAgentState(tabId).config.setupCommand?.trim() ?? "";
+}
+
+function getSetupShell(command: string): { command: string; args: string[] } {
+  const platform = (navigator.platform ?? "").toLowerCase();
+  if (platform.includes("win")) {
+    return { command: "cmd.exe", args: ["/C", command] };
+  }
+  return { command: "sh", args: ["-lc", command] };
+}
+
+function getSetupFailureMessage(
+  exitCode: number | undefined,
+  terminatedByUser: boolean | undefined,
+  fallback?: string,
+): string {
+  if (terminatedByUser) {
+    return "Setup command was stopped.";
+  }
+  if (typeof exitCode === "number") {
+    return `Setup command exited with code ${exitCode}.`;
+  }
+  return fallback ?? "Setup command failed.";
+}
+
+function buildSetupFailure(
+  command: string,
+  cwd: string,
+  attemptCount: number,
+  errorMessage: string,
+): PendingGitWorktreeSetupOutput {
+  return {
+    status: "failed_pending",
+    command,
+    cwd,
+    attemptCount,
+    stdout: "",
+    stderr: errorMessage,
+    errorMessage,
+  };
+}
+
+function buildSetupStateFromExecOutput(
+  setupCommand: string,
+  output: ExecRunOutput,
+  attemptCount: number,
+): GitWorktreeSetupState {
+  const base = {
+    command: setupCommand,
+    cwd: output.cwd,
+    attemptCount,
+    exitCode: output.exitCode,
+    durationMs: output.durationMs,
+    stdout: output.stdout,
+    stderr: output.stderr,
+    truncatedStdout: output.truncatedStdout,
+    truncatedStderr: output.truncatedStderr,
+    terminatedByUser: output.terminatedByUser,
+  };
+
+  if (output.terminatedByUser || output.exitCode !== 0) {
+    return {
+      ...base,
+      status: "failed_pending",
+      errorMessage: getSetupFailureMessage(
+        output.exitCode,
+        output.terminatedByUser,
+      ),
+    };
+  }
+
+  return {
+    ...base,
+    status: "success",
+  };
+}
+
+async function runSetupAttempt(
+  tabId: string,
+  toolCallId: string,
+  worktreePath: string,
+  setupCommand: string,
+  attemptCount: number,
+  onSetupOutput?: OutputCallback,
+): Promise<GitWorktreeSetupState> {
+  if (attemptCount > 1) {
+    onSetupOutput?.(
+      "stdout",
+      `\nRetrying setup command (attempt ${attemptCount})...\n`,
+    );
+  }
+
+  const shell = getSetupShell(setupCommand);
+  const result = await execRun(
+    worktreePath,
+    {
+      command: shell.command,
+      args: shell.args,
+      runId: toolCallId,
+    },
+    onSetupOutput,
+  );
+
+  if (!result.ok) {
+    const errorMessage =
+      result.error.code === "TIMEOUT"
+        ? "Setup command timed out."
+        : result.error.message;
+    return buildSetupFailure(
+      setupCommand,
+      worktreePath,
+      attemptCount,
+      errorMessage,
+    );
+  }
+
+  return buildSetupStateFromExecOutput(
+    setupCommand,
+    result.data,
+    attemptCount,
+  );
+}
+
 export async function gitWorktreeInit(
   tabId: string,
   toolCallId: string,
   agentCwd: string,
   input: GitWorktreeInitInput,
+  onSetupOutput?: OutputCallback,
 ): Promise<ToolResult<GitWorktreeInitOutput>> {
   const state = getAgentState(tabId);
   const config = state.config;
 
-  // 1. Idempotent — already set up
   if (config.worktreePath) {
     return {
       ok: true,
@@ -74,12 +259,10 @@ export async function gitWorktreeInit(
     };
   }
 
-  // 2. User already declined — don't ask again
   if (config.worktreeDeclined) {
     return { ok: true, data: { declined: true } };
   }
 
-  // 3. Detect git repo root
   let repoRoot: string;
   try {
     const result = await invoke<{
@@ -106,14 +289,13 @@ export async function gitWorktreeInit(
       };
     }
     repoRoot = result.stdout.trim();
-  } catch (e) {
+  } catch (error) {
     return {
       ok: false,
-      error: { code: "INTERNAL", message: `git rev-parse failed: ${e}` },
+      error: { code: "INTERNAL", message: `git rev-parse failed: ${error}` },
     };
   }
 
-  // 4. Derive owner/repo slug from remote URL
   const repoName = repoRoot.split("/").filter(Boolean).pop() ?? "repo";
   let slug = repoName;
   try {
@@ -134,41 +316,22 @@ export async function gitWorktreeInit(
       slug = parseRemoteSlug(result.stdout, repoName);
     }
   } catch {
-    // No remote — fall back to repo dir name
+    // No remote — fall back to repo dir name.
   }
 
-  // 5. Build worktree path proposal
   const sanitised = sanitiseBranch(input.suggestedBranch || "agent-branch");
   const repoSlug = trimEdgeSlashes(slug) || repoName;
-  // 6. Update the tool call display status so the UI renders the custom card,
-  //    then block until the user makes a decision.
-  patchAgentState(tabId, (prev) => ({
-    ...prev,
-    chatMessages: prev.chatMessages.map((m) =>
-      m.toolCalls
-        ? {
-            ...m,
-            toolCalls: m.toolCalls.map((t) =>
-              t.id === toolCallId
-                ? {
-                    ...t,
-                    status: "awaiting_worktree" as const,
-                    args: {
-                      ...t.args,
-                      suggestedBranch: input.suggestedBranch,
-                      repoSlug,
-                    },
-                  }
-                : t,
-            ),
-          }
-        : m,
-    ),
-  }));
+  updateWorktreeToolCall(tabId, toolCallId, {
+    status: "awaiting_worktree",
+    argPatch: {
+      suggestedBranch: input.suggestedBranch,
+      repoSlug,
+      setupCommand: config.setupCommand ?? "",
+    },
+  });
 
   const { approved, branchName } = await requestWorktreeApproval(tabId, toolCallId);
 
-  // 7. User declined
   if (!approved) {
     patchAgentState(tabId, (prev) => ({
       ...prev,
@@ -177,7 +340,6 @@ export async function gitWorktreeInit(
     return { ok: true, data: { declined: true } };
   }
 
-  // 8. Create the worktree
   const finalBranch = sanitiseBranch(branchName || sanitised);
   let finalPath: string;
 
@@ -191,17 +353,16 @@ export async function gitWorktreeInit(
       },
     );
     finalPath = created.path;
-  } catch (e) {
+  } catch (error) {
     return {
       ok: false,
       error: {
         code: "INTERNAL",
-        message: `Failed to create worktree: ${e}`,
+        message: `Failed to create worktree: ${error}`,
       },
     };
   }
 
-  // 9. Update AgentConfig — cwd switches to the new worktree
   patchAgentState(tabId, (prev) => ({
     ...prev,
     config: {
@@ -212,8 +373,103 @@ export async function gitWorktreeInit(
     },
   }));
 
-  return {
-    ok: true,
-    data: { path: finalPath, branch: finalBranch },
-  };
+  updateWorktreeToolCall(tabId, toolCallId, {
+    status: "running",
+    argPatch: {
+      branch: finalBranch,
+      worktreePath: finalPath,
+    },
+  });
+
+  let attemptCount = 0;
+  while (true) {
+    const setupCommand = getSetupCommand(tabId);
+    if (!setupCommand) {
+      return {
+        ok: true,
+        data: {
+          path: finalPath,
+          branch: finalBranch,
+          setup: { status: "not_configured" },
+        },
+      };
+    }
+
+    attemptCount += 1;
+    updateWorktreeToolCall(tabId, toolCallId, {
+      status: "running",
+      argPatch: {
+        setupCommand,
+        setupPhase: "running_setup",
+        setupAttemptCount: attemptCount,
+      },
+    });
+
+    const setupAttempt = await runSetupAttempt(
+      tabId,
+      toolCallId,
+      finalPath,
+      setupCommand,
+      attemptCount,
+      onSetupOutput,
+    );
+
+    if (setupAttempt.status === "success") {
+      return {
+        ok: true,
+        data: {
+          path: finalPath,
+          branch: finalBranch,
+          setup: setupAttempt,
+        },
+      };
+    }
+
+    updateWorktreeToolCall(tabId, toolCallId, {
+      status: "awaiting_setup_action",
+      result: {
+        path: finalPath,
+        branch: finalBranch,
+        setup: setupAttempt,
+      },
+      argPatch: {
+        setupCommand,
+        setupPhase: "setup_failed",
+        setupAttemptCount: attemptCount,
+      },
+    });
+
+    const { action } = await requestWorktreeSetupAction(tabId, toolCallId);
+
+    if (action === "retry") {
+      continue;
+    }
+
+    if (action === "abort") {
+      return {
+        ok: false,
+        error: {
+          code: "RUN_ABORTED",
+          message: "User aborted the agent run after setup failed.",
+          details: {
+            path: finalPath,
+            branch: finalBranch,
+            setup: setupAttempt,
+          },
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        path: finalPath,
+        branch: finalBranch,
+        setup: {
+          ...setupAttempt,
+          status: "failed_continued",
+        },
+      },
+    };
+  }
 }

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -354,7 +354,11 @@ describe("tools/index dispatchTool", () => {
   it("passes toolCallId to git_worktree_init", async () => {
     gitWorktreeInitMock.mockResolvedValue({
       ok: true,
-      data: { path: "/tmp/worktree", branch: "codex/feature" },
+      data: {
+        path: "/tmp/worktree",
+        branch: "codex/feature",
+        setup: { status: "not_configured" },
+      },
     });
 
     const result = await dispatchTool(
@@ -370,8 +374,38 @@ describe("tools/index dispatchTool", () => {
       "tool-call-7",
       "/cwd",
       { suggestedBranch: "feature branch" },
+      undefined,
     );
     expect(result).toMatchObject({ ok: true });
+  });
+
+  it("passes onExecOutput callback to git_worktree_init when callbacks provided", async () => {
+    gitWorktreeInitMock.mockResolvedValue({
+      ok: true,
+      data: {
+        path: "/tmp/worktree",
+        branch: "codex/feature",
+        setup: { status: "not_configured" },
+      },
+    });
+
+    const onExecOutput = vi.fn();
+    await dispatchTool(
+      "tab",
+      "/cwd",
+      "git_worktree_init",
+      { suggestedBranch: "feature branch" },
+      "tool-call-7b",
+      { onExecOutput },
+    );
+
+    expect(gitWorktreeInitMock).toHaveBeenCalledWith(
+      "tab",
+      "tool-call-7b",
+      "/cwd",
+      { suggestedBranch: "feature branch" },
+      onExecOutput,
+    );
   });
 
   it("passes toolCallId to exec_run as runId", async () => {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -182,7 +182,7 @@ export async function dispatchTool(
 
     /* ── git ─────────────────────────────────────────────────────────────────────────── */
     case "git_worktree_init":
-      return gitWorktreeInit(tabId, toolCallId, cwd, a);
+      return gitWorktreeInit(tabId, toolCallId, cwd, a, callbacks?.onExecOutput);
 
     /* ── exec ──────────────────────────────────────────────────────────────────────── */
     case "exec_run":

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -11,6 +11,7 @@ export type ToolErrorCode =
   | "CONFLICT"
   | "TOO_LARGE"
   | "TIMEOUT"
+  | "RUN_ABORTED"
   | "INTERNAL";
 
 export interface ToolError {
@@ -146,6 +147,7 @@ export interface ToolCallDisplay {
     | "pending"
     | "awaiting_approval"
     | "awaiting_worktree"
+    | "awaiting_setup_action"
     | "running"
     | "done"
     | "error"
@@ -270,6 +272,10 @@ export interface AgentConfig {
   model: string;
   /** Context window size in tokens, as reported by model catalog for the selected model */
   contextLength?: number;
+  /** Absolute path to the originally selected project root */
+  projectPath?: string;
+  /** Optional project-scoped setup command run after worktree creation */
+  setupCommand?: string;
   /** Absolute path to the git worktree created for this session (set once, never changed) */
   worktreePath?: string;
   /** Git branch name for the worktree */

--- a/src/components/AgentNotificationManager.test.tsx
+++ b/src/components/AgentNotificationManager.test.tsx
@@ -46,6 +46,8 @@ function makeSession(id: string, label: string): PersistedSession {
     worktreePath: "",
     worktreeBranch: "",
     worktreeDeclined: false,
+    projectPath: "",
+    setupCommand: "",
     showDebug: false,
     communicationProfile: "pragmatic",
     advancedOptions: "{}",

--- a/src/components/AgentNotificationManager.tsx
+++ b/src/components/AgentNotificationManager.tsx
@@ -16,7 +16,8 @@ function getAttentionToolCalls(tabId: string): ToolCallDisplay[] {
     .filter(
       (toolCall) =>
         toolCall.status === "awaiting_approval" ||
-        toolCall.status === "awaiting_worktree",
+        toolCall.status === "awaiting_worktree" ||
+        toolCall.status === "awaiting_setup_action",
     );
 }
 

--- a/src/components/CompactToolCall.tsx
+++ b/src/components/CompactToolCall.tsx
@@ -99,6 +99,7 @@ const STATUS_DOT: Record<string, string> = {
   done: "done",
   error: "error",
   denied: "error",
+  awaiting_setup_action: "error",
 };
 
 function truncateText(value: string, max = 56): string {
@@ -675,6 +676,8 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
   const args = tc.args;
   const suggestedBranch =
     typeof args.suggestedBranch === "string" ? args.suggestedBranch : "";
+  const setupCommand =
+    typeof args.setupCommand === "string" ? args.setupCommand.trim() : "";
 
   const resultRecord =
     tc.result && typeof tc.result === "object"
@@ -687,6 +690,28 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
     typeof resultRecord?.path === "string" ? resultRecord.path : null;
   const alreadyExists = resultRecord?.alreadyExists === true;
   const declined = resultRecord?.declined === true;
+  const setup =
+    resultRecord?.setup && typeof resultRecord.setup === "object"
+      ? (resultRecord.setup as Record<string, unknown>)
+      : resultRecord?.details &&
+          typeof resultRecord.details === "object" &&
+          (resultRecord.details as Record<string, unknown>).setup &&
+          typeof (resultRecord.details as Record<string, unknown>).setup === "object"
+        ? ((resultRecord.details as Record<string, unknown>)
+            .setup as Record<string, unknown>)
+        : null;
+  const setupStatus =
+    typeof setup?.status === "string" ? setup.status : null;
+  const setupStdout =
+    typeof setup?.stdout === "string" ? setup.stdout.trimEnd() : "";
+  const setupStderr =
+    typeof setup?.stderr === "string" ? setup.stderr.trimEnd() : "";
+  const setupErrorMessage =
+    typeof setup?.errorMessage === "string" ? setup.errorMessage : null;
+  const setupAttemptCount =
+    typeof setup?.attemptCount === "number" ? setup.attemptCount : null;
+  const setupExitCode =
+    typeof setup?.exitCode === "number" ? setup.exitCode : null;
 
   const errorMessage =
     tc.status === "error" && typeof resultRecord?.message === "string"
@@ -702,6 +727,11 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
         Suggested branch:{" "}
         <span className="font-mono">{suggestedBranch || "(not provided)"}</span>
       </div>
+      {setupCommand ? (
+        <div className="text-xxs text-muted leading-[1.55] mt-1">
+          Setup: <span className="font-mono">{setupCommand}</span>
+        </div>
+      ) : null}
 
       {tc.status === "running" && (
         <div className="text-xxs text-muted mt-1">Preparing worktree...</div>
@@ -726,11 +756,24 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
               Path: <span className="font-mono break-all">{path}</span>
             </div>
           )}
+          {setupStatus === "not_configured" && <div>Setup: not configured</div>}
+          {setupStatus === "success" && <div>Setup: completed</div>}
+          {setupStatus === "failed_continued" && (
+            <div>Setup: failed, continued anyway</div>
+          )}
+          {setupAttemptCount ? <div>Setup attempts: {setupAttemptCount}</div> : null}
+          {setupExitCode !== null ? <div>Setup exit code: {setupExitCode}</div> : null}
+          {setupErrorMessage ? <div>Setup note: {setupErrorMessage}</div> : null}
           {!declined && !path && !branch && !alreadyExists && (
             <div>No worktree data returned.</div>
           )}
         </div>
       )}
+
+      {setupStdout ? <pre className="cmd-output mt-1">{setupStdout}</pre> : null}
+      {setupStderr ? (
+        <pre className="cmd-output cmd-output--error mt-1">{setupStderr}</pre>
+      ) : null}
     </div>
   );
 }
@@ -1110,11 +1153,13 @@ export default function CompactToolCall({
   const isExpandable =
     tc.status !== "awaiting_approval" &&
     tc.status !== "awaiting_worktree" &&
+    tc.status !== "awaiting_setup_action" &&
     !NON_EXPANDABLE_TOOLS.has(tc.tool);
   const isInspectable =
     showDebug &&
     tc.status !== "awaiting_approval" &&
-    tc.status !== "awaiting_worktree";
+    tc.status !== "awaiting_worktree" &&
+    tc.status !== "awaiting_setup_action";
 
   const icon = TOOL_ICON[tc.tool] ?? "build";
   const label = TOOL_LABEL[tc.tool] ?? tc.tool;

--- a/src/components/NewSession.tsx
+++ b/src/components/NewSession.tsx
@@ -15,7 +15,10 @@ import { cn } from "@/utils/cn";
 import { useTabs } from "@/contexts/TabsContext";
 import NewSessionModelSelector from "@/components/NewSessionModelSelector";
 import ProviderSetupHint from "@/components/ProviderSetupHint";
-import { Button } from "@/components/ui";
+import ProjectSettingsModal, {
+  type ProjectSettingsSavePayload,
+} from "@/components/ProjectSettingsModal";
+import { Button, IconButton } from "@/components/ui";
 import type {
   AdvancedModelOptions,
   LatencyCostProfile,
@@ -23,31 +26,15 @@ import type {
   ReasoningVisibility,
 } from "@/agent/types";
 import { DEFAULT_ADVANCED_OPTIONS } from "@/agent/types";
-
-/* ─────────────────────────────────────────────────────────────────────────────
-   Projects
-───────────────────────────────────────────────────────────────────────────── */
-
-type Project = { path: string; name: string };
-
-const PROJECTS_STORAGE_KEY = "rakh-projects";
-
-function loadProjects(): Project[] {
-  try {
-    const stored = localStorage.getItem(PROJECTS_STORAGE_KEY);
-    return stored ? JSON.parse(stored) : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveProjects(projects: Project[]) {
-  try {
-    localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects));
-  } catch (error) {
-    console.error("Failed to save projects:", error);
-  }
-}
+import {
+  loadSavedProjects,
+  removeSavedProject,
+  resolveSavedProject,
+  resolveSavedProjects,
+  upsertSavedProject,
+  type SavedProject,
+} from "@/projects";
+import { writeProjectScriptsConfig } from "@/projectScripts";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Advanced options — localStorage helpers
@@ -99,7 +86,7 @@ function saveAdvancedOptions(opts: AdvancedModelOptions) {
 interface NewSessionProps {
   onSubmit: (
     message: string,
-    cwd: string,
+    project: { path: string; setupCommand?: string } | null,
     model: string,
     contextLength?: number,
     advancedOptions?: AdvancedModelOptions,
@@ -109,15 +96,20 @@ interface NewSessionProps {
 
 export default function NewSession({ onSubmit }: NewSessionProps) {
   const [input, setInput] = useState("");
-  const [projects, setProjects] = useState<Project[]>(loadProjects);
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [projects, setProjects] = useState<SavedProject[]>(loadSavedProjects);
+  const [selectedProject, setSelectedProject] = useState<SavedProject | null>(
+    null,
+  );
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [focused, setFocused] = useState(false);
-  const [advancedOptions, setAdvancedOptions] = useState<AdvancedModelOptions>(loadAdvancedOptions);
-  
-  // Note: the global default profile handles the fallback later if not provided, but we map it locally if they change it.
-  const [communicationProfile, setCommunicationProfile] = useState<string>("global");
+  const [advancedOptions, setAdvancedOptions] =
+    useState<AdvancedModelOptions>(loadAdvancedOptions);
+  const [projectSettingsProject, setProjectSettingsProject] =
+    useState<SavedProject | null>(null);
+  // The global default profile handles fallback later if not provided.
+  const [communicationProfile, setCommunicationProfile] =
+    useState<string>("global");
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -139,6 +131,22 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
       setSelectedModel(providerModels[0].id);
     }
   }, [providerModels, selectedModel, setSelectedModel]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void resolveSavedProjects(loadSavedProjects()).then((resolved) => {
+      if (cancelled) return;
+      setProjects(resolved);
+      setSelectedProject((prev) =>
+        prev ? resolved.find((project) => project.path === prev.path) ?? prev : prev,
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   /* ── Auto-resize textarea ──────────────────────────────────────────────── */
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -171,37 +179,57 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
       const text = input.trim();
       const ctxLen = selectedModelObj?.context_length;
       if (text) {
-        onSubmit(text, selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions, communicationProfile);
+        onSubmit(
+          text,
+          selectedProject
+            ? {
+                path: selectedProject.path,
+                ...(selectedProject.setupCommand
+                  ? { setupCommand: selectedProject.setupCommand }
+                  : {}),
+              }
+            : null,
+          selectedModelObj.id,
+          ctxLen,
+          advancedOptions,
+          communicationProfile,
+        );
       } else {
-        onSubmit("", selectedProject?.path ?? "", selectedModelObj.id, ctxLen, advancedOptions, communicationProfile);
+        onSubmit(
+          "",
+          selectedProject
+            ? {
+                path: selectedProject.path,
+                ...(selectedProject.setupCommand
+                  ? { setupCommand: selectedProject.setupCommand }
+                  : {}),
+              }
+            : null,
+          selectedModelObj.id,
+          ctxLen,
+          advancedOptions,
+          communicationProfile,
+        );
       }
     }
   };
 
-  const selectProject = (p: Project) => {
+  const selectProject = (p: SavedProject) => {
     setSelectedProject(p);
     setDropdownOpen(false);
     textareaRef.current?.focus();
   };
 
-  /* ── Persist projects to localStorage whenever they change ────────────────── */
-  useEffect(() => {
-    saveProjects(projects);
-  }, [projects]);
-
-  const addProject = useCallback((path: string) => {
+  const addProject = useCallback(async (path: string) => {
     const name = path.split("/").filter(Boolean).pop() ?? path;
     const newProject = { path, name };
+    const savedProjects = upsertSavedProject(newProject);
+    const resolvedProjects = await resolveSavedProjects(savedProjects);
+    const resolvedProject =
+      resolvedProjects.find((project) => project.path === path) ?? newProject;
 
-    // Check if project already exists
-    setProjects((prev) => {
-      if (prev.some((p) => p.path === path)) {
-        return prev;
-      }
-      return [...prev, newProject];
-    });
-
-    setSelectedProject(newProject);
+    setProjects(resolvedProjects);
+    setSelectedProject(resolvedProject);
     setDropdownOpen(false);
     textareaRef.current?.focus();
   }, []);
@@ -209,12 +237,72 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
   const removeProject = useCallback(
     (e: React.SyntheticEvent, projectPath: string) => {
       e.stopPropagation();
-      setProjects((prev) => prev.filter((p) => p.path !== projectPath));
+      setProjects(removeSavedProject(projectPath));
       if (selectedProject?.path === projectPath) {
         setSelectedProject(null);
       }
     },
     [selectedProject],
+  );
+
+  const saveProjectSettings = useCallback(
+    async ({ project, writeProjectConfig }: ProjectSettingsSavePayload) => {
+      const nextProject = {
+        path: project.path,
+        name: project.name,
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      };
+
+      if (writeProjectConfig) {
+        await writeProjectScriptsConfig(project.path, {
+          ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+          ...(project.commands?.length ? { commands: project.commands } : {}),
+        });
+      }
+
+      const savedProjects = upsertSavedProject(nextProject);
+      const resolvedProjects = await resolveSavedProjects(savedProjects);
+      const resolvedProject =
+        resolvedProjects.find((entry) => entry.path === nextProject.path) ??
+        nextProject;
+
+      setProjects(resolvedProjects);
+      setSelectedProject((prev) =>
+        prev?.path === resolvedProject.path ? resolvedProject : prev,
+      );
+      setProjectSettingsProject(null);
+    },
+    [],
+  );
+
+  const createProjectConfig = useCallback(
+    async ({ project }: ProjectSettingsSavePayload) => {
+      const nextProject = {
+        path: project.path,
+        name: project.name,
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      };
+
+      await writeProjectScriptsConfig(project.path, {
+        ...(project.setupCommand ? { setupCommand: project.setupCommand } : {}),
+        ...(project.commands?.length ? { commands: project.commands } : {}),
+      });
+
+      const savedProjects = upsertSavedProject(nextProject);
+      const resolvedProjects = await resolveSavedProjects(savedProjects);
+      const resolvedProject =
+        resolvedProjects.find((entry) => entry.path === nextProject.path) ??
+        nextProject;
+
+      setProjects(resolvedProjects);
+      setSelectedProject((prev) =>
+        prev?.path === resolvedProject.path ? resolvedProject : prev,
+      );
+      setProjectSettingsProject(resolvedProject);
+    },
+    [],
   );
 
   const handleAddExistingFolder = async () => {
@@ -282,28 +370,29 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
         {/* ── Selector row: project + model ────────────────────────────── */}
         <div className="ns-selectors-row">
           {/* Project selector pill */}
-          <div className="ns-project-wrap" ref={dropdownRef}>
-            <Button
-              className="ns-project-btn"
-              variant="secondary"
-              size="sm"
-              onClick={() => setDropdownOpen((v) => !v)}
-            >
-              <span className="material-symbols-outlined text-lg">
-                account_tree
-              </span>
-              <span>
-                {selectedProject ? selectedProject.name : "Select Project"}
-              </span>
-              <span
-                className={cn(
-                  "material-symbols-outlined text-md transition-transform duration-200",
-                  dropdownOpen ? "rotate-180" : "rotate-0",
-                )}
+          <div className="ns-project-control">
+            <div className="ns-project-wrap" ref={dropdownRef}>
+              <Button
+                className="ns-project-btn"
+                variant="secondary"
+                size="sm"
+                onClick={() => setDropdownOpen((v) => !v)}
               >
-                expand_more
-              </span>
-            </Button>
+                <span className="material-symbols-outlined text-lg">
+                  account_tree
+                </span>
+                <span>
+                  {selectedProject ? selectedProject.name : "Select Project"}
+                </span>
+                <span
+                  className={cn(
+                    "material-symbols-outlined text-md transition-transform duration-200",
+                    dropdownOpen ? "rotate-180" : "rotate-0",
+                  )}
+                >
+                  expand_more
+                </span>
+              </Button>
 
             {/* Project dropdown */}
             {dropdownOpen && (
@@ -384,6 +473,17 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
                 </div>
               </div>
             )}
+            </div>
+            {selectedProject ? (
+              <IconButton
+                className="ns-project-settings-btn"
+                onClick={() => setProjectSettingsProject(selectedProject)}
+                title={`Project settings for ${selectedProject.name}`}
+                type="button"
+              >
+                <span className="material-symbols-outlined text-md">tune</span>
+              </IconButton>
+            ) : null}
           </div>
 
           <NewSessionModelSelector
@@ -464,6 +564,15 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
         <span>or Type Command</span>
       </footer>
       */}
+      {projectSettingsProject ? (
+        <ProjectSettingsModal
+          key={projectSettingsProject.path}
+          project={projectSettingsProject}
+          onClose={() => setProjectSettingsProject(null)}
+          onSave={saveProjectSettings}
+          onCreateProjectConfig={createProjectConfig}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectSettingsModal from "./ProjectSettingsModal";
+
+const PROJECT_COMMAND_ICONS = [
+  "play_arrow",
+  "settings",
+  "pest_control",
+  "cleaning_services",
+  "science",
+  "package_2",
+  "install_desktop",
+];
+
+describe("ProjectSettingsModal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("arms repo config creation and then shows the repo config path in the footer", async () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const onCreateProjectConfig = vi.fn();
+
+    render(
+      <ProjectSettingsModal
+        project={{ path: "/repo", name: "Repo" }}
+        onClose={onClose}
+        onSave={onSave}
+        onCreateProjectConfig={onCreateProjectConfig}
+      />,
+    );
+
+    screen.getByText("/repo");
+    expect(
+      screen.getByRole("button", { name: "CREATE REPO CONFIG FILE" }),
+    ).not.toBeNull();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("npm install && npm run build"),
+      { target: { value: "  npm install  " } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "ADD" }));
+    fireEvent.change(screen.getByPlaceholderText("Label (e.g. Run app)"), {
+      target: { value: " Run app " },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Command icon No icon" }),
+    );
+    for (const icon of PROJECT_COMMAND_ICONS) {
+      screen.getByRole("option", { name: icon });
+    }
+    fireEvent.click(screen.getByRole("option", { name: "play_arrow" }));
+    fireEvent.change(
+      screen.getByPlaceholderText("Command (e.g. npm run dev)"),
+      {
+        target: { value: " npm run dev " },
+      },
+    );
+    fireEvent.click(screen.getByTitle("Toggle label visibility"));
+    fireEvent.click(screen.getAllByRole("button", { name: "SAVE" })[0]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit command Run app" }),
+    );
+    screen.getByRole("button", { name: "DELETE" });
+    fireEvent.click(screen.getAllByRole("button", { name: "CANCEL" })[0]);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "CREATE REPO CONFIG FILE" }),
+      );
+    });
+
+    expect(
+      screen.getByRole("button", { name: "CREATING REPO CONFIG FILE" }),
+    ).not.toBeNull();
+    expect(onCreateProjectConfig).toHaveBeenCalledWith({
+      project: {
+        path: "/repo",
+        name: "Repo",
+        setupCommand: "npm install",
+        commands: [
+          {
+            id: expect.any(String),
+            label: "Run app",
+            command: "npm run dev",
+            icon: "play_arrow",
+            showLabel: false,
+          },
+        ],
+      },
+      writeProjectConfig: true,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2400);
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "CREATE REPO CONFIG FILE" }),
+    ).toBeNull();
+    expect(screen.queryByText("Project Config File")).toBeNull();
+    screen.getByText(/stored in/i);
+    screen.getByText("/repo/.rakh/scripts.json");
+
+    fireEvent.click(screen.getByRole("button", { name: "SAVE" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      project: {
+        path: "/repo",
+        name: "Repo",
+        setupCommand: "npm install",
+        commands: [
+          {
+            id: expect.any(String),
+            label: "Run app",
+            command: "npm run dev",
+            icon: "play_arrow",
+            showLabel: false,
+          },
+        ],
+      },
+      writeProjectConfig: true,
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows repo config path in the footer immediately when the repo config already exists", () => {
+    const onSave = vi.fn();
+    const onCreateProjectConfig = vi.fn();
+
+    render(
+      <ProjectSettingsModal
+        project={{
+          path: "/repo",
+          name: "Repo",
+          setupCommand: "npm install",
+          hasProjectConfigFile: true,
+        }}
+        onClose={() => undefined}
+        onSave={onSave}
+        onCreateProjectConfig={onCreateProjectConfig}
+      />,
+    );
+
+    expect(screen.queryByText("Project Config File")).toBeNull();
+    screen.getByText(/stored in/i);
+    screen.getByText("/repo/.rakh/scripts.json");
+    expect(
+      screen.queryByRole("button", { name: "CREATE REPO CONFIG FILE" }),
+    ).toBeNull();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("npm install && npm run build"),
+      { target: { value: "   " } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "SAVE" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      project: {
+        path: "/repo",
+        name: "Repo",
+      },
+      writeProjectConfig: true,
+    });
+  });
+});

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -1,0 +1,688 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { SavedProject } from "@/projects";
+import { PROJECT_SCRIPTS_CONFIG_PATH } from "@/projectScripts";
+import type { ProjectCommandConfig } from "@/projectScripts";
+import { Button, ModalShell, TextField, ToggleSwitch } from "@/components/ui";
+
+export interface ProjectSettingsSavePayload {
+  project: SavedProject;
+  writeProjectConfig: boolean;
+}
+
+interface CommandDraft {
+  draftId: string;
+  label: string;
+  command: string;
+  icon: string;
+  showLabel: boolean;
+}
+
+type ProjectConfigStage = "hidden" | "creating" | "visible";
+
+interface EditingCommandState {
+  draft: CommandDraft;
+  editingId: string | null;
+}
+
+interface CommandIconOption {
+  value: string;
+}
+
+interface IconMenuPosition {
+  top: number;
+  left: number;
+  width: number;
+}
+
+const PROJECT_COMMAND_ICON_OPTIONS: CommandIconOption[] = [
+  { value: "" },
+  { value: "play_arrow" },
+  { value: "settings" },
+  { value: "pest_control" },
+  { value: "cleaning_services" },
+  { value: "science" },
+  { value: "package_2" },
+  { value: "install_desktop" },
+];
+
+function createCommandDraft(command?: ProjectCommandConfig): CommandDraft {
+  return {
+    draftId:
+      command?.id?.trim() ||
+      `cmd-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`,
+    label: command?.label ?? "",
+    command: command?.command ?? "",
+    icon: command?.icon ?? "",
+    showLabel: command?.showLabel ?? true,
+  };
+}
+
+function buildCommands(drafts: CommandDraft[]): ProjectCommandConfig[] {
+  return drafts
+    .map<ProjectCommandConfig | null>((draft) => {
+      const label = draft.label.trim();
+      const command = draft.command.trim();
+      const icon = draft.icon.trim();
+      if (!label || !command) return null;
+
+      return {
+        id: draft.draftId,
+        label,
+        command,
+        ...(icon ? { icon } : {}),
+        ...(draft.showLabel !== true ? { showLabel: false } : {}),
+      };
+    })
+    .filter((command): command is ProjectCommandConfig => command !== null);
+}
+
+function commandShowsLabel(command: CommandDraft): boolean {
+  return command.showLabel || !command.icon.trim();
+}
+
+function normalizeCommandDraft(draft: CommandDraft): CommandDraft | null {
+  const label = draft.label.trim();
+  const command = draft.command.trim();
+  const icon = draft.icon.trim();
+  if (!label || !command) return null;
+
+  return {
+    ...draft,
+    label,
+    command,
+    icon,
+  };
+}
+
+function getCommandIconOptions(currentIcon: string): CommandIconOption[] {
+  const normalizedIcon = currentIcon.trim();
+  if (
+    !normalizedIcon ||
+    PROJECT_COMMAND_ICON_OPTIONS.some(
+      (option) => option.value === normalizedIcon,
+    )
+  ) {
+    return PROJECT_COMMAND_ICON_OPTIONS;
+  }
+
+  return [{ value: normalizedIcon }, ...PROJECT_COMMAND_ICON_OPTIONS];
+}
+
+function getCommandIconAriaLabel(icon: string): string {
+  return icon || "No icon";
+}
+
+interface ProjectSettingsModalProps {
+  project: SavedProject;
+  onClose: () => void;
+  onSave: (payload: ProjectSettingsSavePayload) => void | Promise<void>;
+  onCreateProjectConfig: (
+    payload: ProjectSettingsSavePayload,
+  ) => void | Promise<void>;
+}
+
+function buildProjectPayload(
+  project: SavedProject,
+  setupCommand: string,
+  commands: CommandDraft[],
+): SavedProject {
+  const nextCommands = buildCommands(commands);
+  return {
+    path: project.path,
+    name: project.name,
+    ...(setupCommand.trim() ? { setupCommand: setupCommand.trim() } : {}),
+    ...(nextCommands.length > 0 ? { commands: nextCommands } : {}),
+  };
+}
+
+export default function ProjectSettingsModal({
+  project,
+  onClose,
+  onSave,
+  onCreateProjectConfig,
+}: ProjectSettingsModalProps) {
+  const [setupCommand, setSetupCommand] = useState(project.setupCommand ?? "");
+  const [commands, setCommands] = useState<CommandDraft[]>(
+    project.commands?.map((command) => createCommandDraft(command)) ?? [],
+  );
+  const [editingCommand, setEditingCommand] =
+    useState<EditingCommandState | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasProjectConfigFile, setHasProjectConfigFile] = useState(
+    Boolean(project.hasProjectConfigFile),
+  );
+  const [projectConfigStage, setProjectConfigStage] =
+    useState<ProjectConfigStage>(
+      project.hasProjectConfigFile ? "visible" : "hidden",
+    );
+  const [projectConfigError, setProjectConfigError] = useState<string | null>(
+    null,
+  );
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const [iconMenuPosition, setIconMenuPosition] =
+    useState<IconMenuPosition | null>(null);
+  const iconTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const iconMenuRef = useRef<HTMLDivElement | null>(null);
+  const projectConfigPath = `${project.path}/${PROJECT_SCRIPTS_CONFIG_PATH}`;
+  const shouldShowRepoConfigSection =
+    !hasProjectConfigFile && projectConfigStage !== "visible";
+  const selectedCommandIcon = editingCommand?.draft.icon.trim() ?? "";
+  const commandIconOptions = getCommandIconOptions(selectedCommandIcon);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (iconPickerOpen) {
+        setIconPickerOpen(false);
+        return;
+      }
+      onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [iconPickerOpen, onClose]);
+
+  useEffect(() => {
+    setIconPickerOpen(false);
+    setIconMenuPosition(null);
+  }, [editingCommand?.draft.draftId]);
+
+  useEffect(() => {
+    if (!iconPickerOpen) return;
+
+    const updateIconMenuPosition = () => {
+      const rect = iconTriggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      setIconMenuPosition({
+        top: rect.bottom + 8,
+        left: rect.left,
+        width: Math.max(rect.width, 176),
+      });
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (
+        iconTriggerRef.current?.contains(event.target as Node) ||
+        iconMenuRef.current?.contains(event.target as Node)
+      ) {
+        return;
+      }
+
+      setIconPickerOpen(false);
+    };
+
+    updateIconMenuPosition();
+    window.addEventListener("mousedown", handlePointerDown);
+    window.addEventListener("resize", updateIconMenuPosition);
+    window.addEventListener("scroll", updateIconMenuPosition, true);
+
+    return () => {
+      window.removeEventListener("mousedown", handlePointerDown);
+      window.removeEventListener("resize", updateIconMenuPosition);
+      window.removeEventListener("scroll", updateIconMenuPosition, true);
+    };
+  }, [iconPickerOpen]);
+
+  useEffect(() => {
+    if (iconPickerOpen) return;
+    setIconMenuPosition(null);
+  }, [iconPickerOpen]);
+
+  const iconMenu =
+    iconPickerOpen && iconMenuPosition
+      ? createPortal(
+          <div
+            ref={iconMenuRef}
+            className="project-settings-modal__icon-menu"
+            role="listbox"
+            aria-label="Command icon options"
+            onClick={(event) => event.stopPropagation()}
+            style={{
+              top: `${iconMenuPosition.top}px`,
+              left: `${iconMenuPosition.left}px`,
+              minWidth: `${iconMenuPosition.width}px`,
+            }}
+          >
+            {commandIconOptions.map((option) => {
+              const isSelected = option.value === selectedCommandIcon;
+
+              return (
+                <button
+                  key={option.value || "none"}
+                  type="button"
+                  role="option"
+                  aria-label={getCommandIconAriaLabel(option.value)}
+                  aria-selected={isSelected}
+                  className="project-settings-modal__icon-option"
+                  onClick={() => {
+                    setEditingCommand((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            draft: {
+                              ...prev.draft,
+                              icon: option.value,
+                            },
+                          }
+                        : prev,
+                    );
+                    setIconPickerOpen(false);
+                  }}
+                >
+                  {option.value ? (
+                    <span
+                      className="material-symbols-outlined text-base"
+                      aria-hidden="true"
+                    >
+                      {option.value}
+                    </span>
+                  ) : (
+                    <span
+                      className="project-settings-modal__icon-placeholder"
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )
+      : null;
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const nextProject = buildProjectPayload(project, setupCommand, commands);
+      await onSave({
+        project: nextProject,
+        writeProjectConfig: hasProjectConfigFile,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCreateProjectConfig = async () => {
+    setProjectConfigError(null);
+    setProjectConfigStage("creating");
+    try {
+      const nextProject = buildProjectPayload(project, setupCommand, commands);
+      await onCreateProjectConfig({
+        project: nextProject,
+        writeProjectConfig: true,
+      });
+      await new Promise<void>((resolve) => {
+        window.setTimeout(() => resolve(), 2400);
+      });
+      setHasProjectConfigFile(true);
+      setProjectConfigStage("visible");
+    } catch (error) {
+      setProjectConfigStage("hidden");
+      setProjectConfigError(String(error));
+    }
+  };
+
+  const saveEditingCommand = () => {
+    if (!editingCommand) return;
+    const normalizedDraft = normalizeCommandDraft(editingCommand.draft);
+    if (!normalizedDraft) return;
+
+    setCommands((prev) => {
+      const next = normalizedDraft;
+      if (editingCommand.editingId) {
+        return prev.map((command) =>
+          command.draftId === editingCommand.editingId ? next : command,
+        );
+      }
+      return [...prev, next];
+    });
+    setEditingCommand(null);
+  };
+
+  return createPortal(
+    <div
+      className="error-modal-backdrop"
+      onClick={onClose}
+      role="dialog"
+      aria-modal
+      aria-label={`Project settings for ${project.name}`}
+    >
+      <ModalShell
+        className="error-modal tool-modal project-settings-modal"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="error-modal-header">
+          <span className="error-modal-title tool-modal-title">
+            <span className="material-symbols-outlined text-muted shrink-0 text-md">
+              tune
+            </span>
+            Project Settings
+          </span>
+          <Button
+            className="error-modal-close"
+            onClick={onClose}
+            title="Close (Esc)"
+            variant="ghost"
+            size="xxs"
+          >
+            <span className="material-symbols-outlined text-lg">close</span>
+          </Button>
+        </div>
+
+        <div className="error-modal-body project-settings-modal__body">
+          <div className="tool-modal-section">
+            <div className="tool-modal-section-label">Project</div>
+            <div className="project-settings-modal__path">{project.path}</div>
+          </div>
+
+          <div className="tool-modal-section">
+            <div className="tool-modal-section-label">Setup Command</div>
+            <TextField
+              type="text"
+              value={setupCommand}
+              onChange={(event) => setSetupCommand(event.target.value)}
+              placeholder="npm install && npm run build"
+              className="project-settings-modal__input"
+              wrapClassName="project-settings-modal__input-wrap"
+              autoFocus
+            />
+            <p className="project-settings-modal__hint">
+              Runs inside the new worktree after branch creation and before the
+              agent continues.
+            </p>
+          </div>
+
+          <div className="tool-modal-section">
+            <div className="project-settings-modal__commands-header">
+              <div>
+                <div className="tool-modal-section-label">Project Commands</div>
+                <p className="project-settings-modal__hint">
+                  Add shortcuts for commands you frequently run in this project.
+                </p>
+              </div>
+              <Button
+                variant="primary"
+                size="xxs"
+                leftIcon={
+                  <span
+                    className="material-symbols-outlined text-base"
+                    aria-hidden="true"
+                  >
+                    add
+                  </span>
+                }
+                onClick={() =>
+                  setEditingCommand({
+                    draft: createCommandDraft(),
+                    editingId: null,
+                  })
+                }
+                type="button"
+                disabled={editingCommand !== null}
+              >
+                ADD
+              </Button>
+            </div>
+
+            {commands.length > 0 ? (
+              <div className="project-settings-modal__bookmark-bar" role="list">
+                {commands.map((command) => (
+                  <button
+                    key={command.draftId}
+                    type="button"
+                    className="project-settings-modal__bookmark-item"
+                    title={`Edit ${command.label.trim() || "command"}`}
+                    aria-label={`Edit command ${command.label.trim() || "command"}`}
+                    onClick={() =>
+                      setEditingCommand({
+                        draft: { ...command },
+                        editingId: command.draftId,
+                      })
+                    }
+                  >
+                    <div className="project-settings-modal__bookmark-main">
+                      <span
+                        className="material-symbols-outlined text-base"
+                        aria-hidden="true"
+                      >
+                        {command.icon.trim() || "terminal"}
+                      </span>
+                      {commandShowsLabel(command) ? (
+                        <span className="project-settings-modal__bookmark-label">
+                          {command.label.trim() || "Untitled"}
+                        </span>
+                      ) : null}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+
+            {editingCommand ? (
+              <div className="project-settings-modal__command-card">
+                <div className="project-settings-modal__command-grid">
+                  <TextField
+                    type="text"
+                    value={editingCommand.draft.label}
+                    onChange={(event) =>
+                      setEditingCommand((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              draft: {
+                                ...prev.draft,
+                                label: event.target.value,
+                              },
+                            }
+                          : prev,
+                      )
+                    }
+                    placeholder="Label (e.g. Run app)"
+                    className="project-settings-modal__input"
+                    wrapClassName="project-settings-modal__input-wrap"
+                  />
+                  <div className="project-settings-modal__icon-picker">
+                    <button
+                      type="button"
+                      ref={iconTriggerRef}
+                      className="project-settings-modal__icon-trigger"
+                      aria-label={`Command icon ${getCommandIconAriaLabel(selectedCommandIcon)}`}
+                      aria-haspopup="listbox"
+                      aria-expanded={iconPickerOpen}
+                      onClick={() => setIconPickerOpen((prev) => !prev)}
+                    >
+                      {selectedCommandIcon ? (
+                        <span
+                          className="material-symbols-outlined text-base"
+                          aria-hidden="true"
+                        >
+                          {selectedCommandIcon}
+                        </span>
+                      ) : (
+                        <span
+                          className="project-settings-modal__icon-placeholder"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <span
+                        className="material-symbols-outlined text-base project-settings-modal__icon-trigger-chevron"
+                        aria-hidden="true"
+                      >
+                        expand_more
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <TextField
+                  type="text"
+                  value={editingCommand.draft.command}
+                  onChange={(event) =>
+                    setEditingCommand((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            draft: {
+                              ...prev.draft,
+                              command: event.target.value,
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  placeholder="Command (e.g. npm run dev)"
+                  className="project-settings-modal__input"
+                  wrapClassName="project-settings-modal__input-wrap"
+                />
+                <div className="project-settings-modal__command-footer">
+                  <label className="project-settings-modal__show-label">
+                    <span>Show label</span>
+                    <ToggleSwitch
+                      checked={editingCommand.draft.showLabel}
+                      onChange={(next) =>
+                        setEditingCommand((prev) =>
+                          prev
+                            ? {
+                                ...prev,
+                                draft: { ...prev.draft, showLabel: next },
+                              }
+                            : prev,
+                        )
+                      }
+                      title="Toggle label visibility"
+                    />
+                  </label>
+                  <div className="project-settings-modal__command-editor-actions">
+                    {editingCommand.editingId ? (
+                      <Button
+                        variant="danger"
+                        size="xxs"
+                        type="button"
+                        leftIcon={
+                          <span
+                            className="material-symbols-outlined text-base"
+                            aria-hidden="true"
+                          >
+                            delete
+                          </span>
+                        }
+                        onClick={() => {
+                          setCommands((prev) =>
+                            prev.filter(
+                              (entry) =>
+                                entry.draftId !== editingCommand.editingId,
+                            ),
+                          );
+                          setEditingCommand(null);
+                        }}
+                      >
+                        DELETE
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant="ghost"
+                      size="xxs"
+                      type="button"
+                      onClick={() => setEditingCommand(null)}
+                    >
+                      CANCEL
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="xxs"
+                      type="button"
+                      onClick={saveEditingCommand}
+                    >
+                      SAVE
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {shouldShowRepoConfigSection ? (
+            <div className="tool-modal-section project-settings-modal__repo-config">
+              <div className="project-settings-modal__repo-row">
+                <div className="project-settings-modal__repo-copy">
+                  <div className="tool-modal-section-label">
+                    Project Config File
+                  </div>
+                  <p className="project-settings-modal__hint">
+                    Save scripts to{" "}
+                    <code className="text-primary">
+                      {PROJECT_SCRIPTS_CONFIG_PATH}
+                    </code>{" "}
+                    inside this repo.
+                  </p>
+                  {projectConfigError ? (
+                    <p className="project-settings-modal__hint text-error">
+                      {projectConfigError}
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="project-settings-modal__repo-actions">
+                  <Button
+                    variant="primary"
+                    size="xxs"
+                    type="button"
+                    loading={projectConfigStage === "creating"}
+                    onClick={() => {
+                      void handleCreateProjectConfig();
+                    }}
+                    disabled={projectConfigStage === "creating" || isSaving}
+                  >
+                    {projectConfigStage === "creating"
+                      ? "CREATING REPO CONFIG FILE"
+                      : "CREATE REPO CONFIG FILE"}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="error-modal-footer project-settings-modal__footer">
+          <div className="project-settings-modal__footer-meta">
+            {hasProjectConfigFile || projectConfigStage === "visible" ? (
+              <>
+                <span className="project-settings-modal__footer-meta-label">
+                  stored in
+                </span>{" "}
+                <span className="project-settings-modal__footer-path">
+                  {projectConfigPath}
+                </span>
+              </>
+            ) : null}
+          </div>
+          <div className="project-settings-modal__footer-actions">
+            <Button
+              onClick={onClose}
+              variant="ghost"
+              size="xxs"
+              disabled={isSaving || projectConfigStage === "creating"}
+            >
+              CANCEL
+            </Button>
+            <Button
+              onClick={() => {
+                void handleSave();
+              }}
+              variant="primary"
+              size="xxs"
+              loading={isSaving}
+              disabled={isSaving || projectConfigStage === "creating"}
+            >
+              SAVE
+            </Button>
+          </div>
+        </div>
+      </ModalShell>
+      {iconMenu}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ToolCallApproval.test.tsx
+++ b/src/components/ToolCallApproval.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallDisplay } from "@/agent/types";
+import ToolCallApproval from "./ToolCallApproval";
+
+const approvalMocks = vi.hoisted(() => ({
+  resolveWorktreeApprovalMock: vi.fn(),
+  resolveWorktreeSetupActionMock: vi.fn(),
+  resolveApprovalMock: vi.fn(),
+  setApprovalReasonMock: vi.fn(),
+}));
+
+const useAgentsMocks = vi.hoisted(() => ({
+  stopAgentMock: vi.fn(),
+  stopRunningExecToolCallMock: vi.fn(async () => true),
+}));
+
+vi.mock("@/agent/approvals", () => ({
+  resolveApproval: (...args: unknown[]) => approvalMocks.resolveApprovalMock(...args),
+  resolveWorktreeApproval: (...args: unknown[]) =>
+    approvalMocks.resolveWorktreeApprovalMock(...args),
+  resolveWorktreeSetupAction: (...args: unknown[]) =>
+    approvalMocks.resolveWorktreeSetupActionMock(...args),
+  setApprovalReason: (...args: unknown[]) => approvalMocks.setApprovalReasonMock(...args),
+}));
+
+vi.mock("@/agent/useAgents", () => ({
+  useStopAgent: () => useAgentsMocks.stopAgentMock,
+  useStopRunningExecToolCall: () => useAgentsMocks.stopRunningExecToolCallMock,
+}));
+
+function makeWorktreeToolCall(
+  overrides: Partial<ToolCallDisplay> = {},
+): ToolCallDisplay {
+  return {
+    id: "tc-1",
+    tool: "git_worktree_init",
+    args: {
+      suggestedBranch: "feature/setup",
+      repoSlug: "owner/repo",
+      branch: "feature/setup",
+      worktreePath: "/tmp/worktree",
+      setupCommand: "npm install",
+      setupPhase: "setup_failed",
+    },
+    result: {
+      path: "/tmp/worktree",
+      branch: "feature/setup",
+      setup: {
+        status: "failed_pending",
+        cwd: "/tmp/worktree",
+        stdout: "partial output",
+        stderr: "install failed",
+        errorMessage: "Setup command exited with code 1.",
+      },
+    },
+    status: "awaiting_setup_action",
+    ...overrides,
+  };
+}
+
+describe("ToolCallApproval", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    approvalMocks.resolveApprovalMock.mockReset();
+    approvalMocks.resolveWorktreeApprovalMock.mockReset();
+    approvalMocks.resolveWorktreeSetupActionMock.mockReset();
+    approvalMocks.setApprovalReasonMock.mockReset();
+    useAgentsMocks.stopAgentMock.mockReset();
+    useAgentsMocks.stopRunningExecToolCallMock.mockReset();
+    useAgentsMocks.stopRunningExecToolCallMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("auto-continues a failed setup after five seconds", () => {
+    render(
+      <ToolCallApproval
+        toolCall={makeWorktreeToolCall()}
+        tabId="tab-1"
+        onOpenProjectSettings={vi.fn()}
+      />,
+    );
+
+    screen.getByText("SETUP FAILED");
+    screen.getByText("partial output");
+    screen.getByText("install failed");
+    expect(screen.getByText(/Continuing without setup in/i).textContent).toContain(
+      "5s",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5200);
+    });
+
+    expect(approvalMocks.resolveWorktreeSetupActionMock).toHaveBeenCalledWith(
+      "tab-1",
+      "tc-1",
+      "continue",
+    );
+  });
+
+  it("pauses auto-continue and opens project settings when editing the command", () => {
+    const onOpenProjectSettings = vi.fn();
+
+    render(
+      <ToolCallApproval
+        toolCall={makeWorktreeToolCall()}
+        tabId="tab-1"
+        onOpenProjectSettings={onOpenProjectSettings}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "EDIT COMMAND" }));
+
+    expect(onOpenProjectSettings).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/Auto-continue paused/i)).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(5200);
+    });
+
+    expect(approvalMocks.resolveWorktreeSetupActionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ToolCallApproval.tsx
+++ b/src/components/ToolCallApproval.tsx
@@ -1,6 +1,7 @@
 import {
   resolveApproval,
   resolveWorktreeApproval,
+  resolveWorktreeSetupAction,
   setApprovalReason,
 } from "@/agent/approvals";
 import { useState, useEffect, useRef } from "react";
@@ -222,10 +223,203 @@ interface ToolCallApprovalProps {
   toolCall: ToolCallDisplay;
   cwd?: string;
   tabId: string;
+  onOpenProjectSettings?: () => void;
 }
 
-/** Special card shown for git_worktree_init (awaiting_worktree status). */
-function WorktreeApprovalCard({ toolCall, tabId }: { toolCall: ToolCallDisplay; tabId: string }) {
+function renderWorktreeSetupOutput(
+  toolCall: ToolCallDisplay,
+  activeSetup: Record<string, unknown> | null,
+) {
+  if (toolCall.streamingOutput) {
+    return <pre className="cmd-output mt-1">{toolCall.streamingOutput}</pre>;
+  }
+
+  const stdout =
+    typeof activeSetup?.stdout === "string" ? activeSetup.stdout.trimEnd() : "";
+  const stderr =
+    typeof activeSetup?.stderr === "string" ? activeSetup.stderr.trimEnd() : "";
+
+  if (!stdout && !stderr) return null;
+
+  return (
+    <>
+      {stdout ? <pre className="cmd-output mt-1">{stdout}</pre> : null}
+      {stderr ? (
+        <pre className="cmd-output cmd-output--error mt-1">{stderr}</pre>
+      ) : null}
+    </>
+  );
+}
+
+function renderWorktreeSetupCommand({
+  activeSetup,
+  isVisible,
+  setupCommand,
+  setupCwd,
+  toolCall,
+}: {
+  activeSetup: Record<string, unknown> | null;
+  isVisible: boolean;
+  setupCommand: string;
+  setupCwd: string | null;
+  toolCall: ToolCallDisplay;
+}) {
+  if (!isVisible) return null;
+  return (
+    <div className="cmd-block border-b border-border-subtle">
+      <div className="cmd-prompt">
+        <span className="cmd-sigil">$</span>
+        <span className="cmd-text">{setupCommand || "(no setup command)"}</span>
+      </div>
+      {setupCwd ? (
+        <div className="cmd-cwd">
+          <span className="material-symbols-outlined text-xs cmd-cwd-icon">
+            folder_open
+          </span>
+          {setupCwd}
+        </div>
+      ) : null}
+      {renderWorktreeSetupOutput(toolCall, activeSetup)}
+    </div>
+  );
+}
+
+function WorktreeSetupFailureCard({
+  activeSetup,
+  configuredBranch,
+  configuredPath,
+  id,
+  onOpenProjectSettings,
+  setupCommand,
+  setupCwd,
+  setupFailureMessage,
+  tabId,
+  toolCall,
+}: {
+  activeSetup: Record<string, unknown> | null;
+  configuredBranch: string;
+  configuredPath: string | null;
+  id: string;
+  onOpenProjectSettings?: () => void;
+  setupCommand: string;
+  setupCwd: string | null;
+  setupFailureMessage: string | null;
+  tabId: string;
+  toolCall: ToolCallDisplay;
+}) {
+  const [countdownPaused, setCountdownPaused] = useState(false);
+  const [countdownSeconds, setCountdownSeconds] = useState(5);
+
+  useEffect(() => {
+    if (countdownPaused) return;
+
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+      const remaining = Math.max(0, 5 - elapsed);
+      setCountdownSeconds(remaining);
+      if (remaining === 0) {
+        window.clearInterval(timer);
+        resolveWorktreeSetupAction(tabId, id, "continue");
+      }
+    }, 200);
+
+    return () => window.clearInterval(timer);
+  }, [countdownPaused, id, tabId]);
+
+  return (
+    <div className="msg-card animate-fade-up mt-1.5">
+      <div className="msg-card-head">
+        <div className="msg-card-label">
+          <span className="material-symbols-outlined text-base text-warning">
+            warning
+          </span>
+          SETUP FAILED
+        </div>
+        <div className="text-xxs text-muted font-mono opacity-60">
+          git_worktree_init
+        </div>
+      </div>
+
+      <div className="px-3 py-2.5 border-b border-border-subtle">
+        <div className="text-xs text-text leading-[1.6]">
+          Branch <span className="font-mono">{configuredBranch || "(pending)"}</span>
+          {configuredPath ? (
+            <>
+              {" "}
+              is ready at <span className="font-mono break-all">{configuredPath}</span>.
+            </>
+          ) : (
+            "."
+          )}
+        </div>
+        {setupFailureMessage ? (
+          <div className="text-xxs text-error mt-1">{setupFailureMessage}</div>
+        ) : null}
+      </div>
+
+      {renderWorktreeSetupCommand({
+        activeSetup,
+        isVisible: true,
+        setupCommand,
+        setupCwd,
+        toolCall,
+      })}
+
+      <div className="px-3 py-2 border-b border-border-subtle text-xxs text-muted">
+        {countdownPaused
+          ? "Auto-continue paused while editing the setup command."
+          : `Continuing without setup in ${countdownSeconds}s unless you choose an action.`}
+      </div>
+
+      <div className="msg-card-footer">
+        <Button
+          variant="secondary"
+          size="xxs"
+          onClick={() => resolveWorktreeSetupAction(tabId, id, "retry")}
+        >
+          RETRY
+        </Button>
+        {onOpenProjectSettings ? (
+          <Button
+            variant="ghost"
+            size="xxs"
+            onClick={() => {
+              setCountdownPaused(true);
+              onOpenProjectSettings();
+            }}
+          >
+            EDIT COMMAND
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="xxs"
+          onClick={() => resolveWorktreeSetupAction(tabId, id, "continue")}
+        >
+          CONTINUE
+        </Button>
+        <Button
+          variant="danger"
+          size="xxs"
+          onClick={() => resolveWorktreeSetupAction(tabId, id, "abort")}
+        >
+          ABORT
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function WorktreeToolCard({
+  toolCall,
+  tabId,
+  onOpenProjectSettings,
+}: {
+  toolCall: ToolCallDisplay;
+  tabId: string;
+  onOpenProjectSettings?: () => void;
+}) {
   const { id, args } = toolCall;
   const suggested =
     typeof args.suggestedBranch === "string" ? args.suggestedBranch : "";
@@ -233,63 +427,207 @@ function WorktreeApprovalCard({ toolCall, tabId }: { toolCall: ToolCallDisplay; 
     typeof args.repoSlug === "string" && args.repoSlug.trim()
       ? args.repoSlug.replace(/^\/+|\/+$/g, "")
       : "repo";
+  const setupCommand =
+    typeof args.setupCommand === "string" ? args.setupCommand.trim() : "";
+  const setupPhase =
+    typeof args.setupPhase === "string" ? args.setupPhase : "approval";
+  const configuredBranch =
+    typeof args.branch === "string" && args.branch.trim()
+      ? args.branch
+      : suggested;
+  const configuredPath =
+    typeof args.worktreePath === "string" && args.worktreePath.trim()
+      ? args.worktreePath
+      : null;
   const [branch, setBranch] = useState(suggested);
+  const stopAgent = useStopAgent();
+  const stopRunningExecToolCall = useStopRunningExecToolCall();
+
+  const resultRecord =
+    toolCall.result && typeof toolCall.result === "object"
+      ? (toolCall.result as Record<string, unknown>)
+      : null;
+  const setupRecord =
+    resultRecord?.setup && typeof resultRecord.setup === "object"
+      ? (resultRecord.setup as Record<string, unknown>)
+      : null;
+  const setupErrorRecord =
+    resultRecord?.details &&
+    typeof resultRecord.details === "object" &&
+    (resultRecord.details as Record<string, unknown>).setup &&
+    typeof (resultRecord.details as Record<string, unknown>).setup === "object"
+      ? ((resultRecord.details as Record<string, unknown>)
+          .setup as Record<string, unknown>)
+      : null;
+  const activeSetup = setupRecord ?? setupErrorRecord;
+  const setupStatus =
+    typeof activeSetup?.status === "string" ? activeSetup.status : null;
+  const setupCwd =
+    typeof activeSetup?.cwd === "string"
+      ? activeSetup.cwd
+      : configuredPath;
+  const setupFailureMessage =
+    typeof activeSetup?.errorMessage === "string"
+      ? activeSetup.errorMessage
+      : null;
+  const isAwaitingSetupAction = toolCall.status === "awaiting_setup_action";
+  const isSetupRunning = setupPhase === "running_setup";
+  const isSetupPhaseVisible = setupCommand.length > 0 || isSetupRunning;
+
+  if (toolCall.status === "awaiting_worktree") {
+    return (
+      <div className="msg-card animate-fade-up mt-1.5">
+        <div className="msg-card-head">
+          <div className="msg-card-label">
+            <span className="material-symbols-outlined text-base">
+              account_tree
+            </span>
+            CREATE ISOLATED BRANCH
+          </div>
+          <div className="text-xxs text-muted font-mono opacity-60">
+            git_worktree_init
+          </div>
+        </div>
+
+        <div className="px-3 py-2.5 border-b border-border-subtle">
+          <div className="text-xs text-muted font-mono mb-1.5">Branch name</div>
+          <TextField
+            type="text"
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            className="w-full bg-inset py-1.25 px-2 text-xs font-mono"
+            wrapClassName="border border-border-mid rounded"
+            placeholder="feat/my-branch"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                resolveWorktreeApproval(
+                  tabId,
+                  id,
+                  true,
+                  branch.trim() || suggested,
+                );
+              }
+            }}
+          />
+          <div className="text-xxs text-muted font-mono mt-1.25 opacity-60">
+            A worktree will be created under worktrees/{repoSlug}/
+            {branch.trim() || suggested || "branch"}
+          </div>
+          {setupCommand ? (
+            <div className="text-xxs text-muted font-mono mt-1.5 opacity-75">
+              Setup command: <span className="text-text">{setupCommand}</span>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="msg-card-footer">
+          <Button
+            variant="ghost"
+            size="xxs"
+            onClick={() => resolveWorktreeApproval(tabId, id, false, "")}
+          >
+            WORK IN MAIN REPO
+          </Button>
+          <Button
+            variant="primary"
+            size="xxs"
+            onClick={() =>
+              resolveWorktreeApproval(tabId, id, true, branch.trim() || suggested)
+            }
+          >
+            CREATE BRANCH
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAwaitingSetupAction) {
+    return (
+      <WorktreeSetupFailureCard
+        key={`${id}:${String(args.setupAttemptCount ?? 0)}`}
+        activeSetup={activeSetup}
+        configuredBranch={configuredBranch}
+        configuredPath={configuredPath}
+        id={id}
+        onOpenProjectSettings={onOpenProjectSettings}
+        setupCommand={setupCommand}
+        setupCwd={setupCwd}
+        setupFailureMessage={setupFailureMessage}
+        tabId={tabId}
+        toolCall={toolCall}
+      />
+    );
+  }
 
   return (
     <div className="msg-card animate-fade-up mt-1.5">
-      {/* Header */}
       <div className="msg-card-head">
         <div className="msg-card-label">
           <span className="material-symbols-outlined text-base">
             account_tree
           </span>
-          CREATE ISOLATED BRANCH
+          PREPARE WORKTREE
         </div>
         <div className="text-xxs text-muted font-mono opacity-60">
           git_worktree_init
         </div>
       </div>
 
-      {/* Branch name input */}
       <div className="px-3 py-2.5 border-b border-border-subtle">
-        <div className="text-xs text-muted font-mono mb-1.5">Branch name</div>
-        <TextField
-          type="text"
-          value={branch}
-          onChange={(e) => setBranch(e.target.value)}
-          className="w-full bg-inset py-1.25 px-2 text-xs font-mono"
-          wrapClassName="border border-border-mid rounded"
-          placeholder="feat/my-branch"
-          autoFocus
-          onKeyDown={(e) => {
-            if (e.key === "Enter")
-              resolveWorktreeApproval(tabId, id, true, branch.trim() || suggested);
-          }}
-        />
-        <div className="text-xxs text-muted font-mono mt-1.25 opacity-60">
-          A worktree will be created under worktrees/{repoSlug}/
-          {branch.trim() || suggested || "branch"}
+        <div className="text-xs text-muted font-mono">Branch</div>
+        <div className="text-xs text-text mt-1">
+          <span className="font-mono">{configuredBranch || "(pending)"}</span>
+        </div>
+        {configuredPath ? (
+          <div className="text-xxs text-muted font-mono mt-1 opacity-70 break-all">
+            {configuredPath}
+          </div>
+        ) : null}
+        <div className="text-xxs text-muted mt-1.5">
+          {isSetupRunning ? "Running project setup..." : "Creating worktree..."}
         </div>
       </div>
 
-      {/* Footer */}
+      {renderWorktreeSetupCommand({
+        activeSetup,
+        isVisible: isSetupPhaseVisible,
+        setupCommand,
+        setupCwd,
+        toolCall,
+      })}
+
       <div className="msg-card-footer">
-        <Button
-          variant="ghost"
-          size="xxs"
-          onClick={() => resolveWorktreeApproval(tabId, id, false, "")}
-        >
-          WORK IN MAIN REPO
-        </Button>
-        <Button
-          variant="primary"
-          size="xxs"
-          onClick={() =>
-            resolveWorktreeApproval(tabId, id, true, branch.trim() || suggested)
-          }
-        >
-          CREATE BRANCH
-        </Button>
+        {isSetupRunning ? (
+          <>
+            <Button
+              className="tool-approval-stop-btn"
+              variant="secondary"
+              size="xxs"
+              onClick={() => {
+                void stopRunningExecToolCall(tabId, id);
+              }}
+            >
+              STOP
+            </Button>
+            <Button variant="danger" size="xxs" onClick={() => stopAgent(tabId)}>
+              ABORT
+            </Button>
+            <Button variant="primary" size="xxs" loading disabled>
+              RUNNING
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="danger" size="xxs" onClick={() => stopAgent(tabId)}>
+              ABORT
+            </Button>
+            <Button variant="primary" size="xxs" loading disabled>
+              PREPARING
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );
@@ -299,6 +637,7 @@ export default function ToolCallApproval({
   toolCall,
   cwd,
   tabId,
+  onOpenProjectSettings,
 }: ToolCallApprovalProps) {
   const { id, tool, args } = toolCall;
   const stopAgent = useStopAgent();
@@ -317,8 +656,14 @@ export default function ToolCallApproval({
   }, [isExecRunning, toolCall.streamingOutput]);
 
   // Render the dedicated worktree card for git_worktree_init
-  if (toolCall.status === "awaiting_worktree" || tool === "git_worktree_init") {
-    return <WorktreeApprovalCard toolCall={toolCall} tabId={tabId} />;
+  if (tool === "git_worktree_init") {
+    return (
+      <WorktreeToolCard
+        toolCall={toolCall}
+        tabId={tabId}
+        onOpenProjectSettings={onOpenProjectSettings}
+      />
+    );
   }
 
   const icon = TOOL_ICON[tool] ?? "build";

--- a/src/components/ToolCallDetailsModal.tsx
+++ b/src/components/ToolCallDetailsModal.tsx
@@ -77,6 +77,11 @@ const STATUS_BADGE: Record<string, { className: string; label: string }> = {
     className: "bg-primary-dim text-primary",
     label: "AWAITING",
   },
+  awaiting_setup_action: {
+    className:
+      "bg-[color-mix(in_srgb,var(--color-warning)_16%,transparent)] text-warning",
+    label: "SETUP ACTION",
+  },
 };
 
 /** Serialize any value to a readable JSON string. */

--- a/src/components/TopChrome.tsx
+++ b/src/components/TopChrome.tsx
@@ -65,6 +65,7 @@ function resolveTooltipStatus(
     toolCalls.some(
       (toolCall) =>
         toolCall.status === "awaiting_worktree" ||
+        toolCall.status === "awaiting_setup_action" ||
         toolCall.status === "awaiting_approval",
     );
   if (requiresAttention) {

--- a/src/components/compactToolCallStatus.ts
+++ b/src/components/compactToolCallStatus.ts
@@ -22,6 +22,7 @@ export function getExecCommandBadge(
     tc.status === "pending" ||
     tc.status === "awaiting_approval" ||
     tc.status === "awaiting_worktree" ||
+    tc.status === "awaiting_setup_action" ||
     tc.status === "running" ||
     tc.status === "denied"
   ) {

--- a/src/projectScripts.test.ts
+++ b/src/projectScripts.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workspaceMocks = vi.hoisted(() => ({
+  statFileMock: vi.fn(),
+  readFileMock: vi.fn(),
+  writeFileMock: vi.fn(),
+}));
+
+vi.mock("@/agent/tools/workspace", () => ({
+  statFile: (...args: unknown[]) => workspaceMocks.statFileMock(...args),
+  readFile: (...args: unknown[]) => workspaceMocks.readFileMock(...args),
+  writeFile: (...args: unknown[]) => workspaceMocks.writeFileMock(...args),
+}));
+
+import {
+  loadProjectScriptsConfig,
+  writeProjectScriptsConfig,
+} from "./projectScripts";
+
+describe("projectScripts", () => {
+  beforeEach(() => {
+    workspaceMocks.statFileMock.mockReset();
+    workspaceMocks.readFileMock.mockReset();
+    workspaceMocks.writeFileMock.mockReset();
+  });
+
+  it("loads .rakh/scripts.json when present", async () => {
+    workspaceMocks.statFileMock.mockResolvedValue({
+      ok: true,
+      data: { exists: true, path: "/repo/.rakh/scripts.json", kind: "file" },
+    });
+    workspaceMocks.readFileMock.mockResolvedValue({
+      ok: true,
+      data: {
+        content: JSON.stringify({
+          setupCommand: "npm install",
+          commands: [
+            {
+              id: "run",
+              label: "Run app",
+              command: "npm run dev",
+              icon: "play_arrow",
+              showLabel: false,
+            },
+          ],
+        }),
+      },
+    });
+
+    await expect(loadProjectScriptsConfig("/repo")).resolves.toEqual({
+      exists: true,
+      config: {
+        setupCommand: "npm install",
+        commands: [
+          {
+            id: "run",
+            label: "Run app",
+            command: "npm run dev",
+            icon: "play_arrow",
+            showLabel: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it("writes normalized config to .rakh/scripts.json", async () => {
+    workspaceMocks.writeFileMock.mockResolvedValue({
+      ok: true,
+      data: {
+        path: "/repo/.rakh/scripts.json",
+        bytesWritten: 128,
+        created: true,
+        overwritten: true,
+      },
+    });
+
+    await writeProjectScriptsConfig("/repo", {
+      setupCommand: "  npm install  ",
+      commands: [
+        {
+          id: "run",
+          label: "  Run app  ",
+          command: "  npm run dev  ",
+          icon: "  play_arrow  ",
+          showLabel: false,
+        },
+      ],
+    });
+
+    expect(workspaceMocks.writeFileMock).toHaveBeenCalledWith("/repo", {
+      path: ".rakh/scripts.json",
+      content: `${JSON.stringify(
+        {
+          setupCommand: "npm install",
+          commands: [
+            {
+              id: "run",
+              label: "Run app",
+              command: "npm run dev",
+              icon: "play_arrow",
+              showLabel: false,
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      mode: "create_or_overwrite",
+      createDirs: true,
+    });
+  });
+});

--- a/src/projectScripts.ts
+++ b/src/projectScripts.ts
@@ -1,0 +1,119 @@
+import { readFile, statFile, writeFile } from "@/agent/tools/workspace";
+
+export const PROJECT_SCRIPTS_CONFIG_PATH = ".rakh/scripts.json";
+
+export interface ProjectCommandConfig {
+  id?: string;
+  label: string;
+  command: string;
+  icon?: string;
+  showLabel?: boolean;
+}
+
+export interface ProjectScriptsConfig {
+  setupCommand?: string;
+  commands?: ProjectCommandConfig[];
+}
+
+export interface ProjectScriptsConfigState {
+  exists: boolean;
+  config: ProjectScriptsConfig | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function normalizeProjectCommandConfig(
+  value: unknown,
+): ProjectCommandConfig | null {
+  if (!isRecord(value)) return null;
+
+  const label = normalizeOptionalString(value.label);
+  const command = normalizeOptionalString(value.command);
+  if (!label || !command) return null;
+
+  return {
+    ...(normalizeOptionalString(value.id) ? { id: normalizeOptionalString(value.id) } : {}),
+    label,
+    command,
+    ...(normalizeOptionalString(value.icon)
+      ? { icon: normalizeOptionalString(value.icon) }
+      : {}),
+    ...(normalizeOptionalBoolean(value.showLabel) !== undefined
+      ? { showLabel: normalizeOptionalBoolean(value.showLabel) }
+      : {}),
+  };
+}
+
+export function normalizeProjectScriptsConfig(
+  value: unknown,
+): ProjectScriptsConfig | null {
+  if (!isRecord(value)) return null;
+
+  const setupCommand = normalizeOptionalString(value.setupCommand);
+  const commands = Array.isArray(value.commands)
+    ? value.commands
+        .map((command) => normalizeProjectCommandConfig(command))
+        .filter((command): command is ProjectCommandConfig => command !== null)
+    : [];
+
+  return {
+    ...(setupCommand ? { setupCommand } : {}),
+    ...(commands.length > 0 ? { commands } : {}),
+  };
+}
+
+export async function loadProjectScriptsConfig(
+  projectPath: string,
+): Promise<ProjectScriptsConfigState> {
+  const stat = await statFile(projectPath, { path: PROJECT_SCRIPTS_CONFIG_PATH });
+  if (!stat.ok || !stat.data.exists) {
+    return { exists: false, config: null };
+  }
+
+  const result = await readFile(projectPath, {
+    path: PROJECT_SCRIPTS_CONFIG_PATH,
+    maxBytes: 200_000,
+  });
+  if (!result.ok) {
+    return { exists: true, config: null };
+  }
+
+  try {
+    const parsed = JSON.parse(result.data.content) as unknown;
+    return {
+      exists: true,
+      config: normalizeProjectScriptsConfig(parsed),
+    };
+  } catch {
+    return { exists: true, config: null };
+  }
+}
+
+export async function writeProjectScriptsConfig(
+  projectPath: string,
+  config: ProjectScriptsConfig,
+): Promise<void> {
+  const normalized = normalizeProjectScriptsConfig(config) ?? {};
+  const result = await writeFile(projectPath, {
+    path: PROJECT_SCRIPTS_CONFIG_PATH,
+    content: `${JSON.stringify(normalized, null, 2)}\n`,
+    mode: "create_or_overwrite",
+    createDirs: true,
+  });
+
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+}

--- a/src/projects.test.ts
+++ b/src/projects.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { applyProjectScriptsConfig } from "./projects";
+
+describe("projects", () => {
+  it("prefers repo config values when .rakh/scripts.json exists", () => {
+    expect(
+      applyProjectScriptsConfig(
+        {
+          path: "/repo",
+          name: "Repo",
+          setupCommand: "local setup",
+          commands: [
+            {
+              id: "local-run",
+              label: "Local Run",
+              command: "npm run local",
+            },
+          ],
+        },
+        {
+          exists: true,
+          config: {
+            setupCommand: "repo setup",
+            commands: [
+              {
+                id: "repo-run",
+                label: "Repo Run",
+                command: "npm run repo",
+              },
+            ],
+          },
+        },
+      ),
+    ).toEqual({
+      path: "/repo",
+      name: "Repo",
+      hasProjectConfigFile: true,
+      setupCommand: "repo setup",
+      commands: [
+        {
+          id: "repo-run",
+          label: "Repo Run",
+          command: "npm run repo",
+        },
+      ],
+    });
+  });
+});

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,153 @@
+import {
+  loadProjectScriptsConfig,
+  normalizeProjectScriptsConfig,
+  type ProjectCommandConfig,
+  type ProjectScriptsConfigState,
+} from "@/projectScripts";
+
+export interface SavedProject {
+  path: string;
+  name: string;
+  setupCommand?: string;
+  commands?: ProjectCommandConfig[];
+  hasProjectConfigFile?: boolean;
+}
+
+export const PROJECTS_STORAGE_KEY = "rakh-projects";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function inferProjectName(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+function normalizeSetupCommand(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeCommands(value: unknown): ProjectCommandConfig[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const commands = normalizeProjectScriptsConfig({ commands: value })?.commands ?? [];
+  return commands.length > 0 ? commands : undefined;
+}
+
+export function normalizeSavedProject(value: unknown): SavedProject | null {
+  if (!isRecord(value)) return null;
+
+  const rawPath = typeof value.path === "string" ? value.path.trim() : "";
+  if (!rawPath) return null;
+
+  const rawName = typeof value.name === "string" ? value.name.trim() : "";
+  return {
+    path: rawPath,
+    name: rawName || inferProjectName(rawPath),
+    ...(normalizeSetupCommand(value.setupCommand)
+      ? { setupCommand: normalizeSetupCommand(value.setupCommand) }
+      : {}),
+    ...(normalizeCommands(value.commands)
+      ? { commands: normalizeCommands(value.commands) }
+      : {}),
+  };
+}
+
+export function applyProjectScriptsConfig(
+  project: SavedProject,
+  configState: ProjectScriptsConfigState,
+): SavedProject {
+  if (!configState.exists) {
+    const normalized = normalizeSavedProject(project);
+    return normalized ?? {
+      path: project.path,
+      name: project.name,
+    };
+  }
+
+  return {
+    path: project.path,
+    name: project.name,
+    hasProjectConfigFile: true,
+    ...(configState.config?.setupCommand
+      ? { setupCommand: configState.config.setupCommand }
+      : {}),
+    ...(configState.config?.commands?.length
+      ? { commands: configState.config.commands }
+      : {}),
+  };
+}
+
+export async function resolveSavedProject(project: SavedProject): Promise<SavedProject> {
+  const configState = await loadProjectScriptsConfig(project.path);
+  return applyProjectScriptsConfig(project, configState);
+}
+
+export async function resolveSavedProjects(
+  projects: SavedProject[],
+): Promise<SavedProject[]> {
+  return Promise.all(projects.map((project) => resolveSavedProject(project)));
+}
+
+export function loadSavedProjects(): SavedProject[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.localStorage.getItem(PROJECTS_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    const deduped = new Map<string, SavedProject>();
+    for (const item of parsed) {
+      const normalized = normalizeSavedProject(item);
+      if (normalized) {
+        deduped.set(normalized.path, normalized);
+      }
+    }
+    return Array.from(deduped.values());
+  } catch {
+    return [];
+  }
+}
+
+export function saveSavedProjects(projects: SavedProject[]): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    const normalized = projects
+      .map((project) => normalizeSavedProject(project))
+      .filter((project): project is SavedProject => project !== null);
+    window.localStorage.setItem(
+      PROJECTS_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+  } catch (error) {
+    console.error("Failed to save projects:", error);
+  }
+}
+
+export function upsertSavedProject(project: SavedProject): SavedProject[] {
+  const normalized = normalizeSavedProject(project);
+  if (!normalized) return loadSavedProjects();
+
+  const projects = loadSavedProjects();
+  const next = [
+    ...projects.filter((entry) => entry.path !== normalized.path),
+    normalized,
+  ];
+  saveSavedProjects(next);
+  return next;
+}
+
+export function removeSavedProject(projectPath: string): SavedProject[] {
+  const next = loadSavedProjects().filter((project) => project.path !== projectPath);
+  saveSavedProjects(next);
+  return next;
+}
+
+export function findSavedProject(projectPath: string): SavedProject | null {
+  return loadSavedProjects().find((project) => project.path === projectPath) ?? null;
+}

--- a/src/styles/components-modals.css
+++ b/src/styles/components-modals.css
@@ -233,6 +233,302 @@
   margin-bottom: 2px;
 }
 
+.project-settings-modal {
+  width: min(560px, calc(100vw - 32px));
+}
+
+.project-settings-modal__body {
+  gap: 16px;
+  max-height: min(72vh, 760px);
+  overflow-y: auto;
+}
+
+.project-settings-modal__path {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-subtle);
+  background: color-mix(in srgb, var(--color-window) 72%, transparent);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  word-break: break-all;
+}
+
+.project-settings-modal__input-wrap {
+  border-color: var(--color-border-mid);
+  background: color-mix(in srgb, var(--color-window) 78%, transparent);
+}
+
+.project-settings-modal__input {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.project-settings-modal__hint {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+}
+
+.project-settings-modal__commands-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.project-settings-modal__bookmark-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 6px 2px 2px;
+}
+
+.project-settings-modal__command-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-window) 76%, transparent);
+}
+
+.project-settings-modal__command-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 72px;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.project-settings-modal__icon-picker {
+  display: flex;
+  min-width: 0;
+}
+
+.project-settings-modal__icon-trigger {
+  width: 100%;
+  min-height: 0;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-mid);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-window) 78%, transparent);
+  color: var(--color-text);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast);
+}
+
+.project-settings-modal__icon-trigger:hover,
+.project-settings-modal__icon-trigger:focus-visible {
+  border-color: color-mix(in srgb, var(--color-primary) 38%, transparent);
+  background: color-mix(in srgb, var(--color-window) 86%, transparent);
+  outline: none;
+}
+
+.project-settings-modal__icon-trigger-chevron {
+  color: var(--color-muted);
+}
+
+.project-settings-modal__icon-menu {
+  position: fixed;
+  z-index: 10010;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-mid);
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.28);
+}
+
+.project-settings-modal__icon-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast);
+}
+
+.project-settings-modal__icon-option:hover,
+.project-settings-modal__icon-option:focus-visible {
+  border-color: color-mix(in srgb, var(--color-primary) 28%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  outline: none;
+}
+
+.project-settings-modal__icon-option[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--color-primary) 38%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+}
+
+.project-settings-modal__icon-placeholder {
+  width: 18px;
+  height: 18px;
+  border: 1.5px dashed color-mix(in srgb, var(--color-muted) 72%, transparent);
+  border-radius: 999px;
+  opacity: 0.85;
+}
+
+.project-settings-modal__command-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.project-settings-modal__show-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-xs);
+  color: var(--color-text);
+}
+
+.project-settings-modal__bookmark-item {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-subtle);
+  background: color-mix(in srgb, var(--color-window) 82%, transparent);
+  color: var(--color-text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition:
+    background var(--t-fast),
+    border-color var(--t-fast),
+    color var(--t-fast);
+}
+
+.project-settings-modal__bookmark-item:hover,
+.project-settings-modal__bookmark-item:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary) 38%, transparent);
+  outline: none;
+}
+
+.project-settings-modal__bookmark-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.project-settings-modal__bookmark-label {
+  line-height: 1;
+}
+
+.project-settings-modal__command-editor-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.project-settings-modal__repo-config {
+  gap: 10px;
+}
+
+.project-settings-modal__repo-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 16px;
+}
+
+.project-settings-modal__repo-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.project-settings-modal__repo-actions {
+  display: flex;
+  align-self: stretch;
+}
+
+.project-settings-modal__footer {
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.project-settings-modal__footer-meta {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-xxs);
+  color: var(--color-muted);
+}
+
+.project-settings-modal__footer-meta-label {
+  text-transform: lowercase;
+}
+
+.project-settings-modal__footer-path {
+  font-family: var(--font-mono);
+  font-size: var(--text-xxs);
+  color: var(--color-text);
+  line-height: 1.6;
+  word-break: break-all;
+}
+
+.project-settings-modal__footer-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .project-settings-modal__commands-header,
+  .project-settings-modal__command-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .project-settings-modal__repo-row {
+    grid-template-columns: 1fr;
+  }
+
+  .project-settings-modal__command-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-settings-modal__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .project-settings-modal__footer-actions {
+    width: 100%;
+  }
+}
+
 /* ═════════════════════════════════════════════════════════════════════════════
    ERROR DETAILS MODAL  (ErrorDetailsModal component)
    Full-screen overlay showing raw error JSON for debugging.
@@ -307,7 +603,9 @@
   color: var(--color-muted);
   cursor: pointer;
   flex-shrink: 0;
-  transition: color var(--t-fast), background var(--t-fast);
+  transition:
+    color var(--t-fast),
+    background var(--t-fast);
 }
 .image-preview-close:hover {
   color: var(--color-text);

--- a/src/styles/layout-new-session.css
+++ b/src/styles/layout-new-session.css
@@ -54,6 +54,12 @@
   justify-content: center;
 }
 
+.ns-project-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* ── Project selector pill ────────────────────────────────────────────────── */
 .ns-project-wrap {
   position: relative;
@@ -83,6 +89,25 @@
 .ns-project-btn:hover {
   background: var(--color-subtle);
   border-color: var(--color-primary-border);
+}
+
+.ns-project-settings-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--color-subtle) 50%, transparent);
+  color: var(--color-muted);
+  transition:
+    background var(--t-base),
+    border-color var(--t-base),
+    color var(--t-base);
+}
+
+.ns-project-settings-btn:hover {
+  background: var(--color-subtle);
+  border-color: var(--color-primary-border);
+  color: var(--color-text);
 }
 
 /* ── Project dropdown ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- add project-scoped setup and repo-backed scripts configuration for saved projects
- run project setup commands through `git_worktree_init` with streaming output and failure recovery
- add future-proof project command management, including bookmark-style previews and an icon picker

## Testing
- npm run typecheck
- npm run lint
- npm run test -- --run
- cargo test

Fixes #32