### PR TITLE
feat: add MCP settings registry and attachment artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ artifacts, and specialized subagents.
 - Multiple independent agent tabs, each with isolated state and chat history
 - OpenAI, Anthropic, and OpenAI-compatible provider support
 - Safe file edits and shell commands through explicit approval gates
+- Global MCP server registry in Settings, with per-run MCP tool discovery
 - Automatic git worktree setup before agent-driven code changes
 - Built-in subagents for planning, review, security, copy, and GitHub tasks
 - Durable artifacts for plans, reports, and other structured outputs
@@ -68,6 +69,18 @@ You can:
 - add an OpenAI, Anthropic, or OpenAI-compatible provider in Settings
 - import `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` from your environment if they
   are already set
+
+## MCP setup
+
+Rakh can also discover tools from globally configured MCP servers.
+
+In `Settings -> MCP Servers` you can:
+
+- add stdio or streamable HTTP MCP server configs as JSON
+- test discovery before saving
+- enable `Save returned files as artifacts` if you want MCP-returned images or
+  files to be stored in the artifact pane instead of being passed back into
+  model context raw
 
 The model picker is built from the static catalog in
 `src/agent/models.catalog.json` plus any cached model list for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,8 +13,8 @@ backend. The UI manages multiple agent tabs. Each workspace tab owns isolated
 Jotai state, its own chat history, and its own agent run loop.
 
 The agent runtime uses the Vercel AI SDK for streaming model output, tool
