### PR TITLE
feat(ui): change Rakh chat icon to chess_knight

### DIFF
--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -36,7 +36,7 @@ interface AgentMessageProps {
 
 export default function AgentMessage({
   name = "Rakh",
-  icon = "smart_toy",
+  icon = "chess_knight",
   time,
   badge,
   accentColor,


### PR DESCRIPTION
Replace the default `smart_toy` icon with `chess_knight` for the main Rakh agent in chat messages.

## Changes
- Updated default `icon` prop in `AgentMessage` component from `smart_toy` to `chess_knight`

## Notes
- Subagents retain their own custom icons (planner, reviewer, security, etc.)
- No functional changes, purely visual update