### PR TITLE
feat(workspace): add project command shortcuts bar

### DIFF
--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -26,6 +26,10 @@ const workspaceMocks = vi.hoisted(() => ({
   openSettingsTabMock: vi.fn<(section?: string) => void>(),
   patchAgentStateMock: vi.fn(),
   updateTabMock: vi.fn(),
+  findSavedProjectMock: vi.fn(),
+  inferProjectNameMock: vi.fn((path: string) => path.split("/").pop() ?? path),
+  resolveSavedProjectMock: vi.fn(),
+  upsertSavedProjectMock: vi.fn(),
   agentState: {
     autoApproveCommands: "no" as const,
     autoApproveEdits: false,
@@ -33,6 +37,7 @@ const workspaceMocks = vi.hoisted(() => ({
     config: {
       cwd: "/repo",
       model: "model-1",
+      projectPath: undefined as string | undefined,
       worktreeBranch: "main",
     },
     contextWindowKb: null,
@@ -66,6 +71,11 @@ const workspaceMocks = vi.hoisted(() => ({
   transcriptCallback: null as null | ((transcript: string) => void),
   invokeMock: vi.fn(),
   eventHandlers: new Map<string, (event: { payload: unknown }) => void>(),
+  terminalProps: null as null | {
+    isOpen: boolean;
+    cwd?: string;
+    commandRequest?: { id: number; command: string } | null;
+  },
 }));
 
 vi.mock("jotai", async () => {
@@ -109,6 +119,16 @@ vi.mock("@/contexts/TabsContext", () => ({
     openSettingsTab: workspaceMocks.openSettingsTabMock,
     updateTab: workspaceMocks.updateTabMock,
   }),
+}));
+
+vi.mock("@/projects", () => ({
+  findSavedProject: (projectPath: string) =>
+    workspaceMocks.findSavedProjectMock(projectPath),
+  inferProjectName: (path: string) => workspaceMocks.inferProjectNameMock(path),
+  resolveSavedProject: (project: unknown) =>
+    workspaceMocks.resolveSavedProjectMock(project),
+  upsertSavedProject: (project: unknown) =>
+    workspaceMocks.upsertSavedProjectMock(project),
 }));
 
 vi.mock("@/agent/useAgents", () => ({
@@ -173,7 +193,29 @@ vi.mock("@/components/ConversationCards", () => ({
 }));
 
 vi.mock("@/components/Terminal", () => ({
-  default: () => null,
+  default: ({
+    isOpen,
+    cwd,
+    commandRequest,
+  }: {
+    isOpen: boolean;
+    cwd?: string;
+    commandRequest?: { id: number; command: string } | null;
+  }) => {
+    workspaceMocks.terminalProps = {
+      isOpen,
+      cwd,
+      commandRequest: commandRequest ?? null,
+    };
+    return (
+      <div
+        data-testid="terminal"
+        data-open={String(isOpen)}
+        data-cwd={cwd ?? ""}
+        data-command={commandRequest?.command ?? ""}
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/UserMessage", () => ({
@@ -409,6 +451,10 @@ describe("WorkspacePage chat input", () => {
       configurable: true,
       value: vi.fn(),
     });
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
     installSelectionGeometryPolyfills();
     workspaceMocks.sendMessageMock.mockReset();
     workspaceMocks.queueMessageMock.mockReset();
@@ -423,8 +469,13 @@ describe("WorkspacePage chat input", () => {
     workspaceMocks.openSettingsTabMock.mockReset();
     workspaceMocks.patchAgentStateMock.mockReset();
     workspaceMocks.updateTabMock.mockReset();
+    workspaceMocks.findSavedProjectMock.mockReset();
+    workspaceMocks.inferProjectNameMock.mockReset();
+    workspaceMocks.resolveSavedProjectMock.mockReset();
+    workspaceMocks.upsertSavedProjectMock.mockReset();
     workspaceMocks.transcriptCallback = null;
     workspaceMocks.eventHandlers.clear();
+    workspaceMocks.terminalProps = null;
     workspaceMocks.invokeMock.mockReset();
     workspaceMocks.invokeMock.mockResolvedValue({
       matches: [
@@ -434,6 +485,20 @@ describe("WorkspacePage chat input", () => {
       ],
       truncated: false,
     });
+    workspaceMocks.inferProjectNameMock.mockImplementation(
+      (path: string) => path.split("/").pop() ?? path,
+    );
+    workspaceMocks.upsertSavedProjectMock.mockImplementation((project: { path: string }) => [
+      project,
+    ]);
+    workspaceMocks.resolveSavedProjectMock.mockImplementation(async (project: unknown) => {
+      const value = project as { path: string; name?: string; commands?: unknown[] };
+      return {
+        path: value.path,
+        name: value.name ?? (value.path.split("/").pop() || value.path),
+        ...(Array.isArray(value.commands) ? { commands: value.commands } : {}),
+      };
+    });
     workspaceMocks.agentState = {
       autoApproveCommands: "no",
       autoApproveEdits: false,
@@ -441,6 +506,7 @@ describe("WorkspacePage chat input", () => {
       config: {
         cwd: "/repo",
         model: "model-1",
+        projectPath: undefined,
         worktreeBranch: "main",
       },
       contextWindowKb: null,
@@ -675,6 +741,104 @@ describe("WorkspacePage chat input", () => {
       showDebug: false,
     });
     expect(nextState.showDebug).toBe(true);
+  });
+
+  it("renders project commands and opens the terminal when one is executed", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      config: {
+        ...workspaceMocks.agentState.config,
+        projectPath: "/repo",
+      },
+    };
+    workspaceMocks.findSavedProjectMock.mockReturnValue({
+      path: "/repo",
+      name: "Repo",
+    });
+    workspaceMocks.resolveSavedProjectMock.mockResolvedValue({
+      path: "/repo",
+      name: "Repo",
+      commands: [
+        {
+          id: "app",
+          label: "App",
+          command: "npm run dev",
+          icon: "play_arrow",
+        },
+        {
+          id: "lint",
+          label: "Lint",
+          command: "npm run lint",
+          icon: "rule",
+          showLabel: false,
+        },
+      ],
+    });
+
+    render(<WorkspacePage />);
+
+    const appButton = await screen.findByRole("button", { name: "Run App" });
+    expect(screen.getByText("App")).not.toBeNull();
+    expect(screen.queryByText("Lint")).toBeNull();
+    expect(screen.getByRole("button", { name: "Run Lint" })).not.toBeNull();
+    expect(screen.getByText("Toggle")).not.toBeNull();
+    expect(screen.getByText("⌘", { selector: "kbd" })).not.toBeNull();
+    expect(screen.getByText("B", { selector: "kbd" })).not.toBeNull();
+
+    fireEvent.click(appButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal").getAttribute("data-open")).toBe("true");
+    });
+    expect(screen.getByTestId("terminal").getAttribute("data-command")).toBe(
+      "npm run dev",
+    );
+  });
+
+  it("toggles the project command bar with Cmd+B", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      config: {
+        ...workspaceMocks.agentState.config,
+        projectPath: "/repo",
+      },
+    };
+    workspaceMocks.findSavedProjectMock.mockReturnValue({
+      path: "/repo",
+      name: "Repo",
+    });
+    workspaceMocks.resolveSavedProjectMock.mockResolvedValue({
+      path: "/repo",
+      name: "Repo",
+      commands: [
+        {
+          id: "app",
+          label: "App",
+          command: "npm run dev",
+          icon: "play_arrow",
+        },
+      ],
+    });
+
+    render(<WorkspacePage />);
+
+    await screen.findByRole("button", { name: "Run App" });
+    expect(screen.getByText("Toggle")).not.toBeNull();
+    expect(screen.getByText("⌘", { selector: "kbd" })).not.toBeNull();
+    expect(screen.getByText("B", { selector: "kbd" })).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Run App" })).toBeNull();
+    });
+    expect(screen.queryByText("Toggle")).toBeNull();
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Run App" })).not.toBeNull();
+    });
   });
 
   it("does not show the queue strip while the agent is busy with no submitted follow-up", async () => {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -32,6 +32,7 @@ import ToolCallDetailsModal from "@/components/ToolCallDetailsModal";
 import ModelPickerModal from "@/components/ModelPickerModal";
 import CompactToolCall from "@/components/CompactToolCall";
 import ReasoningThought from "@/components/ReasoningThought";
+import ProjectCommandBar from "@/components/ProjectCommandBar";
 import {
   MentionTextarea,
   type MentionTextareaHandle,
@@ -65,7 +66,10 @@ import {
   upsertSavedProject,
   type SavedProject,
 } from "@/projects";
-import { writeProjectScriptsConfig } from "@/projectScripts";
+import {
+  writeProjectScriptsConfig,
+  type ProjectCommandConfig,
+} from "@/projectScripts";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Page
@@ -197,9 +201,16 @@ export default function WorkspacePage() {
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [projectSettingsProject, setProjectSettingsProject] =
     useState<SavedProject | null>(null);
+  const [projectCommands, setProjectCommands] = useState<ProjectCommandConfig[]>([]);
+  const [commandBarOpen, setCommandBarOpen] = useState(true);
+  const [terminalCommandRequest, setTerminalCommandRequest] = useState<{
+    id: number;
+    command: string;
+  } | null>(null);
   const [reasoningExpandedById, setReasoningExpandedById] = useState<
     Record<string, boolean>
   >({});
+  const terminalCommandRequestIdRef = useRef(0);
 
   // Track unseen updates even when pane is collapsed
   const {
@@ -277,7 +288,43 @@ export default function WorkspacePage() {
     }
   }, [isNewSession]);
 
+  useEffect(() => {
+    if (isNewSession) {
+      setProjectCommands([]);
+      return;
+    }
+
+    const projectPath = agent.config.projectPath?.trim();
+    if (!projectPath) {
+      setProjectCommands([]);
+      return;
+    }
+
+    let cancelled = false;
+    const savedProject =
+      findSavedProject(projectPath) ?? {
+        path: projectPath,
+        name: inferProjectName(projectPath),
+      };
+
+    void resolveSavedProject(savedProject)
+      .then((resolvedProject) => {
+        if (cancelled) return;
+        setProjectCommands(resolvedProject.commands ?? []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setProjectCommands([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTabId, agent.config.projectPath, isNewSession]);
+
   const toggleTerminal = useCallback(() => setTerminalOpen((v) => !v), []);
+  const toggleCommandBar = useCallback(() => setCommandBarOpen((v) => !v), []);
+  const openTerminal = useCallback(() => setTerminalOpen(true), []);
   const toggleArtifacts = useCallback(() => setArtifactOpen((v) => !v), []);
   const toggleReasoning = useCallback((messageId: string) => {
     setReasoningExpandedById((prev) => ({
@@ -410,6 +457,7 @@ export default function WorkspacePage() {
           ? { setupCommand: resolvedProject.setupCommand }
           : { setupCommand: undefined }),
       });
+      setProjectCommands(resolvedProject.commands ?? []);
       setProjectSettingsProject(null);
     },
     [agent],
@@ -440,9 +488,23 @@ export default function WorkspacePage() {
           ? { setupCommand: resolvedProject.setupCommand }
           : { setupCommand: undefined }),
       });
+      setProjectCommands(resolvedProject.commands ?? []);
       setProjectSettingsProject(resolvedProject);
     },
     [agent],
+  );
+
+  const handleRunProjectCommand = useCallback(
+    (command: ProjectCommandConfig) => {
+      const nextId = terminalCommandRequestIdRef.current + 1;
+      terminalCommandRequestIdRef.current = nextId;
+      openTerminal();
+      setTerminalCommandRequest({
+        id: nextId,
+        command: command.command,
+      });
+    },
+    [openTerminal],
   );
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -587,20 +649,27 @@ export default function WorkspacePage() {
   // ── Global Keyboard shortcuts ───────────────────────────────────────────
   useEffect(() => {
     const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+
       if (e.ctrlKey && !e.altKey && !e.shiftKey && !e.metaKey) {
-        if (e.key === "t" || e.key === "T") {
+        if (key === "t") {
           e.preventDefault();
           toggleTerminal();
         }
-        if (e.key === "a" || e.key === "A") {
+        if (key === "a") {
           e.preventDefault();
           toggleArtifacts();
         }
       }
+
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && key === "b") {
+        e.preventDefault();
+        toggleCommandBar();
+      }
     };
     window.addEventListener("keydown", handleGlobalKeyDown);
     return () => window.removeEventListener("keydown", handleGlobalKeyDown);
-  }, [toggleTerminal, toggleArtifacts]);
+  }, [toggleTerminal, toggleArtifacts, toggleCommandBar]);
 
   const executePlanDisabled =
     isAgentBusy || voiceInput.busy || voiceInput.isRecording;
@@ -657,9 +726,38 @@ export default function WorkspacePage() {
     : voiceInput.isTranscribing
       ? "Transcribing voice..."
       : "Send";
+  const commandBarShortcutKeys =
+    typeof navigator !== "undefined" &&
+    (((navigator.platform ?? "").toLowerCase().startsWith("mac")) ||
+      navigator.userAgent.toLowerCase().includes("mac os"))
+      ? ["⌘", "B"]
+      : ["Ctrl", "B"];
 
   return (
     <div className="workspace-outer">
+      {commandBarOpen ? (
+        <ProjectCommandBar
+          commands={projectCommands}
+          onCommandClick={handleRunProjectCommand}
+          variant="workspace"
+          trailingContent={
+            <span className="project-command-bar__shortcut-hint">
+              <span className="project-command-bar__shortcut-label">Toggle</span>
+              <span className="project-command-bar__shortcut-keys" aria-hidden="true">
+                {commandBarShortcutKeys.map((key) => (
+                  <kbd
+                    key={key}
+                    className="project-command-bar__shortcut-key"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </span>
+            </span>
+          }
+        />
+      ) : null}
+
       {/* ── Two-pane row ────────────────────────────────────────────── */}
       <div className="workspace" ref={containerRef}>
         {/* ════════════════════════════════════════════════════════════
@@ -1056,6 +1154,7 @@ export default function WorkspacePage() {
         activeTabId={activeTabId}
         cwd={agent.config.cwd}
         agentTitle={agent.tabTitle}
+        commandRequest={terminalCommandRequest}
       />
 
       {/* Error details modal */}

--- a/src/components/ProjectCommandBar.tsx
+++ b/src/components/ProjectCommandBar.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import type { ProjectCommandConfig } from "@/projectScripts";
+import { cn } from "@/utils/cn";
+
+export function shouldShowProjectCommandLabel(
+  command: Pick<ProjectCommandConfig, "icon" | "showLabel">,
+): boolean {
+  return command.showLabel !== false || !command.icon?.trim();
+}
+
+interface ProjectCommandBarProps {
+  commands: ProjectCommandConfig[];
+  onCommandClick: (command: ProjectCommandConfig) => void;
+  buttonAriaLabel?: (command: ProjectCommandConfig) => string;
+  buttonTitle?: (command: ProjectCommandConfig) => string;
+  className?: string;
+  variant?: "workspace" | "modal";
+  trailingContent?: ReactNode;
+}
+
+export default function ProjectCommandBar({
+  commands,
+  onCommandClick,
+  buttonAriaLabel = (command) => `Run ${command.label}`,
+  buttonTitle = (command) => `${command.label} • ${command.command}`,
+  className,
+  variant = "workspace",
+  trailingContent,
+}: ProjectCommandBarProps) {
+  if (commands.length === 0) return null;
+
+  return (
+    <div
+      className={cn("project-command-bar", `project-command-bar--${variant}`, className)}
+      role="toolbar"
+      aria-label="Project commands"
+    >
+      <div className="project-command-bar__scroll">
+        {commands.map((command, index) => {
+          const showLabel = shouldShowProjectCommandLabel(command);
+          return (
+            <button
+              key={command.id ?? `${command.label}-${command.command}-${index}`}
+              type="button"
+              className={cn(
+                "project-command-button",
+                !showLabel && "project-command-button--icon-only",
+              )}
+              title={buttonTitle(command)}
+              aria-label={buttonAriaLabel(command)}
+              onClick={() => onCommandClick(command)}
+            >
+              <span
+                className="material-symbols-outlined text-base"
+                aria-hidden="true"
+              >
+                {command.icon?.trim() || "terminal"}
+              </span>
+              {showLabel ? (
+                <span className="project-command-button__label">
+                  {command.label}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {trailingContent ? (
+        <div className="project-command-bar__trailing">{trailingContent}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -73,6 +73,7 @@ describe("ProjectSettingsModal", () => {
     fireEvent.click(screen.getByTitle("Toggle label visibility"));
     fireEvent.click(screen.getAllByRole("button", { name: "SAVE" })[0]);
 
+    expect(screen.queryByText("Run app")).toBeNull();
     fireEvent.click(
       screen.getByRole("button", { name: "Edit command Run app" }),
     );

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { SavedProject } from "@/projects";
 import { PROJECT_SCRIPTS_CONFIG_PATH } from "@/projectScripts";
 import type { ProjectCommandConfig } from "@/projectScripts";
+import ProjectCommandBar from "@/components/ProjectCommandBar";
 import { Button, ModalShell, TextField, ToggleSwitch } from "@/components/ui";
 
 export interface ProjectSettingsSavePayload {
@@ -75,10 +76,6 @@ function buildCommands(drafts: CommandDraft[]): ProjectCommandConfig[] {
       };
     })
     .filter((command): command is ProjectCommandConfig => command !== null);
-}
-
-function commandShowsLabel(command: CommandDraft): boolean {
-  return command.showLabel || !command.icon.trim();
 }
 
 function normalizeCommandDraft(draft: CommandDraft): CommandDraft | null {
@@ -169,6 +166,17 @@ export default function ProjectSettingsModal({
     !hasProjectConfigFile && projectConfigStage !== "visible";
   const selectedCommandIcon = editingCommand?.draft.icon.trim() ?? "";
   const commandIconOptions = getCommandIconOptions(selectedCommandIcon);
+  const previewCommands = useMemo<ProjectCommandConfig[]>(
+    () =>
+      commands.map((command) => ({
+        id: command.draftId,
+        label: command.label.trim() || "Untitled",
+        command: command.command.trim(),
+        ...(command.icon.trim() ? { icon: command.icon.trim() } : {}),
+        ...(command.showLabel !== true ? { showLabel: false } : {}),
+      })),
+    [commands],
+  );
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -427,39 +435,22 @@ export default function ProjectSettingsModal({
               </Button>
             </div>
 
-            {commands.length > 0 ? (
-              <div className="project-settings-modal__bookmark-bar" role="list">
-                {commands.map((command) => (
-                  <button
-                    key={command.draftId}
-                    type="button"
-                    className="project-settings-modal__bookmark-item"
-                    title={`Edit ${command.label.trim() || "command"}`}
-                    aria-label={`Edit command ${command.label.trim() || "command"}`}
-                    onClick={() =>
-                      setEditingCommand({
-                        draft: { ...command },
-                        editingId: command.draftId,
-                      })
-                    }
-                  >
-                    <div className="project-settings-modal__bookmark-main">
-                      <span
-                        className="material-symbols-outlined text-base"
-                        aria-hidden="true"
-                      >
-                        {command.icon.trim() || "terminal"}
-                      </span>
-                      {commandShowsLabel(command) ? (
-                        <span className="project-settings-modal__bookmark-label">
-                          {command.label.trim() || "Untitled"}
-                        </span>
-                      ) : null}
-                    </div>
-                  </button>
-                ))}
-              </div>
-            ) : null}
+            <ProjectCommandBar
+              commands={previewCommands}
+              variant="modal"
+              buttonAriaLabel={(command) => `Edit command ${command.label}`}
+              buttonTitle={(command) => `Edit ${command.label}`}
+              onCommandClick={(command) => {
+                const matchingCommand = commands.find(
+                  (entry) => entry.draftId === command.id,
+                );
+                if (!matchingCommand) return;
+                setEditingCommand({
+                  draft: { ...matchingCommand },
+                  editingId: matchingCommand.draftId,
+                });
+              }}
+            />
 
             {editingCommand ? (
               <div className="project-settings-modal__command-card">

--- a/src/components/Terminal.test.tsx
+++ b/src/components/Terminal.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Terminal from "./Terminal";
+
+const terminalMocks = vi.hoisted(() => {
+  class MockXTerm {
+    rows = 24;
+    cols = 80;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn();
+    focus = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  class MockWebglAddon {}
+
+  return {
+    MockFitAddon,
+    MockWebglAddon,
+    MockXTerm,
+    exitHandlers: new Map<string, (event: { payload: unknown }) => void>(),
+    invokeMock: vi.fn(),
+    outputHandlers: new Map<string, (event: { payload: unknown }) => void>(),
+  };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: terminalMocks.invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (
+    event: string,
+    handler: (event: { payload: unknown }) => void,
+  ) => {
+    if (event.startsWith("pty-exit-")) {
+      terminalMocks.exitHandlers.set(event, handler);
+    }
+    if (event.startsWith("pty-output-")) {
+      terminalMocks.outputHandlers.set(event, handler);
+    }
+    return Promise.resolve(vi.fn());
+  },
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: terminalMocks.MockXTerm,
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: terminalMocks.MockFitAddon,
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: terminalMocks.MockWebglAddon,
+}));
+
+describe("Terminal command execution", () => {
+  let spawnCount = 0;
+
+  beforeEach(() => {
+    spawnCount = 0;
+    terminalMocks.exitHandlers.clear();
+    terminalMocks.outputHandlers.clear();
+    terminalMocks.invokeMock.mockReset();
+    terminalMocks.invokeMock.mockImplementation(
+      async (command: string, args?: Record<string, unknown>) => {
+        if (command === "spawn_pty") {
+          spawnCount += 1;
+          return `session-${spawnCount}`;
+        }
+        if (command === "write_pty") {
+          return undefined;
+        }
+        if (command === "resize_pty") {
+          return undefined;
+        }
+        throw new Error(`Unexpected invoke ${command} ${JSON.stringify(args ?? {})}`);
+      },
+    );
+
+    class ResizeObserverMock {
+      observe() {}
+      disconnect() {}
+    }
+
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes requested commands into the active PTY session", async () => {
+    const props = {
+      isOpen: false,
+      onToggle: vi.fn(),
+      onToggleArtifacts: vi.fn(),
+      activeTabId: "tab-1",
+      cwd: "/repo",
+      agentTitle: "Agent",
+      commandRequest: null,
+    } as const;
+
+    const { rerender } = render(<Terminal {...props} />);
+
+    await waitFor(() => {
+      expect(terminalMocks.invokeMock).toHaveBeenCalledWith("spawn_pty", {
+        cwd: "/repo",
+        rows: 24,
+        cols: 80,
+      });
+    });
+
+    rerender(
+      <Terminal
+        {...props}
+        commandRequest={{ id: 1, command: "npm run dev" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(terminalMocks.invokeMock).toHaveBeenCalledWith("write_pty", {
+        sessionId: "session-1",
+        data: "npm run dev\r",
+      });
+    });
+  });
+
+  it("restarts an exited shell before running the requested command", async () => {
+    const props = {
+      isOpen: false,
+      onToggle: vi.fn(),
+      onToggleArtifacts: vi.fn(),
+      activeTabId: "tab-1",
+      cwd: "/repo",
+      agentTitle: "Agent",
+      commandRequest: null,
+    } as const;
+
+    const { rerender } = render(<Terminal {...props} />);
+
+    await waitFor(() => {
+      expect(terminalMocks.invokeMock).toHaveBeenCalledWith("spawn_pty", {
+        cwd: "/repo",
+        rows: 24,
+        cols: 80,
+      });
+    });
+
+    terminalMocks.exitHandlers.get("pty-exit-session-1")?.({
+      payload: { exitCode: 1 },
+    });
+
+    rerender(
+      <Terminal
+        {...props}
+        commandRequest={{ id: 1, command: "npm run lint" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(terminalMocks.invokeMock).toHaveBeenCalledWith("spawn_pty", {
+        cwd: "/repo",
+        rows: 24,
+        cols: 80,
+      });
+      expect(terminalMocks.invokeMock).toHaveBeenCalledWith("write_pty", {
+        sessionId: "session-2",
+        data: "npm run lint\r",
+      });
+    });
+  });
+});

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -24,6 +24,7 @@ type PtyExitPayload = {
 };
 
 type TermSession = {
+  tabId: string;
   term: XTerm;
   fitAddon: FitAddon;
   sessionId: string;
@@ -48,6 +49,10 @@ interface TerminalProps {
   activeTabId: string;
   cwd?: string;
   agentTitle?: string;
+  commandRequest?: {
+    id: number;
+    command: string;
+  } | null;
 }
 
 export default function Terminal({
@@ -57,6 +62,7 @@ export default function Terminal({
   activeTabId,
   cwd,
   agentTitle,
+  commandRequest = null,
 }: TerminalProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HTMLDivElement>(null);
@@ -66,8 +72,41 @@ export default function Terminal({
   const [, bumpTerminalUiVersion] = useReducer((n: number) => n + 1, 0);
 
   const sessionsRef = useRef<Map<string, TermSession>>(new Map());
+  const queuedCommandsRef = useRef<Map<string, string[]>>(new Map());
+  const lastCommandRequestIdRef = useRef<number | null>(null);
   /** Track previous cwd to detect mid-session changes (e.g. worktree switch) */
   const prevCwdRef = useRef<string | undefined>(undefined);
+
+  const queueCommand = useCallback((tabId: string, command: string) => {
+    const normalized = command.trim();
+    if (!normalized) return;
+
+    const existing = queuedCommandsRef.current.get(tabId) ?? [];
+    existing.push(normalized);
+    queuedCommandsRef.current.set(tabId, existing);
+  }, []);
+
+  const flushQueuedCommands = useCallback(
+    async (tabId: string, session: TermSession) => {
+      const queued = queuedCommandsRef.current.get(tabId);
+      if (!queued?.length || !session.sessionId || session.exited) return;
+
+      queuedCommandsRef.current.delete(tabId);
+      for (const command of queued) {
+        try {
+          await invoke("write_pty", {
+            sessionId: session.sessionId,
+            data: `${command}\r`,
+          });
+        } catch (error) {
+          console.error("Failed to run queued PTY command", error);
+          queueCommand(tabId, command);
+          break;
+        }
+      }
+    },
+    [queueCommand],
+  );
 
   const disposePtyBindings = useCallback((session: TermSession) => {
     if (session.outputUnlisten) {
@@ -89,7 +128,7 @@ export default function Terminal({
   }, []);
 
   const spawnShellForSession = useCallback(
-    async (session: TermSession) => {
+    async (session: TermSession, spawnCwd?: string) => {
       if (session.spawning) return;
 
       session.spawning = true;
@@ -101,7 +140,7 @@ export default function Terminal({
 
       try {
         const sid = await invoke<string>("spawn_pty", {
-          cwd: cwd || "",
+          cwd: spawnCwd ?? cwd ?? "",
           rows: session.term.rows || 24,
           cols: session.term.cols || 80,
         });
@@ -169,6 +208,8 @@ export default function Terminal({
           });
         });
 
+        await flushQueuedCommands(session.tabId, session);
+
         if (isOpen) {
           setTimeout(() => session.fitAddon.fit(), 0);
         }
@@ -183,16 +224,63 @@ export default function Terminal({
         bumpTerminalUiVersion();
       }
     },
-    [cwd, disposePtyBindings, isOpen],
+    [cwd, disposePtyBindings, flushQueuedCommands, isOpen],
   );
+
+  const ensureSession = useCallback(() => {
+    if (!outputWrapRef.current) return null;
+
+    let session = sessionsRef.current.get(activeTabId);
+    if (session) return session;
+
+    const wrap = outputWrapRef.current;
+    const container = document.createElement("div");
+    container.style.width = "100%";
+    container.style.height = "100%";
+    wrap.appendChild(container);
+
+    const term = new XTerm({
+      allowTransparency: true,
+
+      theme: {
+        background: "var(--color-term-bg)",
+        foreground: "var(--color-text, #ffffff)",
+      },
+      fontFamily:
+        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+      fontSize: 13,
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(new WebglAddon());
+
+    term.open(container);
+
+    session = {
+      tabId: activeTabId,
+      term,
+      fitAddon,
+      sessionId: "",
+      container,
+      exited: false,
+      exitCode: null,
+      spawning: false,
+    };
+    sessionsRef.current.set(activeTabId, session);
+    bumpTerminalUiVersion();
+    void spawnShellForSession(session, cwd);
+
+    return session;
+  }, [activeTabId, cwd, spawnShellForSession]);
 
   const restartActiveSession = useCallback(() => {
     const session = sessionsRef.current.get(activeTabId);
     if (!session || session.spawning) return;
 
     session.term.write("\r\n\x1b[36mRestarting shell...\x1b[0m\r\n");
-    void spawnShellForSession(session);
-  }, [activeTabId, spawnShellForSession]);
+    void spawnShellForSession(session, cwd);
+  }, [activeTabId, cwd, spawnShellForSession]);
 
   /* ── Sync height when isOpen changes (CSS transition applies) ─── */
   useEffect(() => {
@@ -230,8 +318,7 @@ export default function Terminal({
   useEffect(() => {
     if (!outputWrapRef.current) return;
 
-    const wrap = outputWrapRef.current;
-    let session = sessionsRef.current.get(activeTabId);
+    let session: TermSession | null = sessionsRef.current.get(activeTabId) ?? null;
 
     // Hide all containers
     for (const [id, s] of sessionsRef.current.entries()) {
@@ -246,43 +333,13 @@ export default function Terminal({
     }
 
     if (!session) {
-      const container = document.createElement("div");
-      container.style.width = "100%";
-      container.style.height = "100%";
-      wrap.appendChild(container);
-
-      const term = new XTerm({
-        allowTransparency: true,
-
-        theme: {
-          background: "var(--color-term-bg)",
-          foreground: "var(--color-text, #ffffff)",
-        },
-        fontFamily:
-          'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
-        fontSize: 13,
-      });
-
-      const fitAddon = new FitAddon();
-      term.loadAddon(fitAddon);
-      term.loadAddon(new WebglAddon());
-
-      term.open(container);
-
-      session = {
-        term,
-        fitAddon,
-        sessionId: "",
-        container,
-        exited: false,
-        exitCode: null,
-        spawning: false,
-      };
-      sessionsRef.current.set(activeTabId, session);
-      bumpTerminalUiVersion();
-      void spawnShellForSession(session);
+      session = ensureSession();
     }
-  }, [activeTabId, isOpen, spawnShellForSession]);
+
+    if (session) {
+      session.container.style.display = "block";
+    }
+  }, [activeTabId, ensureSession, isOpen]);
 
   /* ── Sync terminal cwd when the agent switches to a worktree mid-session ─── */
   useEffect(() => {
@@ -303,6 +360,38 @@ export default function Terminal({
       data: `cd ${JSON.stringify(cwd)}\r`,
     }).catch(console.error);
   }, [cwd, activeTabId]);
+
+  useEffect(() => {
+    if (!commandRequest) return;
+    if (commandRequest.id === lastCommandRequestIdRef.current) return;
+    lastCommandRequestIdRef.current = commandRequest.id;
+
+    const session = ensureSession();
+    if (!session) return;
+
+    if (session.sessionId && !session.exited && !session.spawning) {
+      invoke("write_pty", {
+        sessionId: session.sessionId,
+        data: `${commandRequest.command}\r`,
+      }).catch((error) => {
+        console.error("Failed to run PTY command", error);
+      });
+      return;
+    }
+
+    queueCommand(activeTabId, commandRequest.command);
+    if (session.exited && !session.spawning) {
+      session.term.write("\r\n\x1b[36mRestarting shell...\x1b[0m\r\n");
+      void spawnShellForSession(session, cwd);
+    }
+  }, [
+    activeTabId,
+    commandRequest,
+    cwd,
+    ensureSession,
+    queueCommand,
+    spawnShellForSession,
+  ]);
 
   // Clean up sessions when component unmounts (app close/reload)
   useEffect(() => {

--- a/src/styles/components-modals.css
+++ b/src/styles/components-modals.css
@@ -280,14 +280,6 @@
   gap: 16px;
 }
 
-.project-settings-modal__bookmark-bar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  overflow-x: auto;
-  padding: 6px 2px 2px;
-}
-
 .project-settings-modal__command-card {
   display: flex;
   flex-direction: column;
@@ -404,43 +396,6 @@
   gap: 10px;
   font-size: var(--text-xs);
   color: var(--color-text);
-}
-
-.project-settings-modal__bookmark-item {
-  display: inline-flex;
-  align-items: center;
-  min-height: 38px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid var(--color-border-subtle);
-  background: color-mix(in srgb, var(--color-window) 82%, transparent);
-  color: var(--color-text);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  cursor: pointer;
-  transition:
-    background var(--t-fast),
-    border-color var(--t-fast),
-    color var(--t-fast);
-}
-
-.project-settings-modal__bookmark-item:hover,
-.project-settings-modal__bookmark-item:focus-visible {
-  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
-  border-color: color-mix(in srgb, var(--color-primary) 38%, transparent);
-  outline: none;
-}
-
-.project-settings-modal__bookmark-main {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  white-space: nowrap;
-}
-
-.project-settings-modal__bookmark-label {
-  line-height: 1;
 }
 
 .project-settings-modal__command-editor-actions {

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -20,6 +20,140 @@
   background: var(--color-surface);
 }
 
+.project-command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 34px;
+  padding: 4px 8px;
+  background: color-mix(in srgb, var(--color-surface) 92%, var(--color-window));
+}
+
+.project-command-bar--workspace {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.project-command-bar--modal {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-window) 78%, transparent);
+}
+
+.project-command-bar__scroll {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 1px;
+}
+
+.project-command-bar__scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.project-command-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid color-mix(in srgb, var(--color-border-mid) 72%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-inset) 82%, transparent);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+  cursor: default;
+  transition:
+    background var(--t-fast),
+    border-color var(--t-fast),
+    color var(--t-fast),
+    transform var(--t-fast);
+}
+
+.project-command-button:hover,
+.project-command-button:focus-visible {
+  background: color-mix(in srgb, var(--color-primary-dim) 65%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.project-command-button:active {
+  transform: translateY(1px);
+}
+
+.project-command-button--icon-only {
+  width: 24px;
+  justify-content: center;
+  padding: 0;
+}
+
+.project-command-button__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.project-command-bar__trailing {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.project-command-bar__shortcut-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+.project-command-bar__shortcut-label {
+  color: var(--color-muted);
+}
+
+.project-command-bar__shortcut-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.project-command-bar__shortcut-key {
+  min-width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border: 1px solid color-mix(in srgb, var(--color-border-mid) 72%, transparent);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--color-window) 82%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 0 rgba(0, 0, 0, 0.18);
+  color: color-mix(in srgb, var(--color-text) 88%, transparent);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: none;
+}
+
 /* ── Chat pane ───────────────────────────────────────────────────────────── */
 .chat-pane {
   min-width: 20%;


### PR DESCRIPTION
## Summary
- add a project command bar below the workspace tabs for project-specific commands
- run command shortcuts through the integrated terminal, including auto-open and shell restart handling
- share the same compact command-bar UI between the workspace and Project Settings preview, including the Cmd+B toggle hint

## Testing
- npm run test -- --run src/WorkspacePage.test.tsx src/components/Terminal.test.tsx src/components/ProjectSettingsModal.test.tsx
- npm run typecheck
- npm run lint -- src/WorkspacePage.tsx src/WorkspacePage.test.tsx src/components/ProjectCommandBar.tsx src/components/Terminal.tsx src/components/Terminal.test.tsx src/components/ProjectSettingsModal.tsx src/components/ProjectSettingsModal.test.tsx

Issue: n/a