### PR TITLE
fix: isolate parallel subagent chat threads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,7 +196,9 @@ renders the shortcuts and runs them in the integrated terminal when clicked.
 
 Subagents are registered in
 [`src/agent/subagents/index.ts`](../src/agent/subagents/index.ts) and run in a
-private tool loop inside the main runner.
+private tool loop inside the main runner. Each subagent invocation owns a
+stable chat bubble/thread in the parent tab so parallel calls to the same
+subagent do not merge their streamed turns together.
 
 Artifacts are the durable output channel for plans, reviews, security reports,
 and other structured handoffs. The detailed contracts live in:

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -8,6 +8,10 @@ Subagents are specialized agents that the main agent can delegate work to with
 They run their own reasoning/tool loop, but their chat output is displayed in
 the parent tab with the subagent's name and styling.
 
+Each `agent_subagent_call` invocation owns its own chat bubble/thread in the
+parent tab. Later turns from that same invocation stay attached to the original
+bubble even when multiple calls to the same subagent are running in parallel.
+
 Subagent registration lives in
 [`src/agent/subagents/index.ts`](../src/agent/subagents/index.ts).
 
@@ -120,7 +124,9 @@ High-level flow:
 5. Subagent optionally writes durable outputs as artifacts
 6. Subagent may also post user-visible conversation cards with `agent_card_add`
 7. Runner validates produced artifacts against the declared contract
-8. Runner returns the result to the parent as:
+8. Runner keeps that invocation's streamed assistant turns attached to one
+   stable bubble/thread in the parent chat UI
+9. Runner returns the result to the parent as:
    - `rawText`
    - `cards`
    - `artifacts`
@@ -214,7 +220,8 @@ Trigger resolution happens in
 [`findSubagentByTrigger()`](../src/agent/subagents/index.ts).
 
 Direct trigger routing still uses the same artifact contract enforcement as
-parent-initiated delegation.
+parent-initiated delegation and still renders as a single threaded subagent
+bubble in the parent tab.
 
 ## Adding a New Subagent
 

--- a/src/agent/chatBubbleGroups.test.ts
+++ b/src/agent/chatBubbleGroups.test.ts
@@ -11,12 +11,17 @@ function userMessage(id: string, content: string): ChatMessage {
   };
 }
 