-calling, subagent delegation, and approval-driven execution against the local
-workspace.
+calling, subagent delegation, MCP-backed dynamic tool registration, and
+approval-driven execution against the local workspace.
 
 ```mermaid
 graph TB
@@ -42,7 +42,8 @@ graph TB
 [`src/App.tsx`](../src/App.tsx) is the bootstrap layer. It:
 
 - loads saved sessions from the Tauri SQLite backend
-- loads configured providers from the Tauri backend (`providers_load`)
+- loads configured providers from IndexedDB
+- loads global MCP server configuration from the Tauri config store
 - hydrates Jotai state before workspace tabs render
 - applies theme mode and theme name to `<html>`
 - auto-saves settled sessions and archives closed workspace tabs
@@ -89,10 +90,8 @@ components subscribe with fine-grained derived atoms from `useAgents.ts`.
 
 ### Model and provider resolution
 
-Provider instances are configured in Settings and persisted to disk via
-[`src/agent/db.ts`](../src/agent/db.ts), which calls the Rust backend commands
-`providers_load` and `providers_save` from
-[`src-tauri/src/db.rs`](../src-tauri/src/db.rs). The model picker is built in
+Provider instances are configured in Settings and stored in IndexedDB via
+[`src/agent/db.ts`](../src/agent/db.ts). The model picker is built in
 [`src/agent/useModels.ts`](../src/agent/useModels.ts):
 
 - OpenAI and Anthropic models come from the static catalog in
@@ -141,13 +140,14 @@ Current tool groups:
 - `workspace_*`: list/stat/read/write/edit/glob/search
 - `exec_run`
 - `git_worktree_init`
+- dynamically discovered `mcp_*` tools prepared per main-agent run
 - `agent_todo_*`
 - `agent_artifact_*`
 - `agent_title_*`
 
 Sensitive actions go through [`src/agent/approvals.ts`](../src/agent/approvals.ts).
 That includes file edits, shell execution, worktree creation, and explicit user
-input requests.
+input requests. MCP tool calls also go through the same approval path.
 
 Review data is captured in two places:
 
@@ -156,49 +156,11 @@ Review data is captured in two places:
 - `AgentState.reviewEdits`: per-file original-to-current diffs shown in the
   review pane
 
-### Project commands and setup scripts
-
-Each workspace project can define a setup command and custom command shortcuts
-via a project-scoped config file. The config lives at
-`<project-root>/.rakh/scripts.json` and is managed through the Project Settings
-modal (gear icon in the workspace header).
-
-[`src/projectScripts.ts`](../src/projectScripts.ts) defines the schema:
-
-```json
-{
-  "setupCommand": "npm install",
-  "commands": [
-    { "id": "build", "label": "Build", "command": "npm run build", "icon": "hammer", "showLabel": true }
-  ]
-}
-```
-
-- `setupCommand`: optional shell command run automatically after git worktree
-  creation for that project
-- `commands`: array of shortcuts displayed in the Project Command Bar
-  (toggle with `Cmd+B`). Each command has an id, label, shell command, optional
-  icon, and showLabel flag.
-
-[`src/projects.ts`](../src/projects.ts) handles resolution:
-
-1. Saved projects (path + name) are stored in localStorage (`rakh-projects`)
-2. On load, `resolveSavedProject()` checks for `.rakh/scripts.json`
-3. If the config file exists, its `setupCommand` and `commands` take precedence
-   over any values in localStorage, and `hasProjectConfigFile` is set to `true`
-4. The Project Settings modal writes directly to `.rakh/scripts.json` when
-   `hasProjectConfigFile` is true, otherwise falls back to localStorage
-
-The Project Command Bar ([`src/components/ProjectCommandBar.tsx`](../src/components/ProjectCommandBar.tsx))
-renders the shortcuts and runs them in the integrated terminal when clicked.
-
 ### Subagents and artifacts
 
 Subagents are registered in
 [`src/agent/subagents/index.ts`](../src/agent/subagents/index.ts) and run in a
-private tool loop inside the main runner. Each subagent invocation owns a
-stable chat bubble/thread in the parent tab so parallel calls to the same
-subagent do not merge their streamed turns together.
+private tool loop inside the main runner.
 
 Artifacts are the durable output channel for plans, reviews, security reports,
 and other structured handoffs. The detailed contracts live in:
@@ -224,6 +186,8 @@ Current backend modules:
 - [`src-tauri/src/pty.rs`](../src-tauri/src/pty.rs): interactive terminal PTY
   lifecycle used by the xterm.js terminal
 - [`src-tauri/src/git.rs`](../src-tauri/src/git.rs): worktree creation command
+- [`src-tauri/src/mcp.rs`](../src-tauri/src/mcp.rs): global MCP config
+  persistence plus per-run MCP transport/session management
 - [`src-tauri/src/whisper.rs`](../src-tauri/src/whisper.rs): local Whisper
   model download/preparation and WAV transcription
 - [`src-tauri/src/shell_env.rs`](../src-tauri/src/shell_env.rs): login-shell
@@ -239,18 +203,16 @@ frontend can refresh the artifact pane without polling.
 
 Rakh persists data in multiple places by design:
 
-- provider instances: `~/.rakh/config/providers.json` (debug: `~/.rakh-dev/config/providers.json`),
-  managed via `providers_load` / `providers_save` Tauri commands
+- provider instances: browser IndexedDB (`rakh-providers`)
 - theme mode, theme name, selected model, and some UI preferences: localStorage
+- global MCP server registry + MCP settings: `~/.rakh/config/mcp_servers.json`
+  or `~/.rakh-dev/config/mcp_servers.json`
 - release sessions and artifact manifests: `~/.rakh/sessions/sessions.db`
 - debug/dev sessions and artifact manifests: `~/.rakh-dev/sessions/sessions.db`
 - release artifact content blobs: `~/.rakh/artifacts/blobs/sha256`
 - debug/dev artifact content blobs: `~/.rakh-dev/artifacts/blobs/sha256`
 - release git worktrees created by the agent: `~/.rakh/worktrees/<owner>/<repo>/<branch>`
 - debug/dev git worktrees created by the agent: `~/.rakh-dev/worktrees/<owner>/<repo>/<branch>`
-- project list (path + name): localStorage (`rakh-projects`)
-- per-project setup commands and shortcuts: `<project-root>/.rakh/scripts.json` (checked
-  on project load, takes precedence over localStorage values)
 
 Session persistence is front-to-back:
 
@@ -270,8 +232,6 @@ Top-level folders worth knowing:
 - `src/`: React UI, agent runtime, tooling wrappers, state, and styles
 - `src/components/`: workspace UI, terminal, settings, artifact pane, and UI primitives
 - `src/agent/`: runner, atoms, persistence, providers, models, tools, subagents
-- `src/projects.ts`: saved project list, project config resolution, localStorage sync
-- `src/projectScripts.ts`: `.rakh/scripts.json` schema, normalization, read/write helpers
 - `src/styles/`: tokens, themes, layout, and component styles
 - `src-tauri/src/`: Rust commands and platform integration
 - `docs/`: architecture, artifact, and subagent documentation

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -11,6 +11,7 @@ They are used for:
 - Review results
 - Security audits
 - Copy review suggestions
+- MCP-returned file/image payloads when MCP artifactization is enabled in Settings
 - Other handoff outputs that should survive beyond a single chat turn
 
 Artifacts are stored per session. The manifest lives in SQLite and the content
@@ -38,6 +39,11 @@ Important fields:
 - `contentFormat`: one of `text`, `markdown`, `unified-diff`, or `json`
 - `metadata`: free-form JSON metadata
 - `content`: optional payload body
+
+Current non-subagent artifact kinds created by the runtime include:
+
+- `mcp-attachment`: JSON-wrapped MCP file/image/resource payloads captured from
+  tool results when the global MCP artifactization toggle is enabled
 
 The supported content formats are centralized in
 [`src/agent/tools/artifactTypes.ts`](../src/agent/tools/artifactTypes.ts).
@@ -96,6 +102,23 @@ For validator-backed JSON artifacts, `artifactGet()` also returns:
 
 The content is returned unchanged. Validation is supplemental metadata, not a
 transformation step.
+
+### MCP attachment artifacts
+
+When `Settings -> MCP Servers -> Save returned files as artifacts` is enabled,
+the main runner will try to move MCP-returned binary/resource payloads into
+artifacts instead of feeding those raw payloads back into model context.
+
+Current behavior:
+
+- the artifact is stored with `kind: "mcp-attachment"` and `contentFormat: "json"`
+- the saved JSON preserves the original MCP payload shape
+- the runner replaces the model-facing tool result with an artifact reference
+  and a note telling the model to use `agent_artifact_get`
+- the artifact pane renders image attachments as real previews when the saved
+  JSON contains an image MIME type plus base64/text image data
+- if artifact creation fails or the toggle is off, the MCP result is left
+  untouched
 
 ## Artifact Change Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "rakh",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rakh",
-      "version": "0.6.0",
+      "version": "0.5.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.46",
         "@ai-sdk/openai": "^3.0.31",
         "@ai-sdk/openai-compatible": "^2.0.30",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lint": "^6.9.5",
         "@lexical/plain-text": "^0.41.0",
         "@lexical/react": "^0.41.0",
         "@lexical/utils": "^0.41.0",
@@ -21,6 +23,7 @@
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@types/diff": "^7.0.2",
+        "@uiw/react-codemirror": "^4.25.8",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -29,6 +32,7 @@
         "framer-motion": "^12.34.3",
         "jotai": "^2.18.0",
         "jotai-family": "^1.0.1",
+        "jsonc-parser": "^3.3.1",
         "lexical": "^0.41.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -553,6 +557,109 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.17",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.17.tgz",
+      "integrity": "sha512-Aim4lFqhbijnchl83RLfABWueSGs1oUCSv0mru91QdhpXQeNKprIdRO9LWA4cYkJvuYTKGJN7++9MXx8XW43ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1739,6 +1846,47 @@
       "peerDependencies": {
         "yjs": ">=13.5.22"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3197,6 +3345,59 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.8.tgz",
+      "integrity": "sha512-9Rr+liiBmK4xzZHszL+twNRJApthqmITBwDP3emNTtTrkBFN4gHlqfp+nodKmoVt1+bUH1qQCtyqt+7dbDTHiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.8.tgz",
+      "integrity": "sha512-A0aLOuJZm2yJ+U9GlMFwxwFciztjd5LhcAG4SMqFxdD58wH+sCQXuY4UU5J2hqgS390qAlShtUgREvJPUonbuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.8",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -3678,6 +3879,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3720,6 +3936,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4911,6 +5133,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6854,6 +7082,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7413,6 +7647,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rakh",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "d": "tauri dev --config src-tauri/tauri.dev.conf.json",
@@ -21,6 +21,8 @@
     "@ai-sdk/anthropic": "^3.0.46",
     "@ai-sdk/openai": "^3.0.31",
     "@ai-sdk/openai-compatible": "^2.0.30",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lint": "^6.9.5",
     "@lexical/plain-text": "^0.41.0",
     "@lexical/react": "^0.41.0",
     "@lexical/utils": "^0.41.0",
@@ -31,6 +33,7 @@
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@types/diff": "^7.0.2",
+    "@uiw/react-codemirror": "^4.25.8",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
@@ -39,6 +42,7 @@
     "framer-motion": "^12.34.3",
     "jotai": "^2.18.0",
     "jotai-family": "^1.0.1",
+    "jsonc-parser": "^3.3.1",
     "lexical": "^0.41.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "glob",
@@ -70,6 +70,7 @@ dependencies = [
  "ignore",
  "portable-pty",
  "reqwest 0.12.28",
+ "rmcp",
  "rusqlite",
  "serde",
  "serde_json",
@@ -531,14 +532,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -647,6 +661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,8 +765,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -761,12 +794,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.116",
 ]
@@ -1189,6 +1246,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1335,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1438,6 +1511,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2508,6 +2582,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +3003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,7 +3236,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -3258,6 +3350,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.13.0",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3384,6 +3490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3556,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -3660,6 +3783,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rand 0.10.0",
+ "reqwest 0.13.2",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,7 +3982,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3838,8 +4007,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3849,6 +4020,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4045,7 +4228,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -4101,7 +4284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4258,6 +4441,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,7 +4596,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4482,7 +4678,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4710,7 +4906,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4736,7 +4932,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4797,7 +4993,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -4965,6 +5161,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5601,7 +5808,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5625,7 +5832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5702,11 +5909,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5716,6 +5935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5752,7 +5980,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5797,6 +6036,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5935,6 +6184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6254,7 +6512,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.6.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]
@@ -31,6 +31,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 sha2 = "0.10"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+rmcp = { version = "1.1.1", features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,15 @@
 pub mod db;
 pub mod exec;
-pub mod external_tools;
 pub mod fs_ops;
 pub mod git;
+pub mod mcp;
 pub mod pty;
 pub mod shell_env;
 pub mod utils;
 pub mod whisper;
 
 use db::{init_db, AppState};
+use mcp::McpRunState;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -31,11 +32,10 @@ pub fn run() {
             pty_masters: Mutex::new(HashMap::new()),
             db: Mutex::new(db),
         })
+        .manage(McpRunState::default())
         .invoke_handler(tauri::generate_handler![
             db::load_provider_env_api_keys,
             git::git_worktree_add,
-            external_tools::open_in_editor,
-            external_tools::open_shell,
             fs_ops::list_dir,
             fs_ops::stat_file,
             fs_ops::read_file,
@@ -66,6 +66,14 @@ pub fn run() {
             db::providers_save,
             db::profiles_load,
             db::profiles_save,
+            mcp::mcp_servers_load,
+            mcp::mcp_settings_load,
+            mcp::mcp_servers_save,
+            mcp::mcp_settings_save,
+            mcp::mcp_test_server,
+            mcp::mcp_prepare_run,
+            mcp::mcp_call_tool,
+            mcp::mcp_shutdown_run,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,0 +1,776 @@
+use crate::shell_env::resolved_login_shell_env;
+use crate::utils::{app_store_root, now_ms, tool_log};
+use reqwest::header::{HeaderName, HeaderValue};
+use rmcp::model::{CallToolRequestParams, CallToolResult, Tool};
+use rmcp::service::RunningService;
+use rmcp::transport::{
+    streamable_http_client::StreamableHttpClientTransportConfig, StreamableHttpClientTransport,
+    TokioChildProcess,
+};
+use rmcp::{RoleClient, ServiceExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::State;
+use tokio::time::timeout;
+
+const DEFAULT_MCP_TIMEOUT_MS: u64 = 20_000;
+const MCP_CLOSE_TIMEOUT_SECS: u64 = 3;
+
+#[derive(Default)]
+pub struct McpRunState {
+    runs: tokio::sync::Mutex<HashMap<String, McpRun>>,
+}
+
+struct McpRun {
+    servers: HashMap<String, Arc<McpServerRuntime>>,
+}
+
+struct McpServerRuntime {
+    server_name: String,
+    timeout_ms: u64,
+    client: tokio::sync::Mutex<RunningService<RoleClient, ()>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "transport", rename_all = "kebab-case")]
+pub enum McpServerRecord {
+    Stdio {
+        id: String,
+        name: String,
+        enabled: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_ms: Option<u64>,
+        command: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        env: HashMap<String, String>,
+    },
+    StreamableHttp {
+        id: String,
+        name: String,
+        enabled: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_ms: Option<u64>,
+        url: String,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
+    },
+}
+
+impl McpServerRecord {
+    fn id(&self) -> &str {
+        match self {
+            Self::Stdio { id, .. } | Self::StreamableHttp { id, .. } => id,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            Self::Stdio { name, .. } | Self::StreamableHttp { name, .. } => name,
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        match self {
+            Self::Stdio { enabled, .. } | Self::StreamableHttp { enabled, .. } => *enabled,
+        }
+    }
+
+    fn timeout_ms(&self) -> u64 {
+        let raw = match self {
+            Self::Stdio { timeout_ms, .. } | Self::StreamableHttp { timeout_ms, .. } => {
+                *timeout_ms
+            }
+        };
+
+        match raw {
+            Some(0) | None => DEFAULT_MCP_TIMEOUT_MS,
+            Some(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpSettingsRecord {
+    #[serde(default)]
+    pub artifactize_returned_files: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+struct PersistedMcpConfigRecord {
+    #[serde(default)]
+    servers: Vec<McpServerRecord>,
+    #[serde(default)]
+    artifactize_returned_files: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+enum PersistedMcpConfigFile {
+    LegacyServers(Vec<McpServerRecord>),
+    Config(PersistedMcpConfigRecord),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolAnnotationsRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destructive_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotent_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_world_hint: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpDiscoveredToolRecord {
+    pub server_id: String,
+    pub server_name: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<McpToolAnnotationsRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerFailureRecord {
+    pub server_id: String,
+    pub server_name: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpPrepareRunResult {
+    pub tools: Vec<McpDiscoveredToolRecord>,
+    pub failures: Vec<McpServerFailureRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerProbeResult {
+    pub server_id: String,
+    pub server_name: String,
+    pub tools: Vec<McpDiscoveredToolRecord>,
+    pub tool_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallResultRecord {
+    pub content: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+fn mcp_servers_config_path() -> Result<PathBuf, String> {
+    Ok(app_store_root()?.join("config").join("mcp_servers.json"))
+}
+
+fn load_mcp_config_from_path(path: &Path) -> Result<PersistedMcpConfigRecord, String> {
+    if !path.exists() {
+        return Ok(PersistedMcpConfigRecord::default());
+    }
+
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("INTERNAL: cannot read MCP servers: {}", error))?;
+    let parsed = serde_json::from_str::<PersistedMcpConfigFile>(&raw)
+        .map_err(|error| format!("INTERNAL: cannot parse MCP servers: {}", error))?;
+
+    Ok(match parsed {
+        PersistedMcpConfigFile::LegacyServers(servers) => PersistedMcpConfigRecord {
+            servers,
+            ..PersistedMcpConfigRecord::default()
+        },
+        PersistedMcpConfigFile::Config(config) => config,
+    })
+}
+
+fn load_mcp_servers_from_path(path: &Path) -> Result<Vec<McpServerRecord>, String> {
+    Ok(load_mcp_config_from_path(path)?.servers)
+}
+
+fn load_mcp_settings_from_path(path: &Path) -> Result<McpSettingsRecord, String> {
+    let config = load_mcp_config_from_path(path)?;
+    Ok(McpSettingsRecord {
+        artifactize_returned_files: config.artifactize_returned_files,
+    })
+}
+
+fn save_mcp_config_to_path(path: &Path, config: &PersistedMcpConfigRecord) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("INTERNAL: cannot create config dir: {}", error))?;
+    }
+
+    let raw = serde_json::to_string_pretty(config)
+        .map_err(|error| format!("INTERNAL: cannot serialise MCP servers: {}", error))?;
+    let tmp = path.with_extension(format!("json.tmp-{}", now_ms()));
+    fs::write(&tmp, raw.as_bytes())
+        .map_err(|error| format!("INTERNAL: cannot write MCP server tmp file: {}", error))?;
+    match fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if path.exists() {
+                let _ = fs::remove_file(&tmp);
+                Ok(())
+            } else {
+                Err(format!("INTERNAL: cannot rename MCP server file: {}", error))
+            }
+        }
+    }
+}
+
+fn save_mcp_servers_to_path(path: &Path, servers: &[McpServerRecord]) -> Result<(), String> {
+    let mut config = load_mcp_config_from_path(path)?;
+    config.servers = servers.to_vec();
+    save_mcp_config_to_path(path, &config)
+}
+
+fn save_mcp_settings_to_path(path: &Path, settings: &McpSettingsRecord) -> Result<(), String> {
+    let mut config = load_mcp_config_from_path(path)?;
+    config.artifactize_returned_files = settings.artifactize_returned_files;
+    save_mcp_config_to_path(path, &config)
+}
+
+fn tool_annotations_record(tool: &Tool) -> Option<McpToolAnnotationsRecord> {
+    tool.annotations.as_ref().map(|annotations| McpToolAnnotationsRecord {
+        title: annotations.title.clone(),
+        read_only_hint: annotations.read_only_hint,
+        destructive_hint: annotations.destructive_hint,
+        idempotent_hint: annotations.idempotent_hint,
+        open_world_hint: annotations.open_world_hint,
+    })
+}
+
+fn discovered_tool_record(server: &McpServerRecord, tool: Tool) -> McpDiscoveredToolRecord {
+    McpDiscoveredToolRecord {
+        server_id: server.id().to_string(),
+        server_name: server.name().to_string(),
+        name: tool.name.to_string(),
+        title: tool.title.clone(),
+        description: tool.description.as_ref().map(|value| value.to_string()),
+        input_schema: Value::Object((*tool.input_schema).clone()),
+        annotations: tool_annotations_record(&tool),
+    }
+}
+
+fn apply_shell_env(command: &mut tokio::process::Command, env_overrides: &HashMap<String, String>) {
+    let shell_env = resolved_login_shell_env();
+
+    if !env_overrides.contains_key("PATH") {
+        if let Some(path) = shell_env.path {
+            command.env("PATH", path);
+        }
+    }
+    if !env_overrides.contains_key("SHELL") {
+        if let Some(shell) = shell_env.shell {
+            command.env("SHELL", shell);
+        }
+    }
+    if !env_overrides.contains_key("LANG") {
+        if let Some(lang) = shell_env.lang {
+            command.env("LANG", lang);
+        }
+    }
+    if !env_overrides.contains_key("LC_ALL") {
+        if let Some(value) = shell_env.lc_all {
+            command.env("LC_ALL", value);
+        }
+    }
+    if !env_overrides.contains_key("LC_CTYPE") {
+        if let Some(value) = shell_env.lc_ctype {
+            command.env("LC_CTYPE", value);
+        }
+    }
+}
+
+async fn connect_stdio_server(
+    server: &McpServerRecord,
+    cwd: &str,
+) -> Result<RunningService<RoleClient, ()>, String> {
+    let McpServerRecord::Stdio {
+        command,
+        args,
+        env,
+        ..
+    } = server
+    else {
+        return Err("Invalid stdio server definition".to_string());
+    };
+
+    let mut child_command = tokio::process::Command::new(command);
+    child_command
+        .args(args)
+        .current_dir(cwd)
+        .envs(env)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    apply_shell_env(&mut child_command, env);
+
+    let transport = TokioChildProcess::builder(child_command)
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map(|(transport, _stderr)| transport)
+        .map_err(|error| format!("Failed to spawn {}: {}", server.name(), error))?;
+
+    timeout(Duration::from_millis(server.timeout_ms()), ().serve(transport))
+        .await
+        .map_err(|_| format!("Timed out connecting to {}", server.name()))?
+        .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
+}
+
+fn parse_custom_headers(
+    headers: &HashMap<String, String>,
+) -> Result<HashMap<HeaderName, HeaderValue>, String> {
+    let mut out = HashMap::new();
+    for (name, value) in headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|error| format!("Invalid header name '{}': {}", name, error))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|error| format!("Invalid header value for '{}': {}", name, error))?;
+        out.insert(header_name, header_value);
+    }
+    Ok(out)
+}
+
+async fn connect_streamable_http_server(
+    server: &McpServerRecord,
+) -> Result<RunningService<RoleClient, ()>, String> {
+    let McpServerRecord::StreamableHttp { url, headers, .. } = server else {
+        return Err("Invalid streamable HTTP server definition".to_string());
+    };
+
+    let config = StreamableHttpClientTransportConfig::with_uri(url.clone())
+        .custom_headers(parse_custom_headers(headers)?);
+    let transport = StreamableHttpClientTransport::from_config(config);
+
+    timeout(Duration::from_millis(server.timeout_ms()), ().serve(transport))
+        .await
+        .map_err(|_| format!("Timed out connecting to {}", server.name()))?
+        .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
+}
+
+async fn connect_server(
+    server: &McpServerRecord,
+    cwd: &str,
+) -> Result<Arc<McpServerRuntime>, String> {
+    let client = match server {
+        McpServerRecord::Stdio { .. } => connect_stdio_server(server, cwd).await?,
+        McpServerRecord::StreamableHttp { .. } => connect_streamable_http_server(server).await?,
+    };
+
+    Ok(Arc::new(McpServerRuntime {
+        server_name: server.name().to_string(),
+        timeout_ms: server.timeout_ms(),
+        client: tokio::sync::Mutex::new(client),
+    }))
+}
+
+async fn list_tools(
+    runtime: &Arc<McpServerRuntime>,
+    server: &McpServerRecord,
+) -> Result<Vec<McpDiscoveredToolRecord>, String> {
+    let client = runtime.client.lock().await;
+    let tools = timeout(Duration::from_millis(runtime.timeout_ms), client.peer().list_all_tools())
+        .await
+        .map_err(|_| format!("Timed out listing tools for {}", runtime.server_name))?
+        .map_err(|error| format!("Failed to list tools for {}: {}", runtime.server_name, error))?;
+
+    Ok(tools
+        .into_iter()
+        .map(|tool| discovered_tool_record(server, tool))
+        .collect())
+}
+
+async fn close_runtime(runtime: Arc<McpServerRuntime>) {
+    let mut client = runtime.client.lock().await;
+    let _ = client
+        .close_with_timeout(Duration::from_secs(MCP_CLOSE_TIMEOUT_SECS))
+        .await;
+}
+
+async fn shutdown_run(run: McpRun) {
+    for runtime in run.servers.into_values() {
+        close_runtime(runtime).await;
+    }
+}
+
+fn map_call_result(result: CallToolResult) -> McpToolCallResultRecord {
+    McpToolCallResultRecord {
+        content: result
+            .content
+            .into_iter()
+            .map(|content| serde_json::to_value(content).unwrap_or_else(|_| json!({ "type": "text", "text": "Unable to serialize MCP content." })))
+            .collect(),
+        structured_content: result.structured_content,
+        is_error: result.is_error,
+        meta: result.meta.map(|meta| Value::Object(meta.0)),
+    }
+}
+
+fn input_to_arguments(input: Value) -> Result<Option<Map<String, Value>>, String> {
+    match input {
+        Value::Null => Ok(None),
+        Value::Object(map) => Ok(Some(map)),
+        _ => Err("MCP tool input must be a JSON object.".to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn mcp_servers_load() -> Result<Vec<McpServerRecord>, String> {
+    tool_log("mcp_servers_load", "start", json!({}));
+    let path = mcp_servers_config_path()?;
+    let records = load_mcp_servers_from_path(&path)?;
+    tool_log("mcp_servers_load", "ok", json!({ "count": records.len() }));
+    Ok(records)
+}
+
+#[tauri::command]
+pub fn mcp_settings_load() -> Result<McpSettingsRecord, String> {
+    tool_log("mcp_settings_load", "start", json!({}));
+    let path = mcp_servers_config_path()?;
+    let settings = load_mcp_settings_from_path(&path)?;
+    tool_log(
+        "mcp_settings_load",
+        "ok",
+        json!({ "artifactizeReturnedFiles": settings.artifactize_returned_files }),
+    );
+    Ok(settings)
+}
+
+#[tauri::command]
+pub fn mcp_servers_save(servers: Vec<McpServerRecord>) -> Result<(), String> {
+    tool_log(
+        "mcp_servers_save",
+        "start",
+        json!({ "count": servers.len() }),
+    );
+    let path = mcp_servers_config_path()?;
+    save_mcp_servers_to_path(&path, &servers)?;
+    tool_log("mcp_servers_save", "ok", json!({ "count": servers.len() }));
+    Ok(())
+}
+
+#[tauri::command]
+pub fn mcp_settings_save(settings: McpSettingsRecord) -> Result<(), String> {
+    tool_log(
+        "mcp_settings_save",
+        "start",
+        json!({ "artifactizeReturnedFiles": settings.artifactize_returned_files }),
+    );
+    let path = mcp_servers_config_path()?;
+    save_mcp_settings_to_path(&path, &settings)?;
+    tool_log(
+        "mcp_settings_save",
+        "ok",
+        json!({ "artifactizeReturnedFiles": settings.artifactize_returned_files }),
+    );
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mcp_test_server(server: McpServerRecord) -> Result<McpServerProbeResult, String> {
+    tool_log(
+        "mcp_test_server",
+        "start",
+        json!({ "serverId": server.id(), "serverName": server.name() }),
+    );
+    let cwd = std::env::current_dir()
+        .ok()
+        .and_then(|path| path.to_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| ".".to_string());
+
+    let runtime = connect_server(&server, &cwd).await?;
+    let tools = list_tools(&runtime, &server).await?;
+    close_runtime(runtime).await;
+
+    let result = McpServerProbeResult {
+        server_id: server.id().to_string(),
+        server_name: server.name().to_string(),
+        tool_count: tools.len(),
+        tools,
+    };
+
+    tool_log(
+        "mcp_test_server",
+        "ok",
+        json!({ "serverId": result.server_id, "toolCount": result.tool_count }),
+    );
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn mcp_prepare_run(
+    run_id: String,
+    cwd: String,
+    servers: Vec<McpServerRecord>,
+    state: State<'_, McpRunState>,
+) -> Result<McpPrepareRunResult, String> {
+    tool_log(
+        "mcp_prepare_run",
+        "start",
+        json!({ "runId": run_id, "cwd": cwd, "serverCount": servers.len() }),
+    );
+
+    let mut runtimes = HashMap::new();
+    let mut tools = Vec::new();
+    let mut failures = Vec::new();
+
+    for server in servers.iter().filter(|server| server.enabled()) {
+        match connect_server(server, &cwd).await {
+            Ok(runtime) => match list_tools(&runtime, server).await {
+                Ok(server_tools) => {
+                    tools.extend(server_tools);
+                    runtimes.insert(server.id().to_string(), runtime);
+                }
+                Err(error) => {
+                    close_runtime(runtime).await;
+                    failures.push(McpServerFailureRecord {
+                        server_id: server.id().to_string(),
+                        server_name: server.name().to_string(),
+                        error,
+                    });
+                }
+            },
+            Err(error) => failures.push(McpServerFailureRecord {
+                server_id: server.id().to_string(),
+                server_name: server.name().to_string(),
+                error,
+            }),
+        }
+    }
+
+    let previous = {
+        let mut runs = state.runs.lock().await;
+        if runtimes.is_empty() {
+            runs.remove(&run_id)
+        } else {
+            runs.insert(run_id.clone(), McpRun { servers: runtimes })
+        }
+    };
+    if let Some(previous) = previous {
+        shutdown_run(previous).await;
+    }
+
+    tool_log(
+        "mcp_prepare_run",
+        "ok",
+        json!({
+            "runId": run_id,
+            "toolCount": tools.len(),
+            "failureCount": failures.len(),
+        }),
+    );
+
+    Ok(McpPrepareRunResult { tools, failures })
+}
+
+#[tauri::command]
+pub async fn mcp_call_tool(
+    run_id: String,
+    server_id: String,
+    tool_name: String,
+    input: Value,
+    state: State<'_, McpRunState>,
+) -> Result<McpToolCallResultRecord, String> {
+    let runtime = {
+        let runs = state.runs.lock().await;
+        runs.get(&run_id)
+            .and_then(|run| run.servers.get(&server_id))
+            .cloned()
+    }
+    .ok_or_else(|| format!("MCP server '{}' is not available for run '{}'.", server_id, run_id))?;
+
+    let client = runtime.client.lock().await;
+    let mut request = CallToolRequestParams::new(tool_name.clone());
+    if let Some(arguments) = input_to_arguments(input)? {
+        request = request.with_arguments(arguments);
+    }
+
+    let result = timeout(
+        Duration::from_millis(runtime.timeout_ms),
+        client.peer().call_tool(request),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "Timed out calling MCP tool '{}' on '{}'.",
+            tool_name, runtime.server_name
+        )
+    })?
+    .map_err(|error| format!("MCP tool '{}' failed: {}", tool_name, error))?;
+
+    Ok(map_call_result(result))
+}
+
+#[tauri::command]
+pub async fn mcp_shutdown_run(
+    run_id: String,
+    state: State<'_, McpRunState>,
+) -> Result<(), String> {
+    let removed = {
+        let mut runs = state.runs.lock().await;
+        runs.remove(&run_id)
+    };
+
+    if let Some(run) = removed {
+        shutdown_run(run).await;
+    }
+
+    tool_log("mcp_shutdown_run", "ok", json!({ "runId": run_id }));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_servers() -> Vec<McpServerRecord> {
+        vec![
+            McpServerRecord::Stdio {
+                id: "filesystem".to_string(),
+                name: "Filesystem".to_string(),
+                enabled: true,
+                timeout_ms: Some(25_000),
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-filesystem".to_string(),
+                    ".".to_string(),
+                ],
+                env: HashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            },
+            McpServerRecord::StreamableHttp {
+                id: "docs".to_string(),
+                name: "Docs".to_string(),
+                enabled: false,
+                timeout_ms: None,
+                url: "http://localhost:8123/mcp".to_string(),
+                headers: HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer token".to_string(),
+                )]),
+            },
+        ]
+    }
+
+    #[test]
+    fn load_mcp_servers_from_path_returns_empty_when_missing() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("config").join("mcp_servers.json");
+
+        let loaded = load_mcp_servers_from_path(&path).expect("load should succeed");
+
+        assert!(loaded.is_empty());
+        let settings = load_mcp_settings_from_path(&path).expect("settings load should succeed");
+        assert_eq!(
+            settings,
+            McpSettingsRecord {
+                artifactize_returned_files: false,
+            }
+        );
+    }
+
+    #[test]
+    fn save_and_load_mcp_servers_round_trip() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("config").join("mcp_servers.json");
+        let servers = sample_servers();
+
+        save_mcp_servers_to_path(&path, &servers).expect("save should succeed");
+
+        let raw = fs::read_to_string(&path).expect("config file should exist");
+        assert!(raw.contains("\"servers\""));
+        assert!(raw.contains("\"transport\": \"stdio\""));
+        assert!(raw.contains("\"transport\": \"streamable-http\""));
+        assert!(raw.contains("\"artifactizeReturnedFiles\": false"));
+
+        let loaded = load_mcp_servers_from_path(&path).expect("load should succeed");
+        assert_eq!(loaded, servers);
+        let settings = load_mcp_settings_from_path(&path).expect("settings load should succeed");
+        assert_eq!(
+            settings,
+            McpSettingsRecord {
+                artifactize_returned_files: false,
+            }
+        );
+    }
+
+    #[test]
+    fn save_mcp_settings_preserves_existing_servers() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("config").join("mcp_servers.json");
+        let servers = sample_servers();
+
+        save_mcp_servers_to_path(&path, &servers).expect("save should succeed");
+        save_mcp_settings_to_path(
+            &path,
+            &McpSettingsRecord {
+                artifactize_returned_files: true,
+            },
+        )
+        .expect("settings save should succeed");
+
+        let loaded = load_mcp_servers_from_path(&path).expect("load should succeed");
+        assert_eq!(loaded, servers);
+        let settings = load_mcp_settings_from_path(&path).expect("settings load should succeed");
+        assert_eq!(
+            settings,
+            McpSettingsRecord {
+                artifactize_returned_files: true,
+            }
+        );
+    }
+
+    #[test]
+    fn load_mcp_settings_from_legacy_server_array_defaults_to_false() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("config").join("mcp_servers.json");
+        let servers = sample_servers();
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("config dir");
+        }
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&servers).expect("serialize legacy servers"),
+        )
+        .expect("write config");
+
+        let loaded = load_mcp_servers_from_path(&path).expect("load should succeed");
+        assert_eq!(loaded, servers);
+        let settings = load_mcp_settings_from_path(&path).expect("settings load should succeed");
+        assert_eq!(
+            settings,
+            McpSettingsRecord {
+                artifactize_returned_files: false,
+            }
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,12 @@ import {
   agentAtomFamily,
 } from "@/agent/atoms";
 import { loadProviders, providersAtom, loadProfiles, profilesAtom } from "@/agent/db";
+import {
+  loadMcpServers,
+  loadMcpSettings,
+  mcpServersAtom,
+  mcpSettingsAtom,
+} from "@/agent/mcp";
 import { hydratePersistedSession } from "@/agent/sessionRestore";
 import WorkspacePage from "@/WorkspacePage";
 import SettingsPage from "@/components/settings/SettingsPage";
@@ -171,11 +177,19 @@ export default function App() {
     // Prime provider env keys at startup so settings opens without waiting on backend reads.
     void preloadEnvProviderKeys();
 
-    Promise.all([loadSessions(), loadProviders(), loadProfiles()]).then(
-      ([sessions, providers, profiles]) => {
+    Promise.all([
+      loadSessions(),
+      loadProviders(),
+      loadProfiles(),
+      loadMcpServers(),
+      loadMcpSettings(),
+    ]).then(
+      ([sessions, providers, profiles, mcpServers, mcpSettings]) => {
         // Load providers and profiles into global store early
         jotaiStore.set(providersAtom, providers);
         jotaiStore.set(profilesAtom, profiles);
+        jotaiStore.set(mcpServersAtom, mcpServers);
+        jotaiStore.set(mcpSettingsAtom, mcpSettings);
 
         // Hydrate Jotai atoms before first render of agent components
         for (const s of sessions) {

--- a/src/agent/mcp.ts
+++ b/src/agent/mcp.ts
@@ -1,0 +1,254 @@
+import { invoke } from "@tauri-apps/api/core";
+import { jsonSchema, tool as aiTool } from "ai";
+import { atom } from "jotai";
+
+type JsonObject = Record<string, unknown>;
+
+interface McpServerBase {
+  id: string;
+  name: string;
+  enabled: boolean;
+  timeoutMs?: number;
+}
+
+export interface McpStdioServerConfig extends McpServerBase {
+  transport: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpStreamableHttpServerConfig extends McpServerBase {
+  transport: "streamable-http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServerConfig =
+  | McpStdioServerConfig
+  | McpStreamableHttpServerConfig;
+
+export interface McpToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface McpDiscoveredTool {
+  serverId: string;
+  serverName: string;
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema: JsonObject;
+  annotations?: McpToolAnnotations;
+}
+
+export interface McpServerFailure {
+  serverId: string;
+  serverName: string;
+  error: string;
+}
+
+export interface McpPrepareRunResult {
+  tools: McpDiscoveredTool[];
+  failures: McpServerFailure[];
+}
+
+export interface McpToolCallResponse {
+  content: unknown[];
+  structuredContent?: unknown;
+  isError?: boolean;
+  meta?: JsonObject;
+}
+
+export interface McpSettings {
+  artifactizeReturnedFiles: boolean;
+}
+
+export interface McpServerProbeResult {
+  serverId: string;
+  serverName: string;
+  tools: McpDiscoveredTool[];
+  toolCount: number;
+}
+
+export interface McpToolDisplayMetadata {
+  serverId: string;
+  serverName: string;
+  toolName: string;
+  toolTitle?: string;
+}
+
+export interface McpToolRegistration {
+  syntheticName: string;
+  serverId: string;
+  serverName: string;
+  toolName: string;
+  toolTitle?: string;
+  description?: string;
+  inputSchema: JsonObject;
+  annotations?: McpToolAnnotations;
+}
+
+export interface McpRuntimeToolRegistry {
+  definitions: Record<string, McpToolDefinition>;
+  toolsByName: Record<string, McpToolRegistration>;
+}
+
+export type McpToolDefinition = ReturnType<typeof aiTool>;
+
+export const DEFAULT_MCP_SETTINGS: McpSettings = {
+  artifactizeReturnedFiles: false,
+};
+
+export const mcpServersAtom = atom<McpServerConfig[]>([]);
+export const mcpSettingsAtom = atom<McpSettings>(DEFAULT_MCP_SETTINGS);
+
+function normalizeMcpSettings(
+  value: Partial<McpSettings> | null | undefined,
+): McpSettings {
+  return {
+    artifactizeReturnedFiles: value?.artifactizeReturnedFiles === true,
+  };
+}
+
+export async function loadMcpServers(): Promise<McpServerConfig[]> {
+  return invoke<McpServerConfig[]>("mcp_servers_load");
+}
+
+export async function saveMcpServers(servers: McpServerConfig[]): Promise<void> {
+  await invoke("mcp_servers_save", { servers });
+}
+
+export async function loadMcpSettings(): Promise<McpSettings> {
+  const settings = await invoke<Partial<McpSettings>>("mcp_settings_load");
+  return normalizeMcpSettings(settings);
+}
+
+export async function saveMcpSettings(settings: McpSettings): Promise<void> {
+  await invoke("mcp_settings_save", {
+    settings: normalizeMcpSettings(settings),
+  });
+}
+
+export async function testMcpServer(
+  server: McpServerConfig,
+): Promise<McpServerProbeResult> {
+  return invoke<McpServerProbeResult>("mcp_test_server", { server });
+}
+
+export async function prepareMcpRun(
+  runId: string,
+  cwd: string,
+  servers: McpServerConfig[],
+): Promise<McpPrepareRunResult> {
+  return invoke<McpPrepareRunResult>("mcp_prepare_run", { runId, cwd, servers });
+}
+
+export async function callMcpTool(
+  runId: string,
+  serverId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<McpToolCallResponse> {
+  return invoke<McpToolCallResponse>("mcp_call_tool", {
+    runId,
+    serverId,
+    toolName,
+    input,
+  });
+}
+
+export async function shutdownMcpRun(runId: string): Promise<void> {
+  await invoke("mcp_shutdown_run", { runId });
+}
+
+function slugify(value: string): string {
+  const out = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return out || "tool";
+}
+
+function normalizeInputSchema(schema: unknown): JsonObject {
+  if (schema && typeof schema === "object" && !Array.isArray(schema)) {
+    return schema as JsonObject;
+  }
+  return {
+    type: "object",
+    additionalProperties: true,
+  };
+}
+
+export function getMcpToolDisplayLabel(
+  meta: McpToolDisplayMetadata,
+): string {
+  return `MCP / ${meta.serverName} / ${meta.toolTitle ?? meta.toolName}`;
+}
+
+export function buildMcpRuntimeToolRegistry(
+  tools: McpDiscoveredTool[],
+  reservedNames: Iterable<string> = [],
+): McpRuntimeToolRegistry {
+  const usedNames = new Set(reservedNames);
+  const definitions: Record<string, McpToolDefinition> = {};
+  const toolsByName: Record<string, McpToolRegistration> = {};
+
+  for (const tool of tools) {
+    const serverKey = slugify(tool.serverName || tool.serverId);
+    const toolKey = slugify(tool.name);
+    const baseName = `mcp_${serverKey}_${toolKey}`;
+    let syntheticName = baseName;
+    let counter = 2;
+
+    while (usedNames.has(syntheticName)) {
+      syntheticName = `${baseName}_${counter}`;
+      counter += 1;
+    }
+
+    usedNames.add(syntheticName);
+
+    definitions[syntheticName] = aiTool({
+      description:
+        tool.description ??
+        tool.title ??
+        `Call the MCP tool "${tool.name}" from "${tool.serverName}".`,
+      inputSchema: jsonSchema(normalizeInputSchema(tool.inputSchema)),
+    });
+    toolsByName[syntheticName] = {
+      syntheticName,
+      serverId: tool.serverId,
+      serverName: tool.serverName,
+      toolName: tool.name,
+      toolTitle: tool.title,
+      description: tool.description,
+      inputSchema: normalizeInputSchema(tool.inputSchema),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+    };
+  }
+
+  return { definitions, toolsByName };
+}
+
+export function extractMcpToolErrorMessage(
+  result: McpToolCallResponse,
+): string {
+  if (typeof result.structuredContent === "string" && result.structuredContent) {
+    return result.structuredContent;
+  }
+
+  for (const item of result.content) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as { type?: unknown; text?: unknown };
+    if (raw.type === "text" && typeof raw.text === "string" && raw.text.trim()) {
+      return raw.text.trim();
+    }
+  }
+
+  return "MCP tool reported an error.";
+}

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -13,6 +13,9 @@ type MockTurn = {
   toolCalls?: MockToolCall[];
   toolCallsError?: unknown;
   streamError?: unknown;
+  finishReason?: string;
+  rawFinishReason?: string;
+  steps?: unknown[];
 };
 
 type MockAgentState = {
@@ -41,6 +44,8 @@ type MockAgentState = {
 const {
   states,
   providersAtomMock,
+  mcpServersAtomMock,
+  mcpSettingsAtomMock,
   globalCommunicationProfileAtomMock,
   profilesAtomMock,
   jotaiStoreMock,
@@ -57,9 +62,15 @@ const {
   createOpenAICompatibleMock,
   execAbortMock,
   execStopMock,
+  prepareMcpRunMock,
+  callMcpToolMock,
+  shutdownMcpRunMock,
+  artifactCreateMock,
 } = vi.hoisted(() => ({
   states: {} as Record<string, MockAgentState>,
   providersAtomMock: { kind: "providers-atom" },
+  mcpServersAtomMock: { kind: "mcp-servers-atom" },
+  mcpSettingsAtomMock: { kind: "mcp-settings-atom" },
   globalCommunicationProfileAtomMock: { kind: "global-communication-profile-atom" },
   profilesAtomMock: { kind: "profiles-atom" },
   jotaiStoreMock: {
@@ -78,6 +89,10 @@ const {
   execAbortMock: vi.fn(),
   execStopMock: vi.fn(),
   createOpenAICompatibleMock: vi.fn(),
+  prepareMcpRunMock: vi.fn(),
+  callMcpToolMock: vi.fn(),
+  shutdownMcpRunMock: vi.fn(),
+  artifactCreateMock: vi.fn(),
 }));
 
 vi.mock("./atoms", () => ({
@@ -144,6 +159,94 @@ vi.mock("./tools/exec", () => ({
   execStop: (...args: unknown[]) => execStopMock(...args),
 }));
 
+vi.mock("./mcp", () => {
+  const slugify = (value: string) =>
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "tool";
+
+  return {
+    mcpServersAtom: mcpServersAtomMock,
+    mcpSettingsAtom: mcpSettingsAtomMock,
+    loadMcpServers: vi.fn(),
+    loadMcpSettings: vi.fn(),
+    saveMcpServers: vi.fn(),
+    saveMcpSettings: vi.fn(),
+    testMcpServer: vi.fn(),
+    prepareMcpRun: (...args: unknown[]) => prepareMcpRunMock(...args),
+    callMcpTool: (...args: unknown[]) => callMcpToolMock(...args),
+    shutdownMcpRun: (...args: unknown[]) => shutdownMcpRunMock(...args),
+    extractMcpToolErrorMessage: (result: {
+      structuredContent?: unknown;
+      content: Array<{ type?: unknown; text?: unknown }>;
+    }) => {
+      if (
+        typeof result.structuredContent === "string" &&
+        result.structuredContent.trim()
+      ) {
+        return result.structuredContent;
+      }
+      const textPart = result.content.find(
+        (item) => item?.type === "text" && typeof item.text === "string",
+      );
+      return textPart?.text ?? "MCP tool reported an error.";
+    },
+    buildMcpRuntimeToolRegistry: (
+      tools: Array<{
+        serverId: string;
+        serverName: string;
+        name: string;
+        title?: string;
+        description?: string;
+        inputSchema: Record<string, unknown>;
+      }>,
+      reservedNames: Iterable<string> = [],
+    ) => {
+      const usedNames = new Set(reservedNames);
+      const definitions: Record<string, Record<string, unknown>> = {};
+      const toolsByName: Record<string, Record<string, unknown>> = {};
+
+      for (const tool of tools) {
+        const baseName = `mcp_${slugify(tool.serverName || tool.serverId)}_${slugify(tool.name)}`;
+        let syntheticName = baseName;
+        let counter = 2;
+        while (usedNames.has(syntheticName)) {
+          syntheticName = `${baseName}_${counter}`;
+          counter += 1;
+        }
+        usedNames.add(syntheticName);
+        definitions[syntheticName] = {
+          description: tool.description ?? tool.title ?? tool.name,
+          inputSchema: tool.inputSchema,
+        };
+        toolsByName[syntheticName] = {
+          syntheticName,
+          serverId: tool.serverId,
+          serverName: tool.serverName,
+          toolName: tool.name,
+          toolTitle: tool.title,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        };
+      }
+
+      return { definitions, toolsByName };
+    },
+  };
+});
+
+vi.mock("./tools/artifacts", async () => {
+  const actual = await vi.importActual<typeof import("./tools/artifacts")>(
+    "./tools/artifacts",
+  );
+  return {
+    ...actual,
+    artifactCreate: (...args: unknown[]) => artifactCreateMock(...args),
+  };
+});
+
 import {
   buildProviderOptions,
   resumeQueue,
@@ -154,9 +257,8 @@ import {
   stopAgent,
   stopRunningExecToolCall,
 } from "./runner";
-import { groupChatMessagesForBubbles } from "./chatBubbleGroups";
 import { registerDynamicModels } from "./modelCatalog";
-import type { AdvancedModelOptions, ChatMessage } from "./types";
+import type { AdvancedModelOptions } from "./types";
 import { DEFAULT_ADVANCED_OPTIONS } from "./types";
 
 function makeState(overrides: Partial<MockAgentState> = {}): MockAgentState {
@@ -255,16 +357,6 @@ async function flushAsyncWork(rounds = 6): Promise<void> {
   }
 }
 
-function createDeferred<T = void>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
 describe("runner", () => {
   beforeEach(() => {
     registerDynamicModels([
@@ -293,6 +385,10 @@ describe("runner", () => {
     createAnthropicMock.mockReset();
     execAbortMock.mockReset();
     execStopMock.mockReset();
+    prepareMcpRunMock.mockReset();
+    callMcpToolMock.mockReset();
+    shutdownMcpRunMock.mockReset();
+    artifactCreateMock.mockReset();
     jotaiStoreMock.get.mockReset();
 
     jotaiStoreMock.get.mockImplementation((atom: unknown) => {
@@ -319,6 +415,12 @@ describe("runner", () => {
           },
         ];
       }
+      if (atom === mcpServersAtomMock) {
+        return [];
+      }
+      if (atom === mcpSettingsAtomMock) {
+        return { artifactizeReturnedFiles: false };
+      }
       if (atom === profilesAtomMock) {
         return [];
       }
@@ -334,9 +436,45 @@ describe("runner", () => {
     dispatchToolMock.mockResolvedValue({ ok: true, data: { ok: true } });
     validateToolMock.mockResolvedValue(null);
     execStopMock.mockResolvedValue(true);
+    prepareMcpRunMock.mockResolvedValue({ tools: [], failures: [] });
+    callMcpToolMock.mockResolvedValue({ content: [] });
+    shutdownMcpRunMock.mockResolvedValue(undefined);
+    artifactCreateMock.mockResolvedValue({
+      ok: true,
+      data: { artifact: makeArtifact() },
+    });
 
     streamTextMock.mockImplementation(() => {
       const turn = turns.shift() ?? { deltas: [], toolCalls: [] };
+      const turnToolCalls = turn.toolCalls ?? [];
+      const streamedText = (turn.fullStreamParts ?? [])
+        .flatMap((part) =>
+          typeof part === "object" &&
+          part !== null &&
+          "type" in part &&
+          part.type === "text-delta" &&
+          "delta" in part &&
+          typeof part.delta === "string"
+            ? [part.delta]
+            : [],
+        )
+        .join("");
+      const streamedReasoning = (turn.fullStreamParts ?? [])
+        .flatMap((part) =>
+          typeof part === "object" &&
+          part !== null &&
+          "type" in part &&
+          part.type === "reasoning-delta" &&
+          "delta" in part &&
+          typeof part.delta === "string"
+            ? [part.delta]
+            : [],
+        )
+        .join("");
+      const turnText = `${streamedText}${(turn.deltas ?? []).join("")}`;
+      const turnReasoning = `${streamedReasoning}${(turn.reasoningDeltas ?? []).join("")}`;
+      const finishReason =
+        turn.finishReason ?? (turnToolCalls.length > 0 ? "tool-calls" : "stop");
       const textStream = (async function* () {
         if (turn.streamError) throw turn.streamError;
         for (const delta of turn.deltas ?? []) yield delta;
@@ -356,7 +494,23 @@ describe("runner", () => {
         fullStream,
         toolCalls: turn.toolCallsError
           ? Promise.reject(turn.toolCallsError)
-          : Promise.resolve(turn.toolCalls ?? []),
+          : Promise.resolve(turnToolCalls),
+        finishReason: Promise.resolve(finishReason),
+        rawFinishReason: Promise.resolve(turn.rawFinishReason),
+        steps: Promise.resolve(
+          turn.steps ?? [
+            {
+              stepNumber: 0,
+              finishReason,
+              rawFinishReason: turn.rawFinishReason,
+              text: turnText,
+              reasoningText: turnReasoning || undefined,
+              toolCalls: turnToolCalls.map((toolCall) => ({
+                toolName: toolCall.name,
+              })),
+            },
+          ],
+        ),
       };
     });
   });
@@ -404,6 +558,417 @@ describe("runner", () => {
       content: "Hello world",
     });
     expect(dispatchToolMock).not.toHaveBeenCalled();
+  });
+
+  it("merges discovered MCP tools into the main run and routes them through approval", async () => {
+    const tabId = "tab-mcp-tool";
+    setState(tabId, {
+      config: { cwd: "/workspace/app", model: "openai/gpt-5.2" },
+    });
+    jotaiStoreMock.get.mockImplementation((atom: unknown) => {
+      if (atom === providersAtomMock) {
+        return [
+          {
+            id: "test-openai-id",
+            name: "test-openai",
+            type: "openai",
+            apiKey: "test-key",
+          },
+        ];
+      }
+      if (atom === mcpServersAtomMock) {
+        return [
+          {
+            id: "filesystem",
+            name: "Filesystem",
+            enabled: true,
+            transport: "stdio",
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+          },
+        ];
+      }
+      if (atom === profilesAtomMock) return [];
+      if (atom === globalCommunicationProfileAtomMock) {
+        return "global-test-profile";
+      }
+      return undefined;
+    });
+    prepareMcpRunMock.mockResolvedValue({
+      tools: [
+        {
+          serverId: "filesystem",
+          serverName: "Filesystem",
+          name: "read_file",
+          title: "Read File",
+          description: "Read a file from the MCP filesystem server.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+            },
+            required: ["path"],
+          },
+        },
+      ],
+      failures: [],
+    });
+    callMcpToolMock.mockResolvedValue({
+      content: [{ type: "text", text: "README contents" }],
+      structuredContent: { path: "README.md" },
+      isError: false,
+    });
+    turns.push({
+      deltas: ["Checking files."],
+      toolCalls: [
+        {
+          id: "tc-mcp-1",
+          name: "mcp_filesystem_read_file",
+          arguments: { path: "README.md" },
+        },
+      ],
+    });
+    turns.push({ deltas: ["Done."], toolCalls: [] });
+
+    await runAgent(tabId, "read the readme");
+
+    expect(prepareMcpRunMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "/workspace/app",
+      [
+        expect.objectContaining({
+          id: "filesystem",
+          name: "Filesystem",
+          enabled: true,
+        }),
+      ],
+    );
+    const firstStreamCall = streamTextMock.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(firstStreamCall).toBeDefined();
+    expect(firstStreamCall?.tools).toMatchObject({
+      mcp_filesystem_read_file: expect.objectContaining({
+        description: "Read a file from the MCP filesystem server.",
+      }),
+    });
+    expect(requestApprovalMock).toHaveBeenCalledWith("tab-mcp-tool", "tc-mcp-1");
+    expect(validateToolMock).not.toHaveBeenCalled();
+    expect(dispatchToolMock).not.toHaveBeenCalled();
+    expect(callMcpToolMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "filesystem",
+      "read_file",
+      { path: "README.md" },
+    );
+    expect(parseToolMessageResult(tabId, "tc-mcp-1")).toMatchObject({
+      ok: true,
+      data: {
+        content: [{ type: "text", text: "README contents" }],
+        structuredContent: { path: "README.md" },
+        isError: false,
+      },
+    });
+    expect(states[tabId].chatMessages[1]).toMatchObject({
+      badge: "CALLING TOOLS",
+      toolCalls: [
+        expect.objectContaining({
+          tool: "mcp_filesystem_read_file",
+          status: "done",
+          mcp: {
+            serverId: "filesystem",
+            serverName: "Filesystem",
+            toolName: "read_file",
+            toolTitle: "Read File",
+          },
+        }),
+      ],
+    });
+    expect(shutdownMcpRunMock).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it("artifactizes MCP file payloads only when the global MCP setting is enabled", async () => {
+    const tabId = "tab-mcp-artifactize";
+    setState(tabId, {
+      config: { cwd: "/workspace/app", model: "openai/gpt-5.2" },
+    });
+    jotaiStoreMock.get.mockImplementation((atom: unknown) => {
+      if (atom === providersAtomMock) {
+        return [
+          {
+            id: "test-openai-id",
+            name: "test-openai",
+            type: "openai",
+            apiKey: "test-key",
+          },
+        ];
+      }
+      if (atom === mcpServersAtomMock) {
+        return [
+          {
+            id: "playwright",
+            name: "Playwright",
+            enabled: true,
+            transport: "stdio",
+            command: "npx",
+            args: ["@playwright/mcp"],
+          },
+        ];
+      }
+      if (atom === mcpSettingsAtomMock) {
+        return { artifactizeReturnedFiles: true };
+      }
+      if (atom === profilesAtomMock) return [];
+      if (atom === globalCommunicationProfileAtomMock) {
+        return "global-test-profile";
+      }
+      return undefined;
+    });
+    prepareMcpRunMock.mockResolvedValue({
+      tools: [
+        {
+          serverId: "playwright",
+          serverName: "Playwright",
+          name: "browser_take_screenshot",
+          title: "Take Screenshot",
+          description: "Capture the current viewport.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              filename: { type: "string" },
+            },
+          },
+        },
+      ],
+      failures: [],
+    });
+    callMcpToolMock.mockResolvedValue({
+      content: [
+        { type: "text", text: "### Result\n- [Screenshot](screenshot-2.png)" },
+        {
+          type: "image",
+          mimeType: "image/png",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+        },
+      ],
+      isError: false,
+    });
+    artifactCreateMock.mockResolvedValue({
+      ok: true,
+      data: {
+        artifact: makeArtifact({
+          artifactId: "mcp_attachment_1",
+          version: 2,
+          kind: "mcp-attachment",
+          summary: "Playwright · Take Screenshot · image/png",
+        }),
+      },
+    });
+    turns.push({
+      deltas: ["Taking a screenshot."],
+      toolCalls: [
+        {
+          id: "tc-mcp-image-1",
+          name: "mcp_playwright_browser_take_screenshot",
+          arguments: { filename: "screenshot-2.png" },
+        },
+      ],
+    });
+    turns.push({ deltas: ["Done."], toolCalls: [] });
+
+    await runAgent(tabId, "take a screenshot");
+
+    expect(artifactCreateMock).toHaveBeenCalledWith(
+      tabId,
+      expect.objectContaining({
+        agentId: "agent_main",
+        runId: expect.stringMatching(/^run_/),
+      }),
+      expect.objectContaining({
+        kind: "mcp-attachment",
+        contentFormat: "json",
+        summary: "Playwright · Take Screenshot · image/png",
+      }),
+    );
+    const toolResult = parseToolMessageResult(tabId, "tc-mcp-image-1");
+    expect(JSON.stringify(toolResult)).not.toContain("iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB");
+    expect(toolResult).toMatchObject({
+      ok: true,
+      data: {
+        content: [
+          { type: "text", text: "### Result\n- [Screenshot](screenshot-2.png)" },
+          {
+            type: "text",
+            text: expect.stringContaining("mcp_attachment_1@2"),
+          },
+        ],
+        meta: {
+          __rakhMcpArtifacts: [
+            expect.objectContaining({
+              artifactId: "mcp_attachment_1",
+              version: 2,
+              originalType: "image",
+              mimeType: "image/png",
+            }),
+          ],
+        },
+      },
+    });
+    const followUpMessages = (
+      streamTextMock.mock.calls[1]?.[0] as
+        | { messages?: Array<Record<string, unknown>> }
+        | undefined
+    )?.messages;
+    expect(JSON.stringify(followUpMessages)).not.toContain(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+    );
+    expect(JSON.stringify(followUpMessages)).toContain("mcp_attachment_1");
+  });
+
+  it("leaves MCP file payloads untouched when MCP artifactization is disabled", async () => {
+    const tabId = "tab-mcp-no-artifactize";
+    setState(tabId, {
+      config: { cwd: "/workspace/app", model: "openai/gpt-5.2" },
+    });
+    jotaiStoreMock.get.mockImplementation((atom: unknown) => {
+      if (atom === providersAtomMock) {
+        return [
+          {
+            id: "test-openai-id",
+            name: "test-openai",
+            type: "openai",
+            apiKey: "test-key",
+          },
+        ];
+      }
+      if (atom === mcpServersAtomMock) {
+        return [
+          {
+            id: "playwright",
+            name: "Playwright",
+            enabled: true,
+            transport: "stdio",
+            command: "npx",
+            args: ["@playwright/mcp"],
+          },
+        ];
+      }
+      if (atom === mcpSettingsAtomMock) {
+        return { artifactizeReturnedFiles: false };
+      }
+      if (atom === profilesAtomMock) return [];
+      if (atom === globalCommunicationProfileAtomMock) {
+        return "global-test-profile";
+      }
+      return undefined;
+    });
+    prepareMcpRunMock.mockResolvedValue({
+      tools: [
+        {
+          serverId: "playwright",
+          serverName: "Playwright",
+          name: "browser_take_screenshot",
+          title: "Take Screenshot",
+          description: "Capture the current viewport.",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+      failures: [],
+    });
+    callMcpToolMock.mockResolvedValue({
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+        },
+      ],
+      isError: false,
+    });
+    turns.push({
+      deltas: ["Taking a screenshot."],
+      toolCalls: [
+        {
+          id: "tc-mcp-image-raw",
+          name: "mcp_playwright_browser_take_screenshot",
+          arguments: { filename: "screenshot-2.png" },
+        },
+      ],
+    });
+    turns.push({ deltas: ["Done."], toolCalls: [] });
+
+    await runAgent(tabId, "take a screenshot");
+
+    expect(artifactCreateMock).not.toHaveBeenCalled();
+    expect(parseToolMessageResult(tabId, "tc-mcp-image-raw")).toMatchObject({
+      ok: true,
+      data: {
+        content: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+          },
+        ],
+        isError: false,
+      },
+    });
+  });
+
+  it("adds an MCP warning message when one configured server fails discovery", async () => {
+    const tabId = "tab-mcp-warning";
+    setState(tabId);
+    jotaiStoreMock.get.mockImplementation((atom: unknown) => {
+      if (atom === providersAtomMock) {
+        return [
+          {
+            id: "test-openai-id",
+            name: "test-openai",
+            type: "openai",
+            apiKey: "test-key",
+          },
+        ];
+      }
+      if (atom === mcpServersAtomMock) {
+        return [
+          {
+            id: "broken-server",
+            name: "Broken Server",
+            enabled: true,
+            transport: "streamable-http",
+            url: "http://localhost:1234/mcp",
+          },
+        ];
+      }
+      if (atom === profilesAtomMock) return [];
+      if (atom === globalCommunicationProfileAtomMock) {
+        return "global-test-profile";
+      }
+      return undefined;
+    });
+    prepareMcpRunMock.mockResolvedValue({
+      tools: [],
+      failures: [
+        {
+          serverId: "broken-server",
+          serverName: "Broken Server",
+          error: "Connection refused",
+        },
+      ],
+    });
+    turns.push({ deltas: ["Continuing without MCP."], toolCalls: [] });
+
+    await runAgent(tabId, "hello");
+
+    expect(states[tabId].chatMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          badge: "MCP WARNING",
+          content: expect.stringContaining("Broken Server: Connection refused"),
+        }),
+      ]),
+    );
+    expect(shutdownMcpRunMock).toHaveBeenCalledWith(expect.any(String));
   });
 
   it("includes reviewer scope guidance in the main system prompt via description", async () => {
@@ -522,6 +1087,23 @@ describe("runner", () => {
         expect.arrayContaining([debugPrefix, "stream:reasoning-delta"]),
         expect.arrayContaining([debugPrefix, "stream:text-delta"]),
         expect.arrayContaining([debugPrefix, "stream:tool-calls:raw"]),
+        expect.arrayContaining([
+          debugPrefix,
+          "stream:finish",
+          expect.objectContaining({
+            finishReason: "stop",
+            stepCount: 1,
+            steps: [
+              expect.objectContaining({
+                stepNumber: 0,
+                finishReason: "stop",
+                textChars: "Final answer.".length,
+                reasoningChars: "Inspect files.".length,
+                toolCallCount: 0,
+              }),
+            ],
+          }),
+        ]),
         expect.arrayContaining([debugPrefix, "stream:summary"]),
       ]),
     );
@@ -1129,7 +1711,7 @@ describe("runner", () => {
     );
 
     resumeQueue(tabId);
-    await flushAsyncWork(12);
+    await flushAsyncWork(20);
 
     expect(states[tabId].queueState).toBe("idle");
     expect(states[tabId].queuedMessages).toEqual([]);
@@ -1849,176 +2431,6 @@ describe("runner", () => {
         },
       });
       expect(streamTextMock).toHaveBeenCalledTimes(4);
-    });
-
-    it("keeps parallel subagent invocations isolated in chat state", async () => {
-      const tabId = "tab-subagent-parallel";
-      setState(tabId);
-
-      const subagentToolCallIds = [
-        "tc-github-1",
-        "tc-github-2",
-        "tc-github-3",
-      ] as const;
-      const subagentOutputs = [
-        {
-          text: "Created issue for the tray request.",
-          reasoning: "Inspect tray-related code paths.",
-        },
-        {
-          text: "Created issue for archived tab grouping.",
-          reasoning: "Inspect archived session persistence.",
-        },
-        {
-          text: "Created issue for approved command allowlists.",
-          reasoning: "Inspect exec approvals and settings state.",
-        },
-      ] as const;
-      const subagentGates = subagentOutputs.map(() => createDeferred<void>());
-      const emptyStream = () => (async function* () {})();
-      let streamCallIndex = 0;
-
-      streamTextMock.mockImplementation(() => {
-        const currentCall = streamCallIndex;
-        streamCallIndex += 1;
-
-        if (currentCall === 0) {
-          return {
-            textStream: emptyStream(),
-            fullStream: emptyStream(),
-            toolCalls: Promise.resolve(
-              subagentToolCallIds.map((toolCallId, index) => ({
-                id: toolCallId,
-                name: "agent_subagent_call",
-                arguments: {
-                  subagentId: "github",
-                  message: `create issue ${index + 1}`,
-                },
-              })),
-            ),
-          };
-        }
-
-        if (currentCall >= 1 && currentCall <= 3) {
-          const output = subagentOutputs[currentCall - 1];
-          const gate = subagentGates[currentCall - 1];
-          return {
-            textStream: emptyStream(),
-            fullStream: (async function* () {
-              await gate.promise;
-              yield {
-                type: "reasoning-start",
-                id: `reasoning-${currentCall}`,
-              };
-              yield {
-                type: "reasoning-delta",
-                id: `reasoning-${currentCall}`,
-                delta: output.reasoning,
-              };
-              await Promise.resolve();
-              yield {
-                type: "text-delta",
-                id: `text-${currentCall}`,
-                delta: output.text,
-              };
-              yield {
-                type: "reasoning-end",
-                id: `reasoning-${currentCall}`,
-              };
-            })(),
-            toolCalls: Promise.resolve([]),
-          };
-        }
-
-        if (currentCall === 4) {
-          return {
-            textStream: (async function* () {
-              yield "All issues created.";
-            })(),
-            fullStream: (async function* () {
-              yield {
-                type: "text-delta",
-                id: "text-main-final",
-                delta: "All issues created.",
-              };
-            })(),
-            toolCalls: Promise.resolve([]),
-          };
-        }
-
-        throw new Error(`Unexpected streamText call index ${currentCall}`);
-      });
-
-      const runPromise = runAgent(tabId, "create three issues");
-      await flushAsyncWork(6);
-
-      expect(streamCallIndex).toBe(4);
-
-      subagentGates[1]?.resolve();
-      await flushAsyncWork(6);
-      subagentGates[0]?.resolve();
-      await flushAsyncWork(6);
-      subagentGates[2]?.resolve();
-
-      await runPromise;
-
-      const state = states[tabId];
-      expect(state.status).toBe("idle");
-
-      const subagentMessages = state.chatMessages.filter(
-        (message) => message.agentName === "GitHub Operator",
-      );
-      expect(subagentMessages).toHaveLength(3);
-      expect(
-        new Set(subagentMessages.map((message) => message.bubbleGroupId)),
-      ).toEqual(new Set(subagentToolCallIds));
-      expect(
-        subagentMessages.every((message) => message.streaming === false),
-      ).toBe(true);
-      expect(
-        subagentMessages.every(
-          (message) => message.reasoningStreaming === undefined,
-        ),
-      ).toBe(true);
-      expect(
-        subagentMessages.every(
-          (message) => typeof message.reasoningDurationMs === "number",
-        ),
-      ).toBe(true);
-
-      const toolCallStatusById = new Map(
-        state.chatMessages
-          .flatMap(
-            (message) =>
-              (message.toolCalls as Array<Record<string, unknown>> | undefined) ??
-              [],
-          )
-          .map((toolCall) => [toolCall.id, toolCall.status]),
-      );
-      for (const toolCallId of subagentToolCallIds) {
-        expect(toolCallStatusById.get(toolCallId)).toBe("done");
-      }
-
-      for (const [index, toolCallId] of subagentToolCallIds.entries()) {
-        expect(parseToolMessageResult(tabId, toolCallId)).toMatchObject({
-          ok: true,
-          data: {
-            subagentId: "github",
-            rawText: subagentOutputs[index]?.text,
-          },
-        });
-      }
-
-      const groupedMessages = groupChatMessagesForBubbles(
-        state.chatMessages as unknown as ChatMessage[],
-      );
-      expect(
-        groupedMessages.filter(
-          (group) =>
-            group.kind === "assistant" &&
-            group.agentName === "GitHub Operator",
-        ),
-      ).toHaveLength(3);
     });
 
     it("rejects invalid reviewer artifacts before persistence and succeeds after retry", async () => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -26,6 +26,18 @@ import {
 } from "./tools";
 import { execAbort, execStop } from "./tools/exec";
 import {
+  buildMcpRuntimeToolRegistry,
+  callMcpTool,
+  extractMcpToolErrorMessage,
+  mcpServersAtom,
+  mcpSettingsAtom,
+  prepareMcpRun,
+  shutdownMcpRun,
+  type McpToolDefinition,
+  type McpToolCallResponse,
+  type McpToolRegistration,
+} from "./mcp";
+import {
   getAllSubagents,
   getSubagent,
   findSubagentByTrigger,
@@ -84,6 +96,7 @@ import type {
 } from "@/agent/tools/workspace";
 import { profilesAtom, type ProviderInstance } from "./db";
 import {
+  artifactCreate,
   artifactGet,
   getArtifactFrameworkMetadata,
   withArtifactFrameworkMetadata,
@@ -177,6 +190,372 @@ function isRunAbortedToolResult(result: unknown): boolean {
 
 function shouldStreamToolOutput(toolName: string): boolean {
   return toolName === "exec_run" || toolName === "git_worktree_init";
+}
+
+interface MainAgentMcpRuntime {
+  toolDefinitions: Record<string, McpToolDefinition>;
+  toolsByName: Record<string, McpToolRegistration>;
+}
+
+function buildMcpWarningMessage(failures: Array<{ serverName: string; error: string }>): string {
+  const prefix =
+    failures.length === 1
+      ? "One MCP server could not be loaded for this run:"
+      : `${failures.length} MCP servers could not be loaded for this run:`;
+  const details = failures
+    .map((failure) => `- ${failure.serverName}: ${failure.error}`)
+    .join("\n");
+  return `${prefix}\n${details}`;
+}
+
+async function prepareMainAgentMcpRuntime(
+  tabId: string,
+  runId: string,
+  cwd: string,
+): Promise<MainAgentMcpRuntime> {
+  const configuredServers = jotaiStore.get(mcpServersAtom);
+  if (!configuredServers.some((server) => server.enabled)) {
+    return { toolDefinitions: {}, toolsByName: {} };
+  }
+
+  try {
+    const prepared = await prepareMcpRun(runId, cwd, configuredServers);
+    if (prepared.failures.length > 0) {
+      appendChatMessage(tabId, {
+        id: msgId(),
+        role: "assistant",
+        content: buildMcpWarningMessage(prepared.failures),
+        timestamp: Date.now(),
+        badge: "MCP WARNING",
+      });
+    }
+
+    const registry = buildMcpRuntimeToolRegistry(
+      prepared.tools,
+      Object.keys(TOOL_DEFINITIONS),
+    );
+    return {
+      toolDefinitions: registry.definitions,
+      toolsByName: registry.toolsByName,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendChatMessage(tabId, {
+      id: msgId(),
+      role: "assistant",
+      content: `MCP discovery failed for this run.\n- ${message}`,
+      timestamp: Date.now(),
+      badge: "MCP WARNING",
+    });
+    return { toolDefinitions: {}, toolsByName: {} };
+  }
+}
+
+type McpArtifactPayloadCandidate =
+  | {
+      payload: Record<string, unknown>;
+      originalType: string;
+      mimeType?: string;
+      filename?: string;
+      dataEncoding?: "base64" | "utf8";
+    }
+  | {
+      payload: Record<string, unknown>;
+      originalType: "resource";
+      mimeType?: string;
+      filename?: string;
+      dataEncoding?: "base64" | "utf8";
+    };
+
+interface McpArtifactReference {
+  artifactId: string;
+  version: number;
+  mimeType?: string;
+  originalType: string;
+  filename?: string;
+}
+
+function getMcpArtifactPayloadCandidate(
+  value: unknown,
+): McpArtifactPayloadCandidate | null {
+  if (!isRecord(value)) return null;
+
+  const payloadType =
+    typeof value.type === "string" && value.type.trim()
+      ? value.type.trim()
+      : "file";
+  const mimeType =
+    typeof value.mimeType === "string" && value.mimeType.trim()
+      ? value.mimeType.trim()
+      : undefined;
+  const filename =
+    typeof value.filename === "string" && value.filename.trim()
+      ? value.filename.trim()
+      : typeof value.name === "string" && value.name.trim()
+        ? value.name.trim()
+        : undefined;
+
+  if (
+    typeof value.data === "string" &&
+    (payloadType === "image" ||
+      payloadType === "audio" ||
+      payloadType === "file" ||
+      mimeType !== undefined)
+  ) {
+    return {
+      payload: value,
+      originalType: payloadType,
+      mimeType,
+      filename,
+      dataEncoding: "base64",
+    };
+  }
+
+  if (payloadType !== "resource" || !isRecord(value.resource)) {
+    return null;
+  }
+
+  const resourceMimeType =
+    typeof value.resource.mimeType === "string" && value.resource.mimeType.trim()
+      ? value.resource.mimeType.trim()
+      : undefined;
+  const resourceFilename =
+    typeof value.resource.name === "string" && value.resource.name.trim()
+      ? value.resource.name.trim()
+      : typeof value.resource.uri === "string" && value.resource.uri.trim()
+        ? value.resource.uri.trim()
+        : filename;
+
+  if (typeof value.resource.blob === "string") {
+    return {
+      payload: value,
+      originalType: "resource",
+      mimeType: resourceMimeType,
+      filename: resourceFilename,
+      dataEncoding: "base64",
+    };
+  }
+
+  if (typeof value.resource.text === "string") {
+    return {
+      payload: value,
+      originalType: "resource",
+      mimeType: resourceMimeType,
+      filename: resourceFilename,
+      dataEncoding: "utf8",
+    };
+  }
+
+  return null;
+}
+
+function buildMcpArtifactReferenceMessage(
+  reference: McpArtifactReference,
+): string {
+  const payloadLabel = [
+    reference.originalType,
+    reference.mimeType,
+    reference.filename,
+  ]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(" · ");
+  const prefix = payloadLabel
+    ? `MCP payload stored as artifact (${payloadLabel})`
+    : "MCP payload stored as artifact";
+  return (
+    `${prefix}: ${reference.artifactId}@${reference.version}. ` +
+    "Retrieve it from the artifact repository with agent_artifact_get."
+  );
+}
+
+function buildMcpArtifactReferenceRecord(
+  reference: McpArtifactReference,
+): Record<string, unknown> {
+  return {
+    artifactId: reference.artifactId,
+    version: reference.version,
+    originalType: reference.originalType,
+    ...(reference.mimeType ? { mimeType: reference.mimeType } : {}),
+    ...(reference.filename ? { filename: reference.filename } : {}),
+    note: "Binary MCP payload removed from model context. Retrieve it from the artifact repository with agent_artifact_get.",
+  };
+}
+
+async function createMcpPayloadArtifact(
+  tabId: string,
+  runId: string,
+  mcpTool: McpToolRegistration,
+  candidate: McpArtifactPayloadCandidate,
+): Promise<McpArtifactReference | null> {
+  const summaryParts = [
+    mcpTool.serverName,
+    mcpTool.toolTitle ?? mcpTool.toolName,
+    candidate.mimeType ?? candidate.originalType,
+  ];
+  const summary = summaryParts
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(" · ");
+  const artifactInput = {
+    kind: "mcp-attachment",
+    summary,
+    contentFormat: "json" as const,
+    content: JSON.stringify(candidate.payload, null, 2),
+    metadata: {
+      source: {
+        type: "mcp",
+        serverId: mcpTool.serverId,
+        serverName: mcpTool.serverName,
+        toolName: mcpTool.toolName,
+        ...(mcpTool.toolTitle ? { toolTitle: mcpTool.toolTitle } : {}),
+      },
+      attachment: {
+        originalType: candidate.originalType,
+        ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+        ...(candidate.filename ? { filename: candidate.filename } : {}),
+        ...(candidate.dataEncoding ? { dataEncoding: candidate.dataEncoding } : {}),
+      },
+    },
+  };
+  const artifactResult = await artifactCreate(
+    tabId,
+    { runId, agentId: "agent_main" },
+    artifactInput,
+  );
+  if (!artifactResult.ok) {
+    console.warn("Failed to artifactize MCP payload", {
+      serverId: mcpTool.serverId,
+      toolName: mcpTool.toolName,
+      error: artifactResult.error,
+    });
+    return null;
+  }
+
+  return {
+    artifactId: artifactResult.data.artifact.artifactId,
+    version: artifactResult.data.artifact.version,
+    originalType: candidate.originalType,
+    ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+    ...(candidate.filename ? { filename: candidate.filename } : {}),
+  };
+}
+
+async function sanitizeMcpStructuredValue(
+  value: unknown,
+  tabId: string,
+  runId: string,
+  mcpTool: McpToolRegistration,
+  artifactRefs: McpArtifactReference[],
+): Promise<unknown> {
+  const candidate = getMcpArtifactPayloadCandidate(value);
+  if (candidate) {
+    const artifactRef = await createMcpPayloadArtifact(tabId, runId, mcpTool, candidate);
+    if (!artifactRef) return value;
+    artifactRefs.push(artifactRef);
+    return buildMcpArtifactReferenceRecord(artifactRef);
+  }
+
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((entry) =>
+        sanitizeMcpStructuredValue(entry, tabId, runId, mcpTool, artifactRefs),
+      ),
+    );
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const entries = await Promise.all(
+    Object.entries(value).map(async ([key, entry]) => [
+      key,
+      await sanitizeMcpStructuredValue(entry, tabId, runId, mcpTool, artifactRefs),
+    ]),
+  );
+  return Object.fromEntries(entries);
+}
+
+async function maybeArtifactizeMcpToolResult(
+  tabId: string,
+  runId: string,
+  mcpTool: McpToolRegistration,
+  result: McpToolCallResponse,
+  artifactizeReturnedFiles: boolean,
+): Promise<McpToolCallResponse> {
+  if (!artifactizeReturnedFiles) {
+    return result;
+  }
+
+  const artifactRefs: McpArtifactReference[] = [];
+  const nextContent = await Promise.all(
+    result.content.map(async (item) => {
+      const candidate = getMcpArtifactPayloadCandidate(item);
+      if (!candidate) return item;
+
+      const artifactRef = await createMcpPayloadArtifact(tabId, runId, mcpTool, candidate);
+      if (!artifactRef) return item;
+      artifactRefs.push(artifactRef);
+      return {
+        type: "text",
+        text: buildMcpArtifactReferenceMessage(artifactRef),
+      };
+    }),
+  );
+  const nextStructuredContent =
+    result.structuredContent === undefined
+      ? undefined
+      : await sanitizeMcpStructuredValue(
+          result.structuredContent,
+          tabId,
+          runId,
+          mcpTool,
+          artifactRefs,
+        );
+  const nextMeta =
+    result.meta === undefined
+      ? undefined
+      : await sanitizeMcpStructuredValue(result.meta, tabId, runId, mcpTool, artifactRefs);
+
+  if (artifactRefs.length === 0) {
+    return result;
+  }
+
+  const metaRecord = isRecord(nextMeta) ? { ...nextMeta } : {};
+  metaRecord.__rakhMcpArtifacts = artifactRefs.map((reference) =>
+    buildMcpArtifactReferenceRecord(reference),
+  );
+
+  return {
+    ...result,
+    content: nextContent,
+    ...(result.structuredContent !== undefined
+      ? { structuredContent: nextStructuredContent }
+      : {}),
+    meta: metaRecord,
+  };
+}
+
+function buildToolCallDisplay(
+  toolCall: ApiToolCall,
+  mcpToolsByName: Record<string, McpToolRegistration>,
+): ToolCallDisplay {
+  const registration = mcpToolsByName[toolCall.function.name];
+  return {
+    id: toolCall.id,
+    tool: toolCall.function.name,
+    args: parseArgs(toolCall.function.arguments),
+    ...(registration
+      ? {
+          mcp: {
+            serverId: registration.serverId,
+            serverName: registration.serverName,
+            toolName: registration.toolName,
+            ...(registration.toolTitle ? { toolTitle: registration.toolTitle } : {}),
+          },
+        }
+      : {}),
+    status: "pending",
+  };
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -951,51 +1330,15 @@ function appendChatMessage(tabId: string, msg: ChatMessage): void {
   }));
 }
 
-function updateChatMessageById(
+function updateLastChatMessage(
   tabId: string,
-  messageId: string,
   updater: (msg: ChatMessage) => ChatMessage,
 ): void {
   patchAgentState(tabId, (prev) => {
-    let didUpdate = false;
-    const chatMessages = prev.chatMessages.map((msg) => {
-      if (msg.id !== messageId) return msg;
-      didUpdate = true;
-      return updater(msg);
-    });
-    return didUpdate ? { ...prev, chatMessages } : prev;
-  });
-}
-
-function finalizeLatestStreamingAssistantMessage(tabId: string): void {
-  const finalizedAtMs = Date.now();
-  patchAgentState(tabId, (prev) => {
-    const chatMessages = [...prev.chatMessages];
-    for (let index = chatMessages.length - 1; index >= 0; index -= 1) {
-      const msg = chatMessages[index];
-      if (msg.role !== "assistant") continue;
-      const reasoningStartedAtMs = msg.reasoningStartedAtMs;
-      const shouldFinalizeReasoningDuration =
-        typeof reasoningStartedAtMs === "number" &&
-        typeof msg.reasoningDurationMs !== "number";
-      if (
-        !msg.streaming &&
-        !msg.reasoningStreaming &&
-        !shouldFinalizeReasoningDuration
-      ) {
-        continue;
-      }
-      chatMessages[index] = {
-        ...msg,
-        streaming: false,
-        reasoningStreaming: undefined,
-        reasoningDurationMs: shouldFinalizeReasoningDuration
-          ? Math.max(0, finalizedAtMs - reasoningStartedAtMs)
-          : msg.reasoningDurationMs,
-      };
-      return { ...prev, chatMessages };
-    }
-    return prev;
+    const msgs = [...prev.chatMessages];
+    if (msgs.length === 0) return prev;
+    msgs[msgs.length - 1] = updater(msgs[msgs.length - 1]);
+    return { ...prev, chatMessages: msgs };
   });
 }
 
@@ -1095,6 +1438,89 @@ function logStreamDebug(
     return;
   }
   console.log(prefix, event, toLoggable(payload));
+}
+
+interface DebuggableStreamStep {
+  stepNumber?: unknown;
+  finishReason?: unknown;
+  rawFinishReason?: unknown;
+  text?: unknown;
+  reasoningText?: unknown;
+  toolCalls?: unknown;
+}
+
+interface DebuggableStreamResult {
+  finishReason?: PromiseLike<unknown>;
+  rawFinishReason?: PromiseLike<unknown>;
+  steps?: PromiseLike<unknown>;
+}
+
+function summarizeStreamStepForDebug(
+  step: unknown,
+  fallbackStepNumber: number,
+): Record<string, unknown> {
+  if (!isRecord(step)) {
+    return { stepNumber: fallbackStepNumber };
+  }
+
+  const debugStep = step as DebuggableStreamStep;
+  const toolCalls = Array.isArray(debugStep.toolCalls) ? debugStep.toolCalls : [];
+  const toolNames = toolCalls
+    .map((toolCall) =>
+      isRecord(toolCall) && typeof toolCall.toolName === "string"
+        ? toolCall.toolName
+        : null,
+    )
+    .filter((toolName): toolName is string => toolName !== null);
+
+  return {
+    stepNumber:
+      typeof debugStep.stepNumber === "number"
+        ? debugStep.stepNumber
+        : fallbackStepNumber,
+    ...(typeof debugStep.finishReason === "string"
+      ? { finishReason: debugStep.finishReason }
+      : {}),
+    ...(typeof debugStep.rawFinishReason === "string"
+      ? { rawFinishReason: debugStep.rawFinishReason }
+      : {}),
+    textChars:
+      typeof debugStep.text === "string" ? debugStep.text.length : undefined,
+    reasoningChars:
+      typeof debugStep.reasoningText === "string"
+        ? debugStep.reasoningText.length
+        : undefined,
+    toolCallCount: toolCalls.length,
+    ...(toolNames.length > 0 ? { toolNames } : {}),
+  };
+}
+
+async function logStreamFinishDebug(
+  tabId: string,
+  debugEnabled: boolean,
+  result: DebuggableStreamResult,
+): Promise<void> {
+  if (!debugEnabled) return;
+
+  try {
+    const [finishReason, rawFinishReason, stepsValue] = await Promise.all([
+      result.finishReason ?? Promise.resolve(undefined),
+      result.rawFinishReason ?? Promise.resolve(undefined),
+      result.steps ?? Promise.resolve(undefined),
+    ]);
+    const steps = Array.isArray(stepsValue) ? stepsValue : [];
+
+    logStreamDebug(tabId, debugEnabled, "stream:finish", {
+      ...(typeof finishReason === "string" ? { finishReason } : {}),
+      ...(typeof rawFinishReason === "string" ? { rawFinishReason } : {}),
+      stepCount: steps.length,
+      steps: steps.map((step, index) =>
+        summarizeStreamStepForDebug(step, index),
+      ),
+    });
+  } catch (error) {
+    logStreamDebug(tabId, debugEnabled, "stream:finish:error", error);
+  }
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -1322,7 +1748,6 @@ interface SubagentLoopOptions {
   parentModelId: string;
   providers: ProviderInstance[];
   debugEnabled: boolean;
-  bubbleGroupId?: string;
 }
 
 /**
@@ -1350,12 +1775,10 @@ async function runSubagentLoop(
     parentModelId,
     providers,
     debugEnabled,
-    bubbleGroupId,
   } = opts;
 
   const startedAtMs = Date.now();
   const modelId = resolveSubagentModelId(subagentDef, parentModelId, providers);
-  const resolvedBubbleGroupId = bubbleGroupId?.trim() || msgId();
 
   let languageModel;
   try {
@@ -1706,7 +2129,6 @@ async function runSubagentLoop(
       id: assistantChatId,
       role: "assistant",
       agentName: subagentDef.name,
-      bubbleGroupId: resolvedBubbleGroupId,
       content: "",
       timestamp: Date.now(),
       streaming: true,
@@ -1722,16 +2144,19 @@ async function runSubagentLoop(
     });
 
     const updateSubagentStreamMsg = () => {
-      updateChatMessageById(tabId, assistantChatId, (m) => ({
-        ...m,
-        agentName: subagentDef.name,
-        bubbleGroupId: resolvedBubbleGroupId,
-        content: accText,
-        reasoning: accReasoning || undefined,
-        reasoningStreaming: reasoningActive ? true : undefined,
-        reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
-        reasoningDurationMs: reasoningDurationMs ?? undefined,
-      }));
+      updateLastChatMessage(tabId, (m) =>
+        m.id === assistantChatId
+          ? {
+              ...m,
+              agentName: subagentDef.name,
+              content: accText,
+              reasoning: accReasoning || undefined,
+              reasoningStreaming: reasoningActive ? true : undefined,
+              reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+              reasoningDurationMs: reasoningDurationMs ?? undefined,
+            }
+          : m,
+      );
     };
 
     try {
@@ -1822,11 +2247,11 @@ async function runSubagentLoop(
     );
 
     // Finalise the streaming assistant message.
-    updateChatMessageById(tabId, assistantChatId, (m) => {
+    updateLastChatMessage(tabId, (m) => {
+      if (m.id !== assistantChatId) return m;
       return {
         ...m,
         agentName: subagentDef.name,
-        bubbleGroupId: resolvedBubbleGroupId,
         content: accText,
         reasoning: accReasoning || undefined,
         reasoningStreaming: undefined,
@@ -2314,7 +2739,9 @@ async function runAgentTurn(
       }
       const msg = err instanceof Error ? err.message : String(err);
       setAgentErrorState(tabId, msg, serializeError(err));
-      finalizeLatestStreamingAssistantMessage(tabId);
+      updateLastChatMessage(tabId, (m) =>
+        m.role === "assistant" ? { ...m, streaming: false } : m,
+      );
       return;
     } finally {
       clearActiveRun(tabId, activeRun);
@@ -2506,7 +2933,9 @@ async function runAgentTurn(
     }
     const msg = err instanceof Error ? err.message : String(err);
     setAgentErrorState(tabId, msg, serializeError(err));
-    finalizeLatestStreamingAssistantMessage(tabId);
+    updateLastChatMessage(tabId, (m) =>
+      m.role === "assistant" ? { ...m, streaming: false } : m,
+    );
   } finally {
     clearActiveRun(tabId, activeRun);
     if (activeRun.abortReason !== null) return;
@@ -2548,59 +2977,69 @@ async function agentLoop(
     advancedOpts,
     modelEntry?.sdk_id?.trim(),
   );
+  const mcpRuntime = await prepareMainAgentMcpRuntime(
+    tabId,
+    runId,
+    getAgentState(tabId).config.cwd,
+  );
+  const toolDefinitions = {
+    ...TOOL_DEFINITIONS,
+    ...mcpRuntime.toolDefinitions,
+  };
 
-  // Loop until the model returns a turn with no tool calls
-  for (let iteration = 0; iteration < 50; iteration++) {
-    if (signal.aborted) return;
+  try {
+    // Loop until the model returns a turn with no tool calls
+    for (let iteration = 0; iteration < 50; iteration++) {
+      if (signal.aborted) return;
 
-    const turnStartedAtMs = Date.now();
-    const currentApiMessages = getAgentState(tabId).apiMessages;
-    logStreamDebug(tabId, debugEnabled, "turn:start", {
-      iteration,
-      apiMessageCount: currentApiMessages.length,
-      modelId,
-    });
-    let usedFullStream = false;
-    let streamPartCount = 0;
-    let streamErrorPartCount = 0;
-    let textDeltaCount = 0;
-    let textDeltaChars = 0;
-    let reasoningDeltaCount = 0;
-    let reasoningDeltaChars = 0;
-    let reasoningStartCount = 0;
-    let reasoningEndCount = 0;
+      const turnStartedAtMs = Date.now();
+      const currentApiMessages = getAgentState(tabId).apiMessages;
+      logStreamDebug(tabId, debugEnabled, "turn:start", {
+        iteration,
+        apiMessageCount: currentApiMessages.length,
+        modelId,
+      });
+      let usedFullStream = false;
+      let streamPartCount = 0;
+      let streamErrorPartCount = 0;
+      let textDeltaCount = 0;
+      let textDeltaChars = 0;
+      let reasoningDeltaCount = 0;
+      let reasoningDeltaChars = 0;
+      let reasoningStartCount = 0;
+      let reasoningEndCount = 0;
 
-    // --- Streaming turn ---
-    let accText = "";
-    let accReasoning = "";
-    let reasoningActive = false;
-    let reasoningStartedAtMs: number | null = null;
-    let reasoningDurationMs: number | null = null;
-    const streamErrors: unknown[] = [];
+      // --- Streaming turn ---
+      let accText = "";
+      let accReasoning = "";
+      let reasoningActive = false;
+      let reasoningStartedAtMs: number | null = null;
+      let reasoningDurationMs: number | null = null;
+      const streamErrors: unknown[] = [];
 
-    // Create a placeholder assistant chat message for streaming
-    const assistantChatId = msgId();
-    appendChatMessage(tabId, {
-      id: assistantChatId,
-      role: "assistant",
-      content: "",
-      timestamp: Date.now(),
-      streaming: true,
-    });
+      // Create a placeholder assistant chat message for streaming
+      const assistantChatId = msgId();
+      appendChatMessage(tabId, {
+        id: assistantChatId,
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        streaming: true,
+      });
 
-    patchAgentState(tabId, { status: "thinking", streamingContent: "" });
+      patchAgentState(tabId, { status: "thinking", streamingContent: "" });
 
-    const mappedMessages = mapApiMessagesToModelMessages(currentApiMessages);
+      const mappedMessages = mapApiMessagesToModelMessages(currentApiMessages);
 
-    const result = streamText({
-      model: languageModel,
-      messages: mappedMessages,
-      tools: TOOL_DEFINITIONS,
-      abortSignal: signal,
-      ...(providerOptions ? { providerOptions } : {}),
-    });
+      const result = streamText({
+        model: languageModel,
+        messages: mappedMessages,
+        tools: toolDefinitions,
+        abortSignal: signal,
+        ...(providerOptions ? { providerOptions } : {}),
+      });
 
-    try {
+      try {
       const ensureReasoningStart = () => {
         if (reasoningStartedAtMs === null) {
           reasoningStartedAtMs = Date.now();
@@ -2615,14 +3054,18 @@ async function agentLoop(
       };
 
       const updateStreamingMessage = () => {
-        updateChatMessageById(tabId, assistantChatId, (m) => ({
-          ...m,
-          content: accText,
-          reasoning: accReasoning || undefined,
-          reasoningStreaming: reasoningActive ? true : undefined,
-          reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
-          reasoningDurationMs: reasoningDurationMs ?? undefined,
-        }));
+        updateLastChatMessage(tabId, (m) =>
+          m.id === assistantChatId
+            ? {
+                ...m,
+                content: accText,
+                reasoning: accReasoning || undefined,
+                reasoningStreaming: reasoningActive ? true : undefined,
+                reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+                reasoningDurationMs: reasoningDurationMs ?? undefined,
+              }
+            : m,
+        );
       };
 
       const fullStream = (result as { fullStream?: AsyncIterable<unknown> })
@@ -2714,117 +3157,114 @@ async function agentLoop(
           updateStreamingMessage();
         }
       }
-    } catch (err) {
-      logStreamDebug(tabId, debugEnabled, "stream:throw", err);
-      // Re-throw if it's not a generic abort
-      if (!signal.aborted) throw attachStreamErrors(err, streamErrors);
-      return;
-    }
+      } catch (err) {
+        logStreamDebug(tabId, debugEnabled, "stream:throw", err);
+        // Re-throw if it's not a generic abort
+        if (!signal.aborted) throw attachStreamErrors(err, streamErrors);
+        return;
+      }
 
-    let sdkToolCalls: unknown;
-    try {
-      sdkToolCalls = await result.toolCalls;
-      logStreamDebug(
-        tabId,
-        debugEnabled,
-        "stream:tool-calls:raw",
-        sdkToolCalls,
-      );
-    } catch (err) {
-      logStreamDebug(tabId, debugEnabled, "stream:tool-calls:error", err);
-      throw attachStreamErrors(err, streamErrors);
-    }
+      let sdkToolCalls: unknown;
+      try {
+        sdkToolCalls = await result.toolCalls;
+        logStreamDebug(
+          tabId,
+          debugEnabled,
+          "stream:tool-calls:raw",
+          sdkToolCalls,
+        );
+      } catch (err) {
+        logStreamDebug(tabId, debugEnabled, "stream:tool-calls:error", err);
+        throw attachStreamErrors(err, streamErrors);
+      }
+      await logStreamFinishDebug(tabId, debugEnabled, result);
 
-    // --- Turn complete ---
-    if (reasoningStartedAtMs !== null && reasoningDurationMs === null) {
-      reasoningDurationMs = Math.max(0, Date.now() - reasoningStartedAtMs);
-    }
-    patchAgentState(tabId, { streamingContent: null });
+      // --- Turn complete ---
+      if (reasoningStartedAtMs !== null && reasoningDurationMs === null) {
+        reasoningDurationMs = Math.max(0, Date.now() - reasoningStartedAtMs);
+      }
+      patchAgentState(tabId, { streamingContent: null });
 
-    // Build the assistant API message
-    const parsedToolCalls: ApiToolCall[] = (
-      Array.isArray(sdkToolCalls) ? sdkToolCalls : []
-    )
-      .map((tc) => toApiToolCall(tc))
-      .filter((tc): tc is ApiToolCall => tc !== null);
-    logStreamDebug(tabId, debugEnabled, "stream:tool-calls:parsed", {
-      count: parsedToolCalls.length,
-      toolCallIds: parsedToolCalls.map((tc) => tc.id),
-      toolNames: parsedToolCalls.map((tc) => tc.function.name),
-    });
-    logStreamDebug(tabId, debugEnabled, "stream:summary", {
-      iteration,
-      turnDurationMs: Math.max(0, Date.now() - turnStartedAtMs),
-      usedFullStream,
-      streamPartCount,
-      streamErrorPartCount,
-      textDeltaCount,
-      textDeltaChars,
-      reasoningStartCount,
-      reasoningEndCount,
-      reasoningDeltaCount,
-      reasoningDeltaChars,
-      assistantTextChars: accText.length,
-      assistantReasoningChars: accReasoning.length,
-      toolCallCount: parsedToolCalls.length,
-      reasoningDurationMs: reasoningDurationMs ?? undefined,
-    });
-
-    const assistantApiMsg: AssistantApiMessage = {
-      role: "assistant",
-      content: accText || null,
-      ...(parsedToolCalls.length > 0 ? { tool_calls: parsedToolCalls } : {}),
-    };
-
-    const pendingToolCallDisplays: ToolCallDisplay[] = parsedToolCalls.map(
-      (tc) => ({
-        id: tc.id,
-        tool: tc.function.name,
-        args: parseArgs(tc.function.arguments),
-        status: "pending" as const,
-      }),
-    );
-
-    // Finalise the streaming chat message. Every assistant turn maps to one
-    // assistant bubble; tool calls for this turn stay attached to this bubble.
-    updateChatMessageById(tabId, assistantChatId, (m) => {
-      return {
-        ...m,
-        content: accText,
-        reasoning: accReasoning || undefined,
-        reasoningStreaming: undefined,
-        reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+      // Build the assistant API message
+      const parsedToolCalls: ApiToolCall[] = (
+        Array.isArray(sdkToolCalls) ? sdkToolCalls : []
+      )
+        .map((tc) => toApiToolCall(tc))
+        .filter((tc): tc is ApiToolCall => tc !== null);
+      logStreamDebug(tabId, debugEnabled, "stream:tool-calls:parsed", {
+        count: parsedToolCalls.length,
+        toolCallIds: parsedToolCalls.map((tc) => tc.id),
+        toolNames: parsedToolCalls.map((tc) => tc.function.name),
+      });
+      logStreamDebug(tabId, debugEnabled, "stream:summary", {
+        iteration,
+        turnDurationMs: Math.max(0, Date.now() - turnStartedAtMs),
+        usedFullStream,
+        streamPartCount,
+        streamErrorPartCount,
+        textDeltaCount,
+        textDeltaChars,
+        reasoningStartCount,
+        reasoningEndCount,
+        reasoningDeltaCount,
+        reasoningDeltaChars,
+        assistantTextChars: accText.length,
+        assistantReasoningChars: accReasoning.length,
+        toolCallCount: parsedToolCalls.length,
         reasoningDurationMs: reasoningDurationMs ?? undefined,
-        streaming: false,
-        badge: parsedToolCalls.length > 0 ? "CALLING TOOLS" : undefined,
-        toolCalls:
-          parsedToolCalls.length > 0 ? pendingToolCallDisplays : undefined,
+      });
+
+      const assistantApiMsg: AssistantApiMessage = {
+        role: "assistant",
+        content: accText || null,
+        ...(parsedToolCalls.length > 0 ? { tool_calls: parsedToolCalls } : {}),
       };
-    });
 
-    // Append assistant message to API history
-    patchAgentState(tabId, (prev) => ({
-      ...prev,
-      apiMessages: [...prev.apiMessages, assistantApiMsg],
-    }));
+      const pendingToolCallDisplays: ToolCallDisplay[] = parsedToolCalls.map((tc) =>
+        buildToolCallDisplay(tc, mcpRuntime.toolsByName),
+      );
 
-    // --- No tool calls → agent is done ---
-    if (parsedToolCalls.length === 0) {
-      patchAgentState(tabId, { status: "idle" });
-      return;
-    }
+      // Finalise the streaming chat message. Every assistant turn maps to one
+      // assistant bubble; tool calls for this turn stay attached to this bubble.
+      updateLastChatMessage(tabId, (m) => {
+        if (m.id !== assistantChatId) return m;
+        return {
+          ...m,
+          content: accText,
+          reasoning: accReasoning || undefined,
+          reasoningStreaming: undefined,
+          reasoningStartedAtMs: reasoningStartedAtMs ?? undefined,
+          reasoningDurationMs: reasoningDurationMs ?? undefined,
+          streaming: false,
+          badge: parsedToolCalls.length > 0 ? "CALLING TOOLS" : undefined,
+          toolCalls:
+            parsedToolCalls.length > 0 ? pendingToolCallDisplays : undefined,
+        };
+      });
 
-    // --- Execute tool calls in parallel ---
-    patchAgentState(tabId, { status: "working" });
+      // Append assistant message to API history
+      patchAgentState(tabId, (prev) => ({
+        ...prev,
+        apiMessages: [...prev.apiMessages, assistantApiMsg],
+      }));
 
-    const turnCardAccumulator = createConversationCardAccumulator(
-      tabId,
-      assistantChatId,
-      parsedToolCalls,
-    );
+      // --- No tool calls → agent is done ---
+      if (parsedToolCalls.length === 0) {
+        patchAgentState(tabId, { status: "idle" });
+        return;
+      }
 
-    const toolResults = await Promise.all(
-      parsedToolCalls.map(async (tc) => {
+      // --- Execute tool calls in parallel ---
+      patchAgentState(tabId, { status: "working" });
+
+      const turnCardAccumulator = createConversationCardAccumulator(
+        tabId,
+        assistantChatId,
+        parsedToolCalls,
+      );
+
+      const toolResults = await Promise.all(
+        parsedToolCalls.map(async (tc) => {
         const tcId = tc.id;
 
         /** Update this specific tool call (by id) regardless of which message hosts it. */
@@ -2909,7 +3349,6 @@ async function agentLoop(
             parentModelId: modelId,
             providers,
             debugEnabled,
-            bubbleGroupId: tcId,
           });
 
           updateToolCallById({
@@ -2976,6 +3415,99 @@ async function agentLoop(
         // ── Pre-validation gate ───────────────────────────────────────────
         const preArgs = parseArgs(tc.function.arguments);
         const preCwd = getAgentState(tabId).config.cwd;
+        const mcpTool = mcpRuntime.toolsByName[tc.function.name];
+        const artifactizeReturnedFiles =
+          jotaiStore.get(mcpSettingsAtom)?.artifactizeReturnedFiles === true;
+
+        if (mcpTool) {
+          updateToolCallById({ status: "awaiting_approval" });
+          const approved = await requestApproval(tabId, tcId);
+          if (!approved) {
+            const reason = consumeApprovalReason(tabId, tcId);
+            updateToolCallById({ status: "denied" });
+            return {
+              tool_call_id: tcId,
+              result: {
+                ok: false as const,
+                error: {
+                  code: "PERMISSION_DENIED" as const,
+                  message: reason ?? "MCP tool call denied by user",
+                },
+              },
+            };
+          }
+
+          updateToolCallById({ status: "running" });
+          try {
+            const rawMcpResult = await callMcpTool(
+              runId,
+              mcpTool.serverId,
+              mcpTool.toolName,
+              preArgs,
+            );
+            const mcpResult = await maybeArtifactizeMcpToolResult(
+              tabId,
+              runId,
+              mcpTool,
+              rawMcpResult,
+              artifactizeReturnedFiles,
+            );
+
+            if (mcpResult.isError) {
+              updateToolCallById({
+                status: "error",
+                result: mcpResult,
+              });
+              return {
+                tool_call_id: tcId,
+                result: {
+                  ok: false as const,
+                  error: {
+                    code: "INTERNAL" as const,
+                    message: extractMcpToolErrorMessage(mcpResult),
+                    details: {
+                      mcp: mcpResult,
+                      serverId: mcpTool.serverId,
+                      serverName: mcpTool.serverName,
+                      toolName: mcpTool.toolName,
+                    },
+                  },
+                },
+              };
+            }
+
+            updateToolCallById({
+              status: "done",
+              result: mcpResult,
+            });
+            return {
+              tool_call_id: tcId,
+              result: { ok: true as const, data: mcpResult },
+            };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            const toolError = {
+              code: "INTERNAL" as const,
+              message,
+              details: {
+                serverId: mcpTool.serverId,
+                serverName: mcpTool.serverName,
+                toolName: mcpTool.toolName,
+              },
+            };
+            updateToolCallById({
+              status: "error",
+              result: toolError,
+            });
+            return {
+              tool_call_id: tcId,
+              result: {
+                ok: false as const,
+                error: toolError,
+              },
+            };
+          }
+        }
 
         const validationResult = await validateTool(
           tabId,
@@ -3090,36 +3622,43 @@ async function agentLoop(
         });
 
         return { tool_call_id: tcId, result };
-      }),
-    );
-    if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
-    if (toolResults.some(({ result }) => isRunAbortedToolResult(result))) {
-      throw new RunAbortedError();
+        }),
+      );
+      if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
+      if (toolResults.some(({ result }) => isRunAbortedToolResult(result))) {
+        throw new RunAbortedError();
+      }
+
+      // Append tool result messages to API history
+      const toolApiMessages: ApiMessage[] = toolResults.map(
+        ({ tool_call_id, result }) => ({
+          role: "tool" as const,
+          tool_call_id,
+          content: serializeToolResultForModel(
+            tool_call_id,
+            parsedToolCalls,
+            result,
+          ),
+        }),
+      );
+
+      patchAgentState(tabId, (prev) => ({
+        ...prev,
+        apiMessages: [...prev.apiMessages, ...toolApiMessages],
+      }));
+
+      // Loop for another LLM turn
     }
 
-    // Append tool result messages to API history
-    const toolApiMessages: ApiMessage[] = toolResults.map(
-      ({ tool_call_id, result }) => ({
-        role: "tool" as const,
-        tool_call_id,
-        content: serializeToolResultForModel(
-          tool_call_id,
-          parsedToolCalls,
-          result,
-        ),
-      }),
-    );
-
-    patchAgentState(tabId, (prev) => ({
-      ...prev,
-      apiMessages: [...prev.apiMessages, ...toolApiMessages],
-    }));
-
-    // Loop for another LLM turn
+    // Safety: hit iteration cap
+    setAgentErrorState(tabId, "Reached maximum iteration limit (50 turns)");
+  } finally {
+    try {
+      await shutdownMcpRun(runId);
+    } catch (error) {
+      console.error("Failed to shut down MCP run", error);
+    }
   }
-
-  // Safety: hit iteration cap
-  setAgentErrorState(tabId, "Reached maximum iteration limit (50 turns)");
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -134,6 +134,12 @@ export interface ToolCallDisplay {
   id: string;
   tool: string;
   args: Record<string, unknown>;
+  mcp?: {
+    serverId: string;
+    serverName: string;
+    toolName: string;
+    toolTitle?: string;
+  };
   result?: unknown;
   /** Live stdout+stderr accumulated while the command is running. */
   streamingOutput?: string;
@@ -216,10 +222,7 @@ export interface ChatMessage {
    * Subagent messages carry the subagent's name (e.g. "Planner").
    */
   agentName?: string;
-  /**
-   * Stable bubble/thread identifier for assistant messages that should stay in
-   * the same UI bubble even when other assistant messages interleave.
-   */
+  /** Stable assistant bubble thread key for interleaved assistant messages. */
   bubbleGroupId?: string;
   /** Optional streamed reasoning content for this assistant turn. */
   reasoning?: string;

--- a/src/components/CompactToolCall.tsx
+++ b/src/components/CompactToolCall.tsx
@@ -14,6 +14,7 @@ import {
 import { getExecCommandBadge } from "@/components/compactToolCallStatus";
 import { deserializeDiff } from "@/components/diffSerialization";
 import type { EditFileChange } from "@/agent/tools/workspace";
+import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
 import { cn } from "@/utils/cn";
 import { Badge, StatusDot } from "@/components/ui";
 
@@ -43,55 +44,6 @@ const NON_EXPANDABLE_TOOLS = new Set([
   "agent_todo_list",
   "agent_todo_remove",
 ]);
-
-/* ── Icon + label maps for all tool rows ─────────────────────────────────────── */
-const TOOL_ICON: Record<string, string> = {
-  workspace_listDir: "folder_open",
-  workspace_stat: "info",
-  workspace_readFile: "description",
-  workspace_glob: "search",
-  workspace_search: "manage_search",
-  workspace_editFile: "edit_document",
-  workspace_writeFile: "note_add",
-  exec_run: "terminal",
-  git_worktree_init: "account_tree",
-  agent_card_add: "dashboard_customize",
-  agent_artifact_create: "inventory_2",
-  agent_artifact_version: "layers",
-  agent_artifact_get: "pageview",
-  agent_artifact_list: "lists",
-  agent_todo_add: "checklist",
-  agent_todo_update: "checklist",
-  agent_todo_list: "checklist",
-  agent_todo_remove: "checklist",
-  agent_title_set: "title",
-  agent_title_get: "title",
-  user_input: "contact_support",
-};
-
-const TOOL_LABEL: Record<string, string> = {
-  workspace_listDir: "List Dir",
-  workspace_stat: "Stat File",
-  workspace_readFile: "Read File",
-  workspace_glob: "Glob",
-  workspace_search: "Search",
-  workspace_editFile: "Edit File",
-  workspace_writeFile: "Write File",
-  exec_run: "Run Command",
-  git_worktree_init: "Git Worktree",
-  agent_card_add: "Add Card",
-  agent_artifact_create: "Create Artifact",
-  agent_artifact_version: "Version Artifact",
-  agent_artifact_get: "Get Artifact",
-  agent_artifact_list: "List Artifacts",
-  agent_todo_add: "Add Todo",
-  agent_todo_update: "Update Todo",
-  agent_todo_list: "List Todos",
-  agent_todo_remove: "Remove Todo",
-  agent_title_set: "Set Title",
-  agent_title_get: "Get Title",
-  user_input: "Question",
-};
 
 const STATUS_DOT: Record<string, string> = {
   pending: "pending",
@@ -1161,8 +1113,8 @@ export default function CompactToolCall({
     tc.status !== "awaiting_worktree" &&
     tc.status !== "awaiting_setup_action";
 
-  const icon = TOOL_ICON[tc.tool] ?? "build";
-  const label = TOOL_LABEL[tc.tool] ?? tc.tool;
+  const icon = getToolCallIcon(tc);
+  const label = getToolCallLabel(tc);
   const dotStatus = STATUS_DOT[tc.status] ?? "pending";
   const statusDotVariant =
     dotStatus === "pending"

--- a/src/components/ToolCallApproval.test.tsx
+++ b/src/components/ToolCallApproval.test.tsx
@@ -127,4 +127,27 @@ describe("ToolCallApproval", () => {
 
     expect(approvalMocks.resolveWorktreeSetupActionMock).not.toHaveBeenCalled();
   });
+
+  it("renders MCP tool calls with a friendly server and tool label", () => {
+    render(
+      <ToolCallApproval
+        toolCall={{
+          id: "tc-mcp",
+          tool: "mcp_filesystem_read_file",
+          args: { path: "README.md" },
+          mcp: {
+            serverId: "filesystem",
+            serverName: "Filesystem",
+            toolName: "read_file",
+            toolTitle: "Read File",
+          },
+          status: "awaiting_approval",
+        }}
+        tabId="tab-1"
+        onOpenProjectSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("MCP / Filesystem / Read File")).not.toBeNull();
+  });
 });

--- a/src/components/ToolCallApproval.tsx
+++ b/src/components/ToolCallApproval.tsx
@@ -16,39 +16,12 @@ import type { EditFileChange } from "@/agent/tools/workspace";
 import type { DiffFile } from "@/components/DiffViewer";
 import { deserializeDiff } from "@/components/diffSerialization";
 import { Badge, Button, TextField } from "@/components/ui";
+import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    ToolCallApproval — rendered when a tool call is in "awaiting_approval" state.
    Generic approval card for tool args and pending actions.
 ───────────────────────────────────────────────────────────────────────────── */
-
-/** Icon shown for each tool category. Falls back to "build". */
-const TOOL_ICON: Record<string, string> = {
-  workspace_listDir: "folder_open",
-  workspace_readFile: "description",
-  workspace_writeFile: "edit_document",
-  workspace_editFile: "difference",
-  workspace_glob: "search",
-  exec_run: "terminal",
-  agent_todo_add: "checklist",
-  agent_todo_update: "checklist",
-  agent_todo_list: "checklist",
-  agent_todo_remove: "checklist",
-};
-
-/** Human-friendly label shown in the card header. */
-const TOOL_LABEL: Record<string, string> = {
-  workspace_listDir: "LIST DIRECTORY",
-  workspace_readFile: "READ FILE",
-  workspace_writeFile: "WRITE FILE",
-  workspace_editFile: "EDIT FILE",
-  workspace_glob: "GLOB FILES",
-  exec_run: "RUN COMMAND",
-  agent_todo_add: "ADD TODO",
-  agent_todo_update: "UPDATE TODO",
-  agent_todo_list: "LIST TODOS",
-  agent_todo_remove: "REMOVE TODO",
-};
 
 /** Render a single arg value — keeps strings unquoted, objects as compact JSON. */
 function renderArgValue(value: unknown): string {
@@ -666,8 +639,8 @@ export default function ToolCallApproval({
     );
   }
 
-  const icon = TOOL_ICON[tool] ?? "build";
-  const label = TOOL_LABEL[tool] ?? tool.toUpperCase();
+  const icon = getToolCallIcon(toolCall);
+  const label = getToolCallLabel(toolCall);
 
   const argEntries = Object.entries(args);
 

--- a/src/components/ToolCallDetailsModal.tsx
+++ b/src/components/ToolCallDetailsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import type { ToolCallDisplay } from "@/agent/types";
+import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
 import { cn } from "@/utils/cn";
 import { Button, ModalShell } from "@/components/ui";
 
@@ -9,46 +10,6 @@ import { Button, ModalShell } from "@/components/ui";
    completed (done / denied / error / running) tool call's parameters and
    result after the fact.
 ───────────────────────────────────────────────────────────────────────────── */
-
-/** Icon shown per tool category. Falls back to "build". */
-const TOOL_ICON: Record<string, string> = {
-  workspace_listDir: "folder_open",
-  workspace_readFile: "description",
-  workspace_writeFile: "edit_document",
-  workspace_editFile: "difference",
-  workspace_glob: "search",
-  workspace_search: "manage_search",
-  exec_run: "terminal",
-  agent_card_add: "dashboard_customize",
-  agent_artifact_create: "inventory_2",
-  agent_artifact_version: "layers",
-  agent_artifact_get: "pageview",
-  agent_artifact_list: "lists",
-  agent_todo_add: "checklist",
-  agent_todo_update: "checklist",
-  agent_todo_list: "checklist",
-  agent_todo_remove: "checklist",
-};
-
-/** Human-friendly label shown in the modal header. */
-const TOOL_LABEL: Record<string, string> = {
-  workspace_listDir: "LIST DIRECTORY",
-  workspace_readFile: "READ FILE",
-  workspace_writeFile: "WRITE FILE",
-  workspace_editFile: "EDIT FILE",
-  workspace_glob: "GLOB FILES",
-  workspace_search: "SEARCH FILES",
-  exec_run: "RUN COMMAND",
-  agent_card_add: "ADD CARD",
-  agent_artifact_create: "CREATE ARTIFACT",
-  agent_artifact_version: "VERSION ARTIFACT",
-  agent_artifact_get: "GET ARTIFACT",
-  agent_artifact_list: "LIST ARTIFACTS",
-  agent_todo_add: "ADD TODO",
-  agent_todo_update: "UPDATE TODO",
-  agent_todo_list: "LIST TODOS",
-  agent_todo_remove: "REMOVE TODO",
-};
 
 /** Status badge Tailwind classes */
 const STATUS_BADGE: Record<string, { className: string; label: string }> = {
@@ -105,8 +66,8 @@ export default function ToolCallDetailsModal({
 }: ToolCallDetailsModalProps) {
   const { tool, args, result, status } = toolCall;
 
-  const icon = TOOL_ICON[tool] ?? "build";
-  const label = TOOL_LABEL[tool] ?? tool.toUpperCase();
+  const icon = getToolCallIcon(toolCall);
+  const label = getToolCallLabel(toolCall);
   const badge = STATUS_BADGE[status];
 
   // Close on Escape

--- a/src/components/artifact-pane/model.ts
+++ b/src/components/artifact-pane/model.ts
@@ -19,6 +19,7 @@ const KNOWN_RENDER_KINDS = new Set<ArtifactRenderKind>([
   "review-report",
   "security-report",
   "copy-review",
+  "mcp-attachment",
   "text",
   "markdown",
   "unified-diff",
@@ -366,6 +367,135 @@ export function parseCopyReviewArtifact(
       parsed: parsed.data,
     };
   }
+}
+
+export interface McpAttachmentPreviewPayload {
+  mimeType?: string;
+  filename?: string;
+  previewUrl: string | null;
+  prettyJson: string;
+}
+
+function isImageMimeType(value: unknown): value is string {
+  return typeof value === "string" && value.toLowerCase().startsWith("image/");
+}
+
+function buildImageDataUrl(
+  mimeType: string | undefined,
+  encoding: "base64" | "text",
+  payload: string,
+): string | null {
+  if (!isImageMimeType(mimeType) || !payload.trim()) return null;
+  if (encoding === "base64") {
+    return `data:${mimeType};base64,${payload}`;
+  }
+  return `data:${mimeType};charset=utf-8,${encodeURIComponent(payload)}`;
+}
+
+export function parseMcpAttachmentArtifact(
+  content: string | undefined,
+): ParsedArtifactResult<McpAttachmentPreviewPayload> {
+  const parsed = parseArtifactJson(content);
+  if (!parsed.ok) return parsed;
+
+  const prettyJson = safePrettyJson(parsed.data);
+  if (!isRecord(parsed.data)) {
+    return {
+      ok: true,
+      data: {
+        prettyJson,
+        previewUrl: null,
+      },
+    };
+  }
+
+  const filename =
+    typeof parsed.data.filename === "string" && parsed.data.filename.trim()
+      ? parsed.data.filename.trim()
+      : typeof parsed.data.name === "string" && parsed.data.name.trim()
+        ? parsed.data.name.trim()
+        : undefined;
+
+  if (typeof parsed.data.data === "string") {
+    return {
+      ok: true,
+      data: {
+        mimeType:
+          typeof parsed.data.mimeType === "string" ? parsed.data.mimeType : undefined,
+        filename,
+        previewUrl: buildImageDataUrl(
+          typeof parsed.data.mimeType === "string" ? parsed.data.mimeType : undefined,
+          "base64",
+          parsed.data.data,
+        ),
+        prettyJson,
+      },
+    };
+  }
+
+  if (!isRecord(parsed.data.resource)) {
+    return {
+      ok: true,
+      data: {
+        previewUrl: null,
+        prettyJson,
+        filename,
+      },
+    };
+  }
+
+  const resourceMimeType =
+    typeof parsed.data.resource.mimeType === "string"
+      ? parsed.data.resource.mimeType
+      : undefined;
+  const resourceFilename =
+    typeof parsed.data.resource.name === "string" && parsed.data.resource.name.trim()
+      ? parsed.data.resource.name.trim()
+      : typeof parsed.data.resource.uri === "string" && parsed.data.resource.uri.trim()
+        ? parsed.data.resource.uri.trim()
+        : filename;
+
+  if (typeof parsed.data.resource.blob === "string") {
+    return {
+      ok: true,
+      data: {
+        mimeType: resourceMimeType,
+        filename: resourceFilename,
+        previewUrl: buildImageDataUrl(
+          resourceMimeType,
+          "base64",
+          parsed.data.resource.blob,
+        ),
+        prettyJson,
+      },
+    };
+  }
+
+  if (typeof parsed.data.resource.text === "string") {
+    return {
+      ok: true,
+      data: {
+        mimeType: resourceMimeType,
+        filename: resourceFilename,
+        previewUrl: buildImageDataUrl(
+          resourceMimeType,
+          "text",
+          parsed.data.resource.text,
+        ),
+        prettyJson,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      mimeType: resourceMimeType,
+      filename: resourceFilename,
+      previewUrl: null,
+      prettyJson,
+    },
+  };
 }
 
 export function summarizeSeverityCounts<

--- a/src/components/artifact-pane/renderers.test.tsx
+++ b/src/components/artifact-pane/renderers.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ArtifactManifest } from "@/agent/tools/artifacts";
+import { ArtifactRenderer } from "./renderers";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeArtifact(
+  overrides: Partial<ArtifactManifest> = {},
+): ArtifactManifest {
+  return {
+    sessionId: "tab-1",
+    runId: "run-1",
+    agentId: "agent_main",
+    artifactSeq: 1,
+    artifactId: "mcp_attachment_1",
+    version: 1,
+    kind: "mcp-attachment",
+    summary: "Playwright screenshot",
+    metadata: {},
+    contentFormat: "json",
+    blobHash: "hash",
+    sizeBytes: 128,
+    createdAt: 1_000,
+    content: JSON.stringify(
+      {
+        type: "image",
+        mimeType: "image/png",
+        data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO0p8xkAAAAASUVORK5CYII=",
+      },
+      null,
+      2,
+    ),
+    ...overrides,
+  };
+}
+
+describe("ArtifactRenderer", () => {
+  it("renders image previews for MCP attachment artifacts that contain image payloads", () => {
+    render(<ArtifactRenderer artifact={makeArtifact()} mode="detail" />);
+
+    const image = screen.getByRole("img", { name: "Playwright screenshot" });
+    expect(image.getAttribute("src")).toMatch(/^data:image\/png;base64,/);
+    expect(screen.getByText("image/png")).not.toBeNull();
+    expect(screen.getByText(/"mimeType": "image\/png"/)).not.toBeNull();
+  });
+});

--- a/src/components/artifact-pane/renderers.tsx
+++ b/src/components/artifact-pane/renderers.tsx
@@ -6,6 +6,7 @@ import {
   getArtifactPlainTextExcerpt,
   parseArtifactJson,
   parseCopyReviewArtifact,
+  parseMcpAttachmentArtifact,
   parseReviewReportArtifact,
   parseSecurityReportArtifact,
   resolveArtifactRenderKind,
@@ -318,6 +319,47 @@ function PlanRenderer({ artifact, mode }: ArtifactRendererProps) {
   );
 }
 
+function McpAttachmentRenderer({ artifact, mode }: ArtifactRendererProps) {
+  const parsed = parseMcpAttachmentArtifact(artifact.content);
+  if (!parsed.ok) {
+    return <ParseErrorState error={parsed.error} content={artifact.content} mode={mode} />;
+  }
+
+  const { previewUrl, mimeType, filename, prettyJson } = parsed.data;
+
+  if (!previewUrl) {
+    if (mode === "compact") {
+      return <CompactFallbackText content={prettyJson} />;
+    }
+    return <ArtifactRawText content={prettyJson} />;
+  }
+
+  return (
+    <div className="artifact-render-stack">
+      <div
+        className={cn(
+          "artifact-media-frame",
+          mode === "compact" && "artifact-media-frame--compact",
+        )}
+      >
+        <img
+          src={previewUrl}
+          alt={artifact.summary || artifact.artifactId}
+          className={cn(
+            "artifact-media-preview",
+            mode === "compact" && "artifact-media-preview--compact",
+          )}
+        />
+      </div>
+      <div className="artifact-chip-row">
+        {mimeType ? <Badge variant="muted">{mimeType}</Badge> : null}
+        {filename ? <Badge variant="muted">{filename}</Badge> : null}
+      </div>
+      {mode === "detail" ? <ArtifactRawText content={prettyJson} /> : null}
+    </div>
+  );
+}
+
 function JsonRenderer({ artifact, mode }: ArtifactRendererProps) {
   const parsed = parseArtifactJson(artifact.content);
   if (!parsed.ok) {
@@ -368,6 +410,8 @@ export function ArtifactRenderer({ artifact, mode }: ArtifactRendererProps) {
       return <SecurityReportRenderer artifact={artifact} mode={mode} />;
     case "copy-review":
       return <CopyReviewRenderer artifact={artifact} mode={mode} />;
+    case "mcp-attachment":
+      return <McpAttachmentRenderer artifact={artifact} mode={mode} />;
     case "markdown":
       return <MarkdownRenderer artifact={artifact} mode={mode} />;
     case "json":

--- a/src/components/artifact-pane/types.ts
+++ b/src/components/artifact-pane/types.ts
@@ -16,7 +16,8 @@ export type KnownArtifactType =
   | "plan"
   | "review-report"
   | "security-report"
-  | "copy-review";
+  | "copy-review"
+  | "mcp-attachment";
 
 export type ArtifactRenderKind = KnownArtifactType | ArtifactContentFormat;
 

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { Provider } from "jotai";
 import { TabsProvider, useTabs } from "@/contexts/TabsContext";
 import {
@@ -11,6 +11,7 @@ import {
   jotaiStore,
 } from "@/agent/atoms";
 import { providersAtom } from "@/agent/db";
+import { mcpServersAtom, mcpSettingsAtom } from "@/agent/mcp";
 import SettingsPage from "./SettingsPage";
 
 const updaterMocks = vi.hoisted(() => ({
@@ -18,6 +19,12 @@ const updaterMocks = vi.hoisted(() => ({
   installAppUpdateMock: vi.fn<
     (options?: { beforeInstall?: () => Promise<void> }) => Promise<void>
   >(),
+}));
+
+const mcpMocks = vi.hoisted(() => ({
+  saveMcpServersMock: vi.fn<(servers: unknown[]) => Promise<void>>(),
+  saveMcpSettingsMock: vi.fn<(settings: unknown) => Promise<void>>(),
+  testMcpServerMock: vi.fn<(server: unknown) => Promise<unknown>>(),
 }));
 
 vi.mock("@/agent/useEnvProviderKeys", () => ({
@@ -76,10 +83,42 @@ vi.mock("@/updater", () => ({
   },
 }));
 
+vi.mock("@/agent/mcp", async () => {
+  const actual = await vi.importActual<typeof import("@/agent/mcp")>(
+    "@/agent/mcp",
+  );
+  return {
+    ...actual,
+    saveMcpServers: (...args: unknown[]) =>
+      mcpMocks.saveMcpServersMock(args[0] as unknown[]),
+    saveMcpSettings: (...args: unknown[]) =>
+      mcpMocks.saveMcpSettingsMock(args[0]),
+    testMcpServer: (...args: unknown[]) => mcpMocks.testMcpServerMock(args[0]),
+  };
+});
+
+vi.mock("@/components/ui/JsonCodeEditor", () => ({
+  default: ({
+    value,
+    onChange,
+    "aria-label": ariaLabel,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    "aria-label"?: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel ?? "JSON code editor"}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
 function SettingsPageHarness({
   initialSection = "appearance",
 }: {
-  initialSection?: "appearance" | "updates";
+  initialSection?: "appearance" | "updates" | "mcp";
 }) {
   const { openSettingsTab } = useTabs();
 
@@ -90,7 +129,9 @@ function SettingsPageHarness({
   return <SettingsPage />;
 }
 
-function renderSettingsPage(initialSection: "appearance" | "updates" = "appearance") {
+function renderSettingsPage(
+  initialSection: "appearance" | "updates" | "mcp" = "appearance",
+) {
   return render(
     <Provider store={jotaiStore}>
       <TabsProvider>
@@ -105,6 +146,8 @@ describe("SettingsPage", () => {
     cleanup();
     localStorage.clear();
     jotaiStore.set(providersAtom, []);
+    jotaiStore.set(mcpServersAtom, []);
+    jotaiStore.set(mcpSettingsAtom, { artifactizeReturnedFiles: false });
     jotaiStore.set(appUpdaterStateAtom, {
       ...defaultAppUpdaterState,
       status: "available",
@@ -117,6 +160,32 @@ describe("SettingsPage", () => {
     updaterMocks.installAppUpdateMock.mockReset();
     updaterMocks.checkForAppUpdatesMock.mockResolvedValue(undefined);
     updaterMocks.installAppUpdateMock.mockResolvedValue(undefined);
+    mcpMocks.saveMcpServersMock.mockReset();
+    mcpMocks.saveMcpSettingsMock.mockReset();
+    mcpMocks.testMcpServerMock.mockReset();
+    mcpMocks.saveMcpServersMock.mockResolvedValue(undefined);
+    mcpMocks.saveMcpSettingsMock.mockResolvedValue(undefined);
+    mcpMocks.testMcpServerMock.mockResolvedValue({
+      serverId: "filesystem",
+      serverName: "Filesystem",
+      tools: [
+        {
+          serverId: "filesystem",
+          serverName: "Filesystem",
+          name: "read_file",
+          title: "Read File",
+          inputSchema: { type: "object" },
+        },
+        {
+          serverId: "filesystem",
+          serverName: "Filesystem",
+          name: "list_directory",
+          title: "List Directory",
+          inputSchema: { type: "object" },
+        },
+      ],
+      toolCount: 2,
+    });
   });
 
   afterEach(() => {
@@ -153,5 +222,116 @@ describe("SettingsPage", () => {
     });
     expect(screen.getByText("Theme & Mode")).not.toBeNull();
     expect(screen.getByText("Theme")).not.toBeNull();
+  });
+
+  it("renders the MCP settings section under AI and saves a tested server", async () => {
+    renderSettingsPage("mcp");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "MCP Servers" })).not.toBeNull();
+    });
+
+    expect(screen.getByText("Global MCP Registry")).not.toBeNull();
+    expect(screen.getByText("AI")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Add Server/i }));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Server JSON" }), {
+      target: {
+        value: JSON.stringify(
+          {
+            name: "Filesystem",
+            enabled: true,
+            transport: "stdio",
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+          },
+          null,
+          2,
+        ),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Test" }));
+
+    await waitFor(() => {
+      expect(mcpMocks.testMcpServerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Filesystem",
+          enabled: true,
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+        }),
+      );
+    });
+    expect(screen.getByText("2 tools discovered")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Save Server/i }));
+
+    await waitFor(() => {
+      expect(mcpMocks.saveMcpServersMock).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "Filesystem",
+          enabled: true,
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+        }),
+      ]);
+    });
+    expect(screen.getByText("Filesystem")).not.toBeNull();
+    expect(screen.getByText("stdio · enabled")).not.toBeNull();
+  });
+
+  it("persists the MCP artifactization toggle", async () => {
+    renderSettingsPage("mcp");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "MCP Servers" })).not.toBeNull();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Save returned files as artifacts/i }),
+    );
+
+    await waitFor(() => {
+      expect(mcpMocks.saveMcpSettingsMock).toHaveBeenCalledWith({
+        artifactizeReturnedFiles: true,
+      });
+    });
+    expect(jotaiStore.get(mcpSettingsAtom)).toEqual({
+      artifactizeReturnedFiles: true,
+    });
+  });
+
+  it("opens the MCP schema help modal from the inline help icon", async () => {
+    renderSettingsPage("mcp");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "MCP Servers" })).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Server/i }));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open MCP JSON schema help" }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "MCP Server JSON Schema",
+    });
+
+    expect(dialog).not.toBeNull();
+    expect(
+      within(dialog).getByText(/Remove comments before pasting/i),
+    ).not.toBeNull();
+    expect(
+      within(dialog).getByText(/Example: stdio/i),
+    ).not.toBeNull();
+    expect(
+      within(dialog).getByText(/Example: streamable-http/i),
+    ).not.toBeNull();
+    expect(dialog.textContent).toContain('"NODE_ENV": "production"');
+    expect(dialog.textContent).toContain('"timeoutMs": 15000');
   });
 });

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -5,7 +5,22 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
+import type { Diagnostic } from "@codemirror/lint";
+import {
+  findNodeAtLocation,
+  parseTree,
+  printParseErrorCode,
+  type Node as JsonNode,
+  type ParseError,
+} from "jsonc-parser";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  a11yDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
 import pkg from "../../../package.json";
 import {
   buildUniqueProviderName,
@@ -18,6 +33,13 @@ import {
   type ProviderInstance,
   type CommunicationProfileRecord,
 } from "@/agent/db";
+import {
+  saveMcpSettings,
+  saveMcpServers,
+  testMcpServer,
+  type McpServerConfig,
+  type McpServerProbeResult,
+} from "@/agent/mcp";
 import { cn } from "@/utils/cn";
 import {
   THEME_NAMES,
@@ -28,12 +50,14 @@ import {
   Badge,
   Button,
   IconButton,
+  ModalShell,
   Panel,
   SelectField,
   TextField,
   TextareaField,
   ToggleSwitch,
 } from "@/components/ui";
+import JsonCodeEditor from "@/components/ui/JsonCodeEditor";
 import {
   getAppUpdaterProgressValue,
   getAppUpdaterStatusLabel,
@@ -54,8 +78,320 @@ import type {
 
 type TestStatus = "idle" | "testing" | "ok" | "error";
 type ProviderRefreshStatus = "idle" | "loading" | "ok" | "error";
+type McpProbeStatus = "idle" | "testing" | "ok" | "error";
 
 const REFRESH_FEEDBACK_MS = 3000;
+
+const MCP_SCHEMA_STDIO_EXAMPLE = `{
+  // Shown in Settings.
+  "name": "Filesystem",
+  // true = discover tools on runs.
+  "enabled": true,
+  // Local command server.
+  "transport": "stdio",
+  // Executable to launch.
+  "command": "npx",
+  // Optional CLI args.
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+  // Optional extra env.
+  "env": {
+    "NODE_ENV": "production"
+  }
+}`;
+
+const MCP_SCHEMA_STREAMABLE_HTTP_EXAMPLE = `{
+  // Shown in Settings.
+  "name": "Remote MCP",
+  // true = discover tools on runs.
+  "enabled": true,
+  // Remote HTTP server.
+  "transport": "streamable-http",
+  // Endpoint URL.
+  "url": "https://example.com/mcp",
+  // Optional request headers.
+  "headers": {
+    "Authorization": "Bearer <token>"
+  },
+  // Optional timeout in ms.
+  "timeoutMs": 15000
+}`;
+
+const mcpStringMapSchema = z.record(z.string(), z.string());
+const mcpStdioServerDraftSchema = z.object({
+  id: z.string().trim().min(1, '"id" must not be empty.').optional(),
+  name: z.string().trim().min(1, '"name" is required.'),
+  enabled: z.boolean().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  transport: z.literal("stdio"),
+  command: z.string().trim().min(1, '"command" is required for stdio servers.'),
+  args: z.array(z.string()).optional(),
+  env: mcpStringMapSchema.optional(),
+});
+const mcpStreamableHttpServerDraftSchema = z.object({
+  id: z.string().trim().min(1, '"id" must not be empty.').optional(),
+  name: z.string().trim().min(1, '"name" is required.'),
+  enabled: z.boolean().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  transport: z.literal("streamable-http"),
+  url: z.string().trim().min(1, '"url" is required for streamable-http servers.'),
+  headers: mcpStringMapSchema.optional(),
+});
+const mcpServerDraftSchema = z.discriminatedUnion("transport", [
+  mcpStdioServerDraftSchema,
+  mcpStreamableHttpServerDraftSchema,
+]);
+
+type McpServerDraftInput = z.output<typeof mcpServerDraftSchema>;
+
+function formatMcpServerJson(server?: McpServerConfig): string {
+  const template =
+    server ??
+    ({
+      name: "Filesystem",
+      enabled: true,
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+    } satisfies Omit<Extract<McpServerConfig, { transport: "stdio" }>, "id">);
+
+  return JSON.stringify(template, null, 2);
+}
+
+function formatMcpServerIssue(issue: z.ZodIssue): string {
+  if (issue.path.length === 0) return issue.message;
+  return `${issue.path.join(".")}: ${issue.message}`;
+}
+
+function findMcpIssueNode(
+  tree: JsonNode,
+  path: readonly PropertyKey[],
+): JsonNode {
+  const jsonPath = path.filter(
+    (segment): segment is string | number =>
+      typeof segment === "string" || typeof segment === "number",
+  );
+
+  const exactNode =
+    jsonPath.length > 0 ? findNodeAtLocation(tree, jsonPath) : tree;
+  if (exactNode) return exactNode;
+
+  const parentNode =
+    jsonPath.length > 0
+      ? findNodeAtLocation(tree, jsonPath.slice(0, -1))
+      : undefined;
+  return parentNode ?? tree;
+}
+
+function buildMcpServerDiagnostics(raw: string): Diagnostic[] {
+  if (!raw.trim()) {
+    return [
+      {
+        from: 0,
+        to: 1,
+        severity: "error",
+        message: "Server JSON is required.",
+      },
+    ];
+  }
+
+  const parseErrors: ParseError[] = [];
+  const tree = parseTree(raw, parseErrors, {
+    allowTrailingComma: false,
+    disallowComments: true,
+  });
+  if (parseErrors.length > 0 || !tree) {
+    return parseErrors.map((error) => ({
+      from: error.offset,
+      to: error.offset + Math.max(error.length, 1),
+      severity: "error",
+      message: `Invalid JSON: ${printParseErrorCode(error.error)}.`,
+    }));
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+  const result = mcpServerDraftSchema.safeParse(parsed);
+  if (result.success) return [];
+
+  return result.error.issues.map((issue) => {
+    const node = findMcpIssueNode(tree, issue.path);
+    return {
+      from: node.offset,
+      to: node.offset + Math.max(node.length, 1),
+      severity: "error",
+      message: formatMcpServerIssue(issue),
+    };
+  });
+}
+
+function parseMcpServerJson(
+  raw: string,
+  fallbackId: string,
+): { ok: true; data: McpServerConfig } | { ok: false; error: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Server JSON is required." };
+  }
+
+  const diagnostics = buildMcpServerDiagnostics(trimmed);
+  if (diagnostics.length > 0) {
+    return { ok: false, error: diagnostics[0]?.message ?? "Server JSON is invalid." };
+  }
+
+  const parsed = mcpServerDraftSchema.parse(
+    JSON.parse(trimmed),
+  ) as McpServerDraftInput;
+  return {
+    ok: true,
+    data: {
+      ...parsed,
+      id: parsed.id?.trim() || fallbackId,
+      enabled: parsed.enabled ?? true,
+    },
+  };
+}
+
+function McpSchemaHelpModal({
+  themeMode,
+  onClose,
+}: {
+  themeMode: "dark" | "light";
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="error-modal-backdrop"
+      onClick={onClose}
+      role="dialog"
+      aria-modal
+      aria-label="MCP Server JSON Schema"
+    >
+      <ModalShell
+        className="settings-schema-modal"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="settings-schema-modal__header">
+          <div className="settings-schema-modal__title-wrap">
+            <div className="settings-schema-modal__icon">
+              <span className="material-symbols-outlined text-primary">
+                help
+              </span>
+            </div>
+            <div className="settings-schema-modal__heading">
+              <p className="settings-schema-modal__eyebrow">MCP Settings</p>
+              <h2 className="settings-schema-modal__title">
+                MCP Server JSON Schema
+              </h2>
+              <p className="settings-schema-modal__subtitle">
+                Paste one JSON object per server. Start with{" "}
+                <code>transport</code>, then fill in the required keys for that
+                transport.
+              </p>
+            </div>
+          </div>
+          <Button
+            className="settings-schema-modal__close"
+            type="button"
+            variant="ghost"
+            size="xxs"
+            onClick={onClose}
+            title="Close (Esc)"
+          >
+            <span className="material-symbols-outlined text-lg">close</span>
+          </Button>
+        </div>
+
+        <div className="settings-schema-modal__content">
+          <Panel variant="inset" className="settings-schema-intro">
+            <p className="settings-schema-intro__text">
+              Examples below use short comments for explanation only. Remove the
+              comments before pasting into the editor.
+            </p>
+            <div className="settings-schema-rules">
+              <span className="settings-schema-rule">One JSON object</span>
+              <span className="settings-schema-rule">Pick one transport</span>
+              <span className="settings-schema-rule">Remove comments before pasting</span>
+            </div>
+          </Panel>
+
+          <div className="settings-schema-examples">
+            <Panel variant="inset" className="settings-schema-example">
+              <div className="settings-schema-example__header">
+                <p className="settings-schema-example__title">Example: stdio</p>
+                <Badge variant="primary">Local command</Badge>
+              </div>
+              <div className="settings-schema-example__code">
+                <SyntaxHighlighter
+                  language="javascript"
+                  style={themeMode === "dark" ? a11yDark : oneLight}
+                  customStyle={{
+                    margin: 0,
+                    padding: 0,
+                    background: "transparent",
+                    fontSize: "var(--text-xxs)",
+                    lineHeight: 1.6,
+                  }}
+                  codeTagProps={{
+                    style: {
+                      fontFamily: "var(--font-mono)",
+                    },
+                  }}
+                  wrapLongLines
+                >
+                  {MCP_SCHEMA_STDIO_EXAMPLE}
+                </SyntaxHighlighter>
+              </div>
+            </Panel>
+            <Panel variant="inset" className="settings-schema-example">
+              <div className="settings-schema-example__header">
+                <p className="settings-schema-example__title">
+                  Example: streamable-http
+                </p>
+                <Badge variant="success">Remote endpoint</Badge>
+              </div>
+              <div className="settings-schema-example__code">
+                <SyntaxHighlighter
+                  language="javascript"
+                  style={themeMode === "dark" ? a11yDark : oneLight}
+                  customStyle={{
+                    margin: 0,
+                    padding: 0,
+                    background: "transparent",
+                    fontSize: "var(--text-xxs)",
+                    lineHeight: 1.6,
+                  }}
+                  codeTagProps={{
+                    style: {
+                      fontFamily: "var(--font-mono)",
+                    },
+                  }}
+                  wrapLongLines
+                >
+                  {MCP_SCHEMA_STREAMABLE_HTTP_EXAMPLE}
+                </SyntaxHighlighter>
+              </div>
+            </Panel>
+          </div>
+        </div>
+
+        <div className="settings-schema-modal__footer">
+          <Button type="button" variant="secondary" size="xs" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </ModalShell>
+    </div>,
+    document.body,
+  );
+}
 
 async function fetchOpenAICompatibleModels(
   baseUrl: string,
@@ -298,6 +634,196 @@ function ProviderConfigurator({
           </Button>
         </div>
       </div>
+    </Panel>
+  );
+}
+
+function McpServerConfigurator({
+  server,
+  themeMode,
+  onSave,
+  onCancel,
+}: {
+  server?: McpServerConfig;
+  themeMode: "dark" | "light";
+  onSave: (server: McpServerConfig) => void | Promise<void>;
+  onCancel: () => void;
+}) {
+  const [serverId] = useState(() => server?.id ?? uuidv4());
+  const [jsonInput, setJsonInput] = useState(() => formatMcpServerJson(server));
+  const [showSchemaHelp, setShowSchemaHelp] = useState(false);
+  const [probeStatus, setProbeStatus] = useState<McpProbeStatus>("idle");
+  const [probeError, setProbeError] = useState<string | null>(null);
+  const [probeResult, setProbeResult] = useState<McpServerProbeResult | null>(
+    null,
+  );
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const liveValidation = parseMcpServerJson(jsonInput, serverId);
+
+  const buildServerDraft = (): McpServerConfig | null => {
+    if (!liveValidation.ok) {
+      setSaveError(liveValidation.error);
+      return null;
+    }
+
+    setSaveError(null);
+    return liveValidation.data;
+  };
+
+  const handleTest = async () => {
+    const nextServer = buildServerDraft();
+    if (!nextServer) return;
+
+    setProbeStatus("testing");
+    setProbeError(null);
+    setProbeResult(null);
+    try {
+      const result = await testMcpServer(nextServer);
+      setProbeResult(result);
+      setProbeStatus("ok");
+    } catch (error) {
+      setProbeStatus("error");
+      setProbeError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleSaveClick = () => {
+    const nextServer = buildServerDraft();
+    if (!nextServer) return;
+    void onSave(nextServer);
+  };
+
+  return (
+    <Panel className="settings-provider-form">
+      <div className="settings-provider-form__grid">
+        <div className="settings-field settings-field--full-span">
+          <label className="settings-field-label">Server JSON</label>
+          <div className="settings-input-wrap settings-json-editor-wrap">
+            <JsonCodeEditor
+              aria-label="Server JSON"
+              value={jsonInput}
+              onChange={(value) => {
+                setJsonInput(value);
+                setSaveError(null);
+              }}
+              themeMode={themeMode}
+              placeholder="Paste one MCP server object as JSON."
+              validate={buildMcpServerDiagnostics}
+              className="settings-json-editor"
+              minHeight="260px"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-row">
+        <div className="settings-row-info">
+          <div className="settings-row-label settings-row-label-with-action">
+            <span>JSON schema</span>
+            <IconButton
+              type="button"
+              className="settings-inline-help-btn"
+              aria-label="Open MCP JSON schema help"
+              title="Open MCP JSON schema help"
+              onClick={() => setShowSchemaHelp(true)}
+            >
+              <span className="material-symbols-outlined text-sm">
+                help_outline
+              </span>
+            </IconButton>
+          </div>
+          <span className="settings-row-desc">
+            Use the same object shape that is persisted to disk. Common fields
+            are `name`, `enabled`, `transport`, and optional `timeoutMs`; `id`
+            is optional when creating a new entry.
+          </span>
+        </div>
+      </div>
+
+      {probeResult ? (
+        <Panel variant="inset" className="settings-callout">
+          <div className="settings-callout__icon">
+            <span className="material-symbols-outlined text-success text-[18px]">
+              check_circle
+            </span>
+          </div>
+          <div className="settings-callout__body">
+            <p className="settings-callout__title">
+              {probeResult.toolCount} tool
+              {probeResult.toolCount === 1 ? "" : "s"} discovered
+            </p>
+            <p className="settings-callout__copy">
+              {probeResult.tools.length > 0
+                ? probeResult.tools
+                    .slice(0, 6)
+                    .map((tool) => tool.title ?? tool.name)
+                    .join(", ")
+                : "The server connected successfully but returned no tools."}
+            </p>
+          </div>
+        </Panel>
+      ) : null}
+
+      <div className="settings-provider-form__footer">
+        <div className="settings-provider-form__status" aria-live="polite">
+          {probeStatus === "ok" && !probeResult ? (
+            <span className="settings-feedback settings-feedback--success">
+              <span className="material-symbols-outlined text-md">
+                check_circle
+              </span>
+              Server connected successfully.
+            </span>
+          ) : null}
+          {probeStatus === "error" && probeError ? (
+            <span className="settings-feedback settings-feedback--error">
+              <span className="material-symbols-outlined text-md">error</span>
+              {probeError}
+            </span>
+          ) : null}
+          {saveError ? (
+            <span className="settings-feedback settings-feedback--error">
+              <span className="material-symbols-outlined text-md">error</span>
+              {saveError}
+            </span>
+          ) : !liveValidation.ok ? (
+            <span className="settings-feedback settings-feedback--error">
+              <span className="material-symbols-outlined text-md">error</span>
+              {liveValidation.error}
+            </span>
+          ) : null}
+        </div>
+
+      <div className="settings-provider-form__actions">
+        <Button type="button" variant="ghost" size="xs" onClick={onCancel}>
+          Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="xs"
+            onClick={() => {
+              void handleTest();
+            }}
+            loading={probeStatus === "testing"}
+          >
+            Test
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            onClick={handleSaveClick}
+          >
+            Save Server
+          </Button>
+        </div>
+      </div>
+
+      {showSchemaHelp ? (
+        <McpSchemaHelpModal
+          themeMode={themeMode}
+          onClose={() => setShowSchemaHelp(false)}
+        />
+      ) : null}
     </Panel>
   );
 }
@@ -958,6 +1484,267 @@ function ProvidersSection({
   );
 }
 
+function McpServersSection({
+  controller,
+}: {
+  controller: SettingsControllerValue;
+}) {
+  const [editingServerId, setEditingServerId] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [probeStatusById, setProbeStatusById] = useState<
+    Record<string, ProviderRefreshStatus>
+  >({});
+  const probeResetTimeoutsRef = useRef<Record<string, number>>({});
+
+  const clearProbeResetTimeout = useCallback((serverId: string) => {
+    const timeoutId = probeResetTimeoutsRef.current[serverId];
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+      delete probeResetTimeoutsRef.current[serverId];
+    }
+  }, []);
+
+  const scheduleProbeStatusReset = useCallback(
+    (serverId: string) => {
+      clearProbeResetTimeout(serverId);
+      probeResetTimeoutsRef.current[serverId] = window.setTimeout(() => {
+        setProbeStatusById((prev) => ({ ...prev, [serverId]: "idle" }));
+        delete probeResetTimeoutsRef.current[serverId];
+      }, REFRESH_FEEDBACK_MS);
+    },
+    [clearProbeResetTimeout],
+  );
+
+  useEffect(() => {
+    return () => {
+      Object.values(probeResetTimeoutsRef.current).forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+      probeResetTimeoutsRef.current = {};
+    };
+  }, []);
+
+  const handleSaveServer = async (server: McpServerConfig) => {
+    const nextServers = [
+      ...controller.mcpServers.filter((entry) => entry.id !== server.id),
+      server,
+    ];
+    await saveMcpServers(nextServers);
+    controller.setMcpServers(nextServers);
+    setIsAdding(false);
+    setEditingServerId(null);
+  };
+
+  const handleDeleteServer = async (serverId: string) => {
+    const nextServers = controller.mcpServers.filter(
+      (server) => server.id !== serverId,
+    );
+    await saveMcpServers(nextServers);
+    controller.setMcpServers(nextServers);
+  };
+
+  const handleToggleEnabled = async (
+    server: McpServerConfig,
+    enabled: boolean,
+  ) => {
+    const nextServers = controller.mcpServers.map((entry) =>
+      entry.id === server.id ? { ...entry, enabled } : entry,
+    );
+    await saveMcpServers(nextServers);
+    controller.setMcpServers(nextServers);
+  };
+
+  const handleProbeServer = async (server: McpServerConfig) => {
+    clearProbeResetTimeout(server.id);
+    setProbeStatusById((prev) => ({ ...prev, [server.id]: "loading" }));
+    try {
+      await testMcpServer(server);
+      setProbeStatusById((prev) => ({ ...prev, [server.id]: "ok" }));
+      scheduleProbeStatusReset(server.id);
+    } catch (error) {
+      console.error(`Failed to probe MCP server "${server.name}"`, error);
+      setProbeStatusById((prev) => ({ ...prev, [server.id]: "error" }));
+      scheduleProbeStatusReset(server.id);
+    }
+  };
+
+  const handleToggleArtifactizeReturnedFiles = async (enabled: boolean) => {
+    const nextSettings = {
+      ...controller.mcpSettings,
+      artifactizeReturnedFiles: enabled,
+    };
+    await saveMcpSettings(nextSettings);
+    controller.setMcpSettings(nextSettings);
+  };
+
+  return (
+    <div className="settings-page__section-stack">
+      <SectionCard
+        title="Global MCP Registry"
+        description="Configure the MCP servers that the main agent can discover for every run."
+        actions={
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => {
+              setIsAdding(true);
+              setEditingServerId(null);
+            }}
+            className="text-nowrap"
+          >
+            Add Server
+          </Button>
+        }
+      >
+        <div className="settings-row">
+          <div className="settings-row-info">
+            <span className="settings-row-label">
+              Save returned files as artifacts
+            </span>
+            <span className="settings-row-desc">
+              When enabled, MCP image or file payloads are stored as artifacts
+              and replaced in model context with artifact references.
+            </span>
+          </div>
+          <ToggleSwitch
+            checked={controller.mcpSettings.artifactizeReturnedFiles}
+            className="settings-switch"
+            title="Save returned files as artifacts"
+            onChange={() => {
+              void handleToggleArtifactizeReturnedFiles(
+                !controller.mcpSettings.artifactizeReturnedFiles,
+              );
+            }}
+          />
+        </div>
+
+        <div className="settings-provider-list">
+          {controller.mcpServers.length === 0 && !isAdding ? (
+            <Panel variant="inset" className="settings-empty-panel">
+              <span className="material-symbols-outlined settings-empty-panel__icon">
+                extension
+              </span>
+              <div className="settings-empty-panel__copy">
+                <span className="settings-empty-panel__title">
+                  No MCP servers configured
+                </span>
+                <span className="settings-empty-panel__description">
+                  Add a global MCP server to discover external tools at run
+                  start.
+                </span>
+              </div>
+            </Panel>
+          ) : null}
+
+          {controller.mcpServers.map((server) => {
+            const probeStatus = probeStatusById[server.id] ?? "idle";
+            const probeIcon =
+              probeStatus === "loading"
+                ? "autorenew"
+                : probeStatus === "ok"
+                  ? "check_circle"
+                  : probeStatus === "error"
+                    ? "error"
+                    : "bolt";
+            const probeTitle =
+              probeStatus === "loading"
+                ? "Testing server…"
+                : probeStatus === "ok"
+                  ? "Server probe passed."
+                  : probeStatus === "error"
+                    ? "Server probe failed."
+                    : "Test server";
+
+            return editingServerId === server.id ? (
+              <McpServerConfigurator
+                key={server.id}
+                server={server}
+                themeMode={controller.themeMode}
+                onSave={handleSaveServer}
+                onCancel={() => setEditingServerId(null)}
+              />
+            ) : (
+              <Panel key={server.id} className="settings-provider-card">
+                <div className="settings-provider-card__copy">
+                  <span className="settings-provider-card__title">
+                    {server.name}
+                  </span>
+                  <span className="settings-provider-card__meta">
+                    {server.transport}
+                    {" · "}
+                    {server.enabled ? "enabled" : "disabled"}
+                  </span>
+                </div>
+                <div className="settings-provider-card__actions">
+                  <ToggleSwitch
+                    checked={server.enabled}
+                    className="settings-switch"
+                    onChange={() =>
+                      void handleToggleEnabled(server, !server.enabled)
+                    }
+                  />
+                  <IconButton
+                    className={cn(
+                      "settings-provider-card__icon-btn",
+                      probeStatus === "ok" &&
+                        "settings-provider-card__icon-btn--success",
+                      probeStatus === "error" &&
+                        "settings-provider-card__icon-btn--danger",
+                    )}
+                    onClick={() => void handleProbeServer(server)}
+                    title={probeTitle}
+                    aria-label={`Test ${server.name}`}
+                    disabled={probeStatus === "loading"}
+                  >
+                    <span
+                      className={cn(
+                        "material-symbols-outlined text-sm",
+                        probeStatus === "loading" && "animate-spin",
+                      )}
+                    >
+                      {probeIcon}
+                    </span>
+                  </IconButton>
+                  <IconButton
+                    className="settings-provider-card__icon-btn"
+                    onClick={() => setEditingServerId(server.id)}
+                    title={`Edit ${server.name}`}
+                    aria-label={`Edit ${server.name}`}
+                  >
+                    <span className="material-symbols-outlined text-sm">
+                      edit
+                    </span>
+                  </IconButton>
+                  <IconButton
+                    className="settings-provider-card__icon-btn settings-provider-card__icon-btn--danger"
+                    onClick={() => {
+                      void handleDeleteServer(server.id);
+                    }}
+                    title={`Delete ${server.name}`}
+                    aria-label={`Delete ${server.name}`}
+                  >
+                    <span className="material-symbols-outlined text-sm">
+                      delete
+                    </span>
+                  </IconButton>
+                </div>
+              </Panel>
+            );
+          })}
+
+          {isAdding ? (
+            <McpServerConfigurator
+              themeMode={controller.themeMode}
+              onSave={handleSaveServer}
+              onCancel={() => setIsAdding(false)}
+            />
+          ) : null}
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
 function UpdatesSection({
   controller,
 }: {
@@ -1089,6 +1876,8 @@ function renderSection(
       return <NotificationsSection controller={controller} />;
     case "providers":
       return <ProvidersSection controller={controller} />;
+    case "mcp":
+      return <McpServersSection controller={controller} />;
     case "voice":
       return <VoiceSection controller={controller} />;
     case "updates":

--- a/src/components/settings/model.ts
+++ b/src/components/settings/model.ts
@@ -5,6 +5,7 @@ export type SettingsSectionId =
   | "appearance"
   | "notifications"
   | "providers"
+  | "mcp"
   | "voice"
   | "updates";
 
@@ -57,6 +58,13 @@ export const SETTINGS_SECTIONS: SettingsSectionDefinition[] = [
     label: "AI Providers",
     description: "API keys, model sources, and imports.",
     icon: "hub",
+  },
+  {
+    id: "mcp",
+    groupId: "ai",
+    label: "MCP Servers",
+    description: "Global MCP server registry and discovery checks.",
+    icon: "extension",
   },
   {
     id: "voice",

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -17,6 +17,12 @@ import {
   type ProviderInstance,
   type CommunicationProfileRecord,
 } from "@/agent/db";
+import {
+  mcpServersAtom,
+  mcpSettingsAtom,
+  type McpServerConfig,
+  type McpSettings,
+} from "@/agent/mcp";
 import { ensureNotificationPermission } from "@/notifications";
 import { upsertWorkspaceSessions } from "@/agent/persistence";
 import {
@@ -52,6 +58,10 @@ async function confirmInstallUpdate(version: string): Promise<boolean> {
 export interface SettingsControllerValue {
   providers: ProviderInstance[];
   setProviders: (providers: ProviderInstance[]) => void;
+  mcpServers: McpServerConfig[];
+  setMcpServers: (servers: McpServerConfig[]) => void;
+  mcpSettings: McpSettings;
+  setMcpSettings: (settings: McpSettings) => void;
   envKeysAvailable: EnvKeyEntry[];
   themeMode: "dark" | "light";
   toggleThemeMode: () => void;
@@ -82,6 +92,8 @@ export interface SettingsControllerValue {
 export function useSettingsController(): SettingsControllerValue {
   const { tabs } = useTabs();
   const [providers, setProviders] = useAtom(providersAtom);
+  const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
+  const [mcpSettings, setMcpSettings] = useAtom(mcpSettingsAtom);
   const [themeMode, setThemeMode] = useAtom(themeModeAtom);
   const [themeName, setThemeName] = useAtom(themeNameAtom);
   const [globalCommunicationProfile, setGlobalCommunicationProfile] = useAtom(
@@ -212,6 +224,10 @@ export function useSettingsController(): SettingsControllerValue {
   return {
     providers,
     setProviders,
+    mcpServers,
+    setMcpServers,
+    mcpSettings,
+    setMcpSettings,
     envKeysAvailable,
     themeMode,
     toggleThemeMode,

--- a/src/components/toolDisplay.ts
+++ b/src/components/toolDisplay.ts
@@ -1,0 +1,57 @@
+import type { ToolCallDisplay } from "@/agent/types";
+
+const TOOL_ICON: Record<string, string> = {
+  workspace_listDir: "folder_open",
+  workspace_stat: "info",
+  workspace_readFile: "description",
+  workspace_writeFile: "edit_document",
+  workspace_editFile: "difference",
+  workspace_glob: "search",
+  workspace_search: "manage_search",
+  exec_run: "terminal",
+  git_worktree_init: "account_tree",
+  user_input: "person",
+  agent_card_add: "dashboard_customize",
+  agent_artifact_create: "inventory_2",
+  agent_artifact_version: "layers",
+  agent_artifact_get: "pageview",
+  agent_artifact_list: "lists",
+  agent_todo_add: "checklist",
+  agent_todo_update: "checklist",
+  agent_todo_list: "checklist",
+  agent_todo_remove: "checklist",
+};
+
+const TOOL_LABEL: Record<string, string> = {
+  workspace_listDir: "LIST DIRECTORY",
+  workspace_stat: "STAT FILE",
+  workspace_readFile: "READ FILE",
+  workspace_writeFile: "WRITE FILE",
+  workspace_editFile: "EDIT FILE",
+  workspace_glob: "GLOB FILES",
+  workspace_search: "SEARCH FILES",
+  exec_run: "RUN COMMAND",
+  git_worktree_init: "CREATE ISOLATED BRANCH",
+  user_input: "ASK USER",
+  agent_card_add: "ADD CARD",
+  agent_artifact_create: "CREATE ARTIFACT",
+  agent_artifact_version: "VERSION ARTIFACT",
+  agent_artifact_get: "GET ARTIFACT",
+  agent_artifact_list: "LIST ARTIFACTS",
+  agent_todo_add: "ADD TODO",
+  agent_todo_update: "UPDATE TODO",
+  agent_todo_list: "LIST TODOS",
+  agent_todo_remove: "REMOVE TODO",
+};
+
+export function getToolCallIcon(tc: Pick<ToolCallDisplay, "tool" | "mcp">): string {
+  if (tc.mcp) return "extension";
+  return TOOL_ICON[tc.tool] ?? "build";
+}
+
+export function getToolCallLabel(tc: Pick<ToolCallDisplay, "tool" | "mcp">): string {
+  if (tc.mcp) {
+    return `MCP / ${tc.mcp.serverName} / ${tc.mcp.toolTitle ?? tc.mcp.toolName}`;
+  }
+  return TOOL_LABEL[tc.tool] ?? tc.tool.toUpperCase();
+}

--- a/src/components/ui/JsonCodeEditor.tsx
+++ b/src/components/ui/JsonCodeEditor.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
+import { json, jsonParseLinter } from "@codemirror/lang-json";
+import { lintGutter, linter, type Diagnostic } from "@codemirror/lint";
+import type { Extension } from "@codemirror/state";
+import { cn } from "@/utils/cn";
+
+interface JsonCodeEditorProps
+  extends Omit<
+    ReactCodeMirrorProps,
+    "extensions" | "value" | "onChange" | "theme"
+  > {
+  value: string;
+  onChange: (value: string) => void;
+  themeMode: "dark" | "light";
+  validate?: (value: string) => Diagnostic[];
+}
+
+export default function JsonCodeEditor({
+  value,
+  onChange,
+  themeMode,
+  validate,
+  className,
+  minHeight = "260px",
+  ...props
+}: JsonCodeEditorProps) {
+  const extensions = useMemo<Extension[]>(() => {
+    const baseExtensions: Extension[] = [
+      json(),
+      lintGutter(),
+      linter(jsonParseLinter()),
+    ];
+
+    if (validate) {
+      baseExtensions.push(linter((view) => validate(view.state.doc.toString())));
+    }
+
+    return baseExtensions;
+  }, [validate]);
+
+  return (
+    <CodeMirror
+      value={value}
+      onChange={onChange}
+      theme={themeMode}
+      extensions={extensions}
+      minHeight={minHeight}
+      basicSetup
+      className={cn("json-code-editor", className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 export { default as Badge } from "./Badge";
 export { default as Button } from "./Button";
 export { default as IconButton } from "./IconButton";
+export { default as JsonCodeEditor } from "./JsonCodeEditor";
 export { default as ModalShell } from "./ModalShell";
 export { default as Panel } from "./Panel";
 export { default as SegmentedControl } from "./SegmentedControl";

--- a/src/styles/components-artifacts.css
+++ b/src/styles/components-artifacts.css
@@ -556,6 +556,39 @@
   gap: 12px;
 }
 
+.artifact-media-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-subtle);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-inset) 92%, transparent),
+      color-mix(in srgb, var(--color-surface) 86%, transparent)
+    );
+  padding: 12px;
+}
+
+.artifact-media-frame--compact {
+  padding: 8px;
+}
+
+.artifact-media-preview {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  max-height: min(56vh, 680px);
+  border-radius: 8px;
+  box-shadow: 0 20px 40px rgb(0 0 0 / 24%);
+}
+
+.artifact-media-preview--compact {
+  max-height: 200px;
+}
+
 .artifact-detail-summary {
   margin: 0;
   color: color-mix(in srgb, var(--color-text) 88%, transparent);

--- a/src/styles/components-settings.css
+++ b/src/styles/components-settings.css
@@ -184,6 +184,10 @@
   gap: 8px;
 }
 
+.settings-field--full-span {
+  grid-column: 1 / -1;
+}
+
 .settings-field-label {
   display: flex;
   align-items: center;
@@ -192,6 +196,12 @@
   font-weight: 600;
   color: var(--color-muted);
   letter-spacing: 0.04em;
+}
+
+.settings-row-label-with-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .settings-input-wrap {
@@ -205,6 +215,222 @@
 }
 .settings-input-wrap:focus-within {
   border-color: var(--color-primary-border);
+}
+
+.settings-json-editor-wrap {
+  align-items: stretch;
+  min-height: 260px;
+}
+
+.settings-json-editor {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-json-editor .cm-editor {
+  height: 100%;
+  background: transparent;
+}
+
+.settings-json-editor .cm-scroller {
+  min-height: 260px;
+  font-family: var(--font-mono);
+}
+
+.settings-json-editor .cm-content,
+.settings-json-editor .cm-gutter {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.settings-json-editor .cm-gutters {
+  border-right: 1px solid var(--color-border-mid);
+  background: color-mix(in srgb, var(--color-inset) 85%, var(--color-panel));
+  color: var(--color-muted);
+}
+
+.settings-json-editor .cm-activeLine,
+.settings-json-editor .cm-activeLineGutter {
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.settings-json-editor .cm-cursor {
+  border-left-color: var(--color-text);
+}
+
+.settings-json-editor .cm-focused {
+  outline: none;
+}
+
+.settings-json-editor .cm-tooltip-lint {
+  z-index: 30;
+}
+
+.settings-inline-help-btn {
+  width: 24px;
+  height: 24px;
+  color: var(--color-muted);
+  border-color: var(--color-border-mid);
+  background: color-mix(in srgb, var(--color-panel) 70%, transparent);
+}
+
+.settings-inline-help-btn:hover:not(:disabled) {
+  color: var(--color-text);
+}
+
+.settings-schema-modal {
+  max-width: 940px;
+  max-height: 84vh;
+}
+
+.settings-schema-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 16px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-elevated);
+}
+
+.settings-schema-modal__title-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.settings-schema-modal__icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 24%, transparent);
+}
+
+.settings-schema-modal__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.settings-schema-modal__eyebrow {
+  margin: 0;
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.settings-schema-modal__title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.settings-schema-modal__subtitle {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-muted);
+}
+
+.settings-schema-modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.settings-schema-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border-subtle);
+  background: var(--color-elevated);
+}
+
+.settings-schema-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+}
+
+.settings-schema-intro__text {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.settings-schema-rules {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-schema-rule {
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-mid);
+  background: color-mix(in srgb, var(--color-panel) 70%, transparent);
+  font-size: var(--text-xxs);
+  color: var(--color-muted);
+}
+
+.settings-schema-examples {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-schema-example {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  width: 100%;
+}
+
+.settings-schema-example__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-schema-example__title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.settings-schema-example__code {
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-subtle);
+  background: color-mix(in srgb, var(--color-inset) 86%, var(--color-panel));
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-xxs);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.settings-schema-example__code pre,
+.settings-schema-example__code code {
+  font-family: var(--font-mono) !important;
 }
 
 .settings-input {


### PR DESCRIPTION
## Summary
- move MCP server management into Settings with JSON editing, testing, and global config persistence
- add backend MCP run management, per-run MCP tool registration, and approval-aware MCP tool display metadata
- optionally artifactize MCP-returned file and image payloads into artifacts, with image previews in the artifact pane and updated repo docs

## Testing
- npm run typecheck
- npm run test -- src/agent/chatBubbleGroups.test.ts src/components/artifact-pane/renderers.test.tsx src/components/settings/SettingsPage.test.tsx src/agent/runner.test.ts
- cd src-tauri && cargo test mcp::tests

Fixes #51