-function assistantMessage(id: string, content: string): ChatMessage {
+function assistantMessage(
+  id: string,
+  content: string,
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage {
   return {
     id,
     role: "assistant",
     content,
     timestamp: 1,
+    ...overrides,
   };
 }
 
@@ -99,5 +104,65 @@ describe("groupChatMessagesForBubbles", () => {
       "a2",
       "a3",
     ]);
+  });
+
+  it("keeps legacy assistant grouping unchanged when bubbleGroupId is absent", () => {
+    const groups = groupChatMessagesForBubbles([
+      assistantMessage("a1", "First", { agentName: "GitHub Operator" }),
+      assistantMessage("a2", "Second", { agentName: "GitHub Operator" }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    if (groups[0].kind !== "assistant") {
+      throw new Error("Expected assistant group");
+    }
+    expect(groups[0].messages.map((msg) => msg.id)).toEqual(["a1", "a2"]);
+  });
+
+  it("separates same-agent messages when bubbleGroupId differs", () => {
+    const groups = groupChatMessagesForBubbles([
+      assistantMessage("a1", "First", {
+        agentName: "GitHub Operator",
+        bubbleGroupId: "call-1",
+      }),
+      assistantMessage("a2", "Second", {
+        agentName: "GitHub Operator",
+        bubbleGroupId: "call-2",
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({
+      kind: "assistant",
+      key: "assistant:GitHub Operator:call-1",
+    });
+    expect(groups[1]).toMatchObject({
+      kind: "assistant",
+      key: "assistant:GitHub Operator:call-2",
+    });
+  });
+
+  it("reuses the original bubble position for later messages in the same threaded group", () => {
+    const groups = groupChatMessagesForBubbles([
+      assistantMessage("a1", "First", {
+        agentName: "GitHub Operator",
+        bubbleGroupId: "call-1",
+      }),
+      assistantMessage("b1", "Other", {
+        agentName: "GitHub Operator",
+        bubbleGroupId: "call-2",
+      }),
+      assistantMessage("a2", "Later", {
+        agentName: "GitHub Operator",
+        bubbleGroupId: "call-1",
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    if (groups[0].kind !== "assistant" || groups[1].kind !== "assistant") {
+      throw new Error("Expected assistant groups");
+    }
+    expect(groups[0].messages.map((msg) => msg.id)).toEqual(["a1", "a2"]);
+    expect(groups[1].messages.map((msg) => msg.id)).toEqual(["b1"]);
   });
 });

--- a/src/agent/chatBubbleGroups.ts
+++ b/src/agent/chatBubbleGroups.ts
@@ -28,22 +28,50 @@ function isUserMessage(msg: ChatMessage): msg is UserChatMessage {
 }
 
 /**
- * Group adjacent assistant turns so the UI can render them in a single bubble.
- * User messages are always rendered as standalone bubbles.
+ * Group assistant turns into UI bubbles.
+ * Messages with bubbleGroupId stay attached to a stable bubble even when other
+ * assistant messages interleave. User messages are always standalone.
  */
 export function groupChatMessagesForBubbles(
   messages: ChatMessage[],
 ): ChatBubbleGroup[] {
   const groups: ChatBubbleGroup[] = [];
+  const threadedAssistantGroupIndexes = new Map<string, number>();
 
   for (const msg of messages) {
     if (isAssistantMessage(msg)) {
+      const threadedGroupKey = msg.bubbleGroupId
+        ? `assistant:${msg.agentName ?? "Rakh"}:${msg.bubbleGroupId}`
+        : null;
+      if (threadedGroupKey) {
+        const existingGroupIndex = threadedAssistantGroupIndexes.get(
+          threadedGroupKey,
+        );
+        if (existingGroupIndex !== undefined) {
+          const existingGroup = groups[existingGroupIndex];
+          if (existingGroup?.kind === "assistant") {
+            existingGroup.messages.push(msg);
+            continue;
+          }
+        }
+
+        groups.push({
+          kind: "assistant",
+          key: threadedGroupKey,
+          messages: [msg],
+          agentName: msg.agentName,
+        });
+        threadedAssistantGroupIndexes.set(threadedGroupKey, groups.length - 1);
+        continue;
+      }
+
       const prev = groups[groups.length - 1];
       // Merge into the previous assistant bubble only when the agent name matches.
       if (
         prev &&
         prev.kind === "assistant" &&
-        prev.agentName === msg.agentName
+        prev.agentName === msg.agentName &&
+        prev.messages.every((existingMessage) => !existingMessage.bubbleGroupId)
       ) {
         prev.messages.push(msg);
         continue;

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -154,8 +154,9 @@ import {
   stopAgent,
   stopRunningExecToolCall,
 } from "./runner";
+import { groupChatMessagesForBubbles } from "./chatBubbleGroups";
 import { registerDynamicModels } from "./modelCatalog";
-import type { AdvancedModelOptions } from "./types";
+import type { AdvancedModelOptions, ChatMessage } from "./types";
 import { DEFAULT_ADVANCED_OPTIONS } from "./types";
 
 function makeState(overrides: Partial<MockAgentState> = {}): MockAgentState {
@@ -252,6 +253,16 @@ async function flushAsyncWork(rounds = 6): Promise<void> {
   for (let index = 0; index < rounds; index += 1) {
     await Promise.resolve();
   }
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("runner", () => {
@@ -1838,6 +1849,176 @@ describe("runner", () => {
         },
       });
       expect(streamTextMock).toHaveBeenCalledTimes(4);
+    });
+
+    it("keeps parallel subagent invocations isolated in chat state", async () => {
+      const tabId = "tab-subagent-parallel";
+      setState(tabId);
+
+      const subagentToolCallIds = [
+        "tc-github-1",
+        "tc-github-2",
+        "tc-github-3",
+      ] as const;
+      const subagentOutputs = [
+        {
+          text: "Created issue for the tray request.",
+          reasoning: "Inspect tray-related code paths.",
+        },
+        {
+          text: "Created issue for archived tab grouping.",
+          reasoning: "Inspect archived session persistence.",
+        },
+        {
+          text: "Created issue for approved command allowlists.",
+          reasoning: "Inspect exec approvals and settings state.",
+        },
+      ] as const;
+      const subagentGates = subagentOutputs.map(() => createDeferred<void>());
+      const emptyStream = () => (async function* () {})();
+      let streamCallIndex = 0;
+
+      streamTextMock.mockImplementation(() => {
+        const currentCall = streamCallIndex;
+        streamCallIndex += 1;
+
+        if (currentCall === 0) {
+          return {
+            textStream: emptyStream(),
+            fullStream: emptyStream(),
+            toolCalls: Promise.resolve(
+              subagentToolCallIds.map((toolCallId, index) => ({
+                id: toolCallId,
+                name: "agent_subagent_call",
+                arguments: {
+                  subagentId: "github",
+                  message: `create issue ${index + 1}`,
+                },
+              })),
+            ),
+          };
+        }
+
+        if (currentCall >= 1 && currentCall <= 3) {
+          const output = subagentOutputs[currentCall - 1];
+          const gate = subagentGates[currentCall - 1];
+          return {
+            textStream: emptyStream(),
+            fullStream: (async function* () {
+              await gate.promise;
+              yield {
+                type: "reasoning-start",
+                id: `reasoning-${currentCall}`,
+              };
+              yield {
+                type: "reasoning-delta",
+                id: `reasoning-${currentCall}`,
+                delta: output.reasoning,
+              };
+              await Promise.resolve();
+              yield {
+                type: "text-delta",
+                id: `text-${currentCall}`,
+                delta: output.text,
+              };
+              yield {
+                type: "reasoning-end",
+                id: `reasoning-${currentCall}`,
+              };
+            })(),
+            toolCalls: Promise.resolve([]),
+          };
+        }
+
+        if (currentCall === 4) {
+          return {
+            textStream: (async function* () {
+              yield "All issues created.";
+            })(),
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: "text-main-final",
+                delta: "All issues created.",
+              };
+            })(),
+            toolCalls: Promise.resolve([]),
+          };
+        }
+
+        throw new Error(`Unexpected streamText call index ${currentCall}`);
+      });
+
+      const runPromise = runAgent(tabId, "create three issues");
+      await flushAsyncWork(6);
+
+      expect(streamCallIndex).toBe(4);
+
+      subagentGates[1]?.resolve();
+      await flushAsyncWork(6);
+      subagentGates[0]?.resolve();
+      await flushAsyncWork(6);
+      subagentGates[2]?.resolve();
+
+      await runPromise;
+
+      const state = states[tabId];
+      expect(state.status).toBe("idle");
+
+      const subagentMessages = state.chatMessages.filter(
+        (message) => message.agentName === "GitHub Operator",
+      );
+      expect(subagentMessages).toHaveLength(3);
+      expect(
+        new Set(subagentMessages.map((message) => message.bubbleGroupId)),
+      ).toEqual(new Set(subagentToolCallIds));
+      expect(
+        subagentMessages.every((message) => message.streaming === false),
+      ).toBe(true);
+      expect(
+        subagentMessages.every(
+          (message) => message.reasoningStreaming === undefined,
+        ),
+      ).toBe(true);
+      expect(
+        subagentMessages.every(
+          (message) => typeof message.reasoningDurationMs === "number",
+        ),
+      ).toBe(true);
+
+      const toolCallStatusById = new Map(
+        state.chatMessages
+          .flatMap(
+            (message) =>
+              (message.toolCalls as Array<Record<string, unknown>> | undefined) ??
+              [],
+          )
+          .map((toolCall) => [toolCall.id, toolCall.status]),
+      );
+      for (const toolCallId of subagentToolCallIds) {
+        expect(toolCallStatusById.get(toolCallId)).toBe("done");
+      }
+
+      for (const [index, toolCallId] of subagentToolCallIds.entries()) {
+        expect(parseToolMessageResult(tabId, toolCallId)).toMatchObject({
+          ok: true,
+          data: {
+            subagentId: "github",
+            rawText: subagentOutputs[index]?.text,
+          },
+        });
+      }
+
+      const groupedMessages = groupChatMessagesForBubbles(
+        state.chatMessages as unknown as ChatMessage[],
+      );
+      expect(
+        groupedMessages.filter(
+          (group) =>
+            group.kind === "assistant" &&
+            group.agentName === "GitHub Operator",
+        ),
+      ).toHaveLength(3);
     });
 
     it("rejects invalid reviewer artifacts before persistence and succeeds after retry", async () => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -951,15 +951,51 @@ function appendChatMessage(tabId: string, msg: ChatMessage): void {
   }));
 }
 
-function updateLastChatMessage(
+function updateChatMessageById(
   tabId: string,
+  messageId: string,
   updater: (msg: ChatMessage) => ChatMessage,
 ): void {
   patchAgentState(tabId, (prev) => {
-    const msgs = [...prev.chatMessages];
-    if (msgs.length === 0) return prev;
-    msgs[msgs.length - 1] = updater(msgs[msgs.length - 1]);
-    return { ...prev, chatMessages: msgs };
+    let didUpdate = false;
+    const chatMessages = prev.chatMessages.map((msg) => {
+      if (msg.id !== messageId) return msg;
+      didUpdate = true;
+      return updater(msg);
+    });
+    return didUpdate ? { ...prev, chatMessages } : prev;
+  });
+}
+
+function finalizeLatestStreamingAssistantMessage(tabId: string): void {
+  const finalizedAtMs = Date.now();
+  patchAgentState(tabId, (prev) => {
+    const chatMessages = [...prev.chatMessages];
+    for (let index = chatMessages.length - 1; index >= 0; index -= 1) {
+      const msg = chatMessages[index];
+      if (msg.role !== "assistant") continue;
+      const reasoningStartedAtMs = msg.reasoningStartedAtMs;
+      const shouldFinalizeReasoningDuration =
+        typeof reasoningStartedAtMs === "number" &&
+        typeof msg.reasoningDurationMs !== "number";
+      if (
+        !msg.streaming &&
+        !msg.reasoningStreaming &&
+        !shouldFinalizeReasoningDuration
+      ) {
+        continue;
+      }
+      chatMessages[index] = {
+        ...msg,
+        streaming: false,
+        reasoningStreaming: undefined,
+        reasoningDurationMs: shouldFinalizeReasoningDuration
+          ? Math.max(0, finalizedAtMs - reasoningStartedAtMs)
+          : msg.reasoningDurationMs,
+      };
+      return { ...prev, chatMessages };
+    }
+    return prev;
   });
 }
 
@@ -1286,6 +1322,7 @@ interface SubagentLoopOptions {
   parentModelId: string;
   providers: ProviderInstance[];
   debugEnabled: boolean;
+  bubbleGroupId?: string;
 }
 
 /**
@@ -1313,10 +1350,12 @@ async function runSubagentLoop(
     parentModelId,
     providers,
     debugEnabled,
+    bubbleGroupId,
   } = opts;
 
   const startedAtMs = Date.now();
   const modelId = resolveSubagentModelId(subagentDef, parentModelId, providers);
+  const resolvedBubbleGroupId = bubbleGroupId?.trim() || msgId();
 
   let languageModel;
   try {
@@ -1667,6 +1706,7 @@ async function runSubagentLoop(
       id: assistantChatId,
       role: "assistant",
       agentName: subagentDef.name,
+      bubbleGroupId: resolvedBubbleGroupId,
       content: "",
       timestamp: Date.now(),
       streaming: true,
@@ -1682,19 +1722,16 @@ async function runSubagentLoop(
     });
 
     const updateSubagentStreamMsg = () => {
-      updateLastChatMessage(tabId, (m) =>
-        m.id === assistantChatId
-          ? {
-              ...m,
-              agentName: subagentDef.name,
-              content: accText,
-              reasoning: accReasoning || undefined,
-              reasoningStreaming: reasoningActive ? true : undefined,
-              reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
-              reasoningDurationMs: reasoningDurationMs ?? undefined,
-            }
-          : m,
-      );
+      updateChatMessageById(tabId, assistantChatId, (m) => ({
+        ...m,
+        agentName: subagentDef.name,
+        bubbleGroupId: resolvedBubbleGroupId,
+        content: accText,
+        reasoning: accReasoning || undefined,
+        reasoningStreaming: reasoningActive ? true : undefined,
+        reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+        reasoningDurationMs: reasoningDurationMs ?? undefined,
+      }));
     };
 
     try {
@@ -1785,11 +1822,11 @@ async function runSubagentLoop(
     );
 
     // Finalise the streaming assistant message.
-    updateLastChatMessage(tabId, (m) => {
-      if (m.id !== assistantChatId) return m;
+    updateChatMessageById(tabId, assistantChatId, (m) => {
       return {
         ...m,
         agentName: subagentDef.name,
+        bubbleGroupId: resolvedBubbleGroupId,
         content: accText,
         reasoning: accReasoning || undefined,
         reasoningStreaming: undefined,
@@ -2277,9 +2314,7 @@ async function runAgentTurn(
       }
       const msg = err instanceof Error ? err.message : String(err);
       setAgentErrorState(tabId, msg, serializeError(err));
-      updateLastChatMessage(tabId, (m) =>
-        m.role === "assistant" ? { ...m, streaming: false } : m,
-      );
+      finalizeLatestStreamingAssistantMessage(tabId);
       return;
     } finally {
       clearActiveRun(tabId, activeRun);
@@ -2471,9 +2506,7 @@ async function runAgentTurn(
     }
     const msg = err instanceof Error ? err.message : String(err);
     setAgentErrorState(tabId, msg, serializeError(err));
-    updateLastChatMessage(tabId, (m) =>
-      m.role === "assistant" ? { ...m, streaming: false } : m,
-    );
+    finalizeLatestStreamingAssistantMessage(tabId);
   } finally {
     clearActiveRun(tabId, activeRun);
     if (activeRun.abortReason !== null) return;
@@ -2582,18 +2615,14 @@ async function agentLoop(
       };
 
       const updateStreamingMessage = () => {
-        updateLastChatMessage(tabId, (m) =>
-          m.id === assistantChatId
-            ? {
-                ...m,
-                content: accText,
-                reasoning: accReasoning || undefined,
-                reasoningStreaming: reasoningActive ? true : undefined,
-                reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
-                reasoningDurationMs: reasoningDurationMs ?? undefined,
-              }
-            : m,
-        );
+        updateChatMessageById(tabId, assistantChatId, (m) => ({
+          ...m,
+          content: accText,
+          reasoning: accReasoning || undefined,
+          reasoningStreaming: reasoningActive ? true : undefined,
+          reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+          reasoningDurationMs: reasoningDurationMs ?? undefined,
+        }));
       };
 
       const fullStream = (result as { fullStream?: AsyncIterable<unknown> })
@@ -2758,8 +2787,7 @@ async function agentLoop(
 
     // Finalise the streaming chat message. Every assistant turn maps to one
     // assistant bubble; tool calls for this turn stay attached to this bubble.
-    updateLastChatMessage(tabId, (m) => {
-      if (m.id !== assistantChatId) return m;
+    updateChatMessageById(tabId, assistantChatId, (m) => {
       return {
         ...m,
         content: accText,
@@ -2881,6 +2909,7 @@ async function agentLoop(
             parentModelId: modelId,
             providers,
             debugEnabled,
+            bubbleGroupId: tcId,
           });
 
           updateToolCallById({

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -216,6 +216,11 @@ export interface ChatMessage {
    * Subagent messages carry the subagent's name (e.g. "Planner").
    */
   agentName?: string;
+  /**
+   * Stable bubble/thread identifier for assistant messages that should stay in
+   * the same UI bubble even when other assistant messages interleave.
+   */
+  bubbleGroupId?: string;
   /** Optional streamed reasoning content for this assistant turn. */
   reasoning?: string;
   /** True while reasoning tokens are still streaming for this assistant turn. */


### PR DESCRIPTION
## Summary
- isolate assistant stream updates by message id so concurrent subagent runs do not mutate the wrong chat bubble
- thread each subagent invocation into its own chat bubble via `bubbleGroupId`, while preserving legacy adjacency grouping for normal assistant messages
- add regressions for parallel same-subagent runs and update the subagent/architecture docs to describe the threaded UI behavior

## Testing
- npm test -- --run src/agent/chatBubbleGroups.test.ts src/agent/runner.test.ts
- npm run typecheck
