### PR TITLE
fix(workspace): show stop button while busy

### DIFF
--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -19,6 +19,7 @@ const workspaceMocks = vi.hoisted(() => ({
   resumeQueueMock: vi.fn(),
   removeQueuedMessageMock: vi.fn<(messageId: string) => void>(),
   clearQueuedMessagesMock: vi.fn(),
+  stopAgentMock: vi.fn<(tabId: string) => void>(),
   stopMock: vi.fn(),
   setConfigMock: vi.fn(),
   setAutoApproveEditsMock: vi.fn(),
@@ -133,6 +134,7 @@ vi.mock("@/projects", () => ({
 
 vi.mock("@/agent/useAgents", () => ({
   useAgent: () => workspaceMocks.agentState,
+  useStopAgent: () => workspaceMocks.stopAgentMock,
 }));
 
 vi.mock("@/agent/useModels", () => ({
@@ -462,6 +464,7 @@ describe("WorkspacePage chat input", () => {
     workspaceMocks.resumeQueueMock.mockReset();
     workspaceMocks.removeQueuedMessageMock.mockReset();
     workspaceMocks.clearQueuedMessagesMock.mockReset();
+    workspaceMocks.stopAgentMock.mockReset();
     workspaceMocks.stopMock.mockReset();
     workspaceMocks.setConfigMock.mockReset();
     workspaceMocks.setAutoApproveEditsMock.mockReset();
@@ -593,6 +596,45 @@ describe("WorkspacePage chat input", () => {
       expect(textbox.textContent).toBe("@README.md ");
     });
     expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a stop button while busy when the composer is empty", () => {
+    workspaceMocks.agentState.status = "thinking";
+
+    render(<WorkspacePage />);
+
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Stop agent" }));
+    });
+
+    expect(workspaceMocks.stopAgentMock).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("keeps the send button available while busy when text is queued", async () => {
+    workspaceMocks.agentState.status = "working";
+
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("follow up");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("follow up");
+    });
+
+    expect(screen.queryByRole("button", { name: "Stop agent" })).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    });
+
+    expect(workspaceMocks.queueMessageMock).toHaveBeenCalledWith("follow up");
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Stop agent" })).not.toBeNull();
   });
 
   it("keeps focus and the caret at the end after voice transcript append and refine edit", async () => {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/components/voice-input/VoiceInputUi";
 import { useVoiceInputController } from "@/components/voice-input/useVoiceInputController";
 import { useTabs } from "@/contexts/TabsContext";
-import { useAgent } from "@/agent/useAgents";
+import { useAgent, useStopAgent } from "@/agent/useAgents";
 import { useModels } from "@/agent/useModels";
 import { patchAgentState, voiceInputEnabledAtom } from "@/agent/atoms";
 import {
@@ -87,6 +87,7 @@ export default function WorkspacePage() {
 
   // Agent state — always called (hooks must not be conditional)
   const agent = useAgent(activeTabId);
+  const stopAgent = useStopAgent();
   const isAgentBusy = agent.status === "thinking" || agent.status === "working";
   const { models } = useModels();
 
@@ -797,6 +798,7 @@ export default function WorkspacePage() {
 
   const hasSendableText = input.trim().length > 0;
   const canSend = hasSendableText || attachedImages.length > 0;
+  const showStopButton = isAgentBusy && !hasSendableText;
   const voiceBusy = voiceInput.busy;
   const showBusyComposerTray = agent.queuedMessages.length > 0;
   const sendTitle = voiceInput.isPreparingModel
@@ -1059,9 +1061,7 @@ export default function WorkspacePage() {
               contextMaxKb={contextWindowKb?.maxKb ?? null}
             />
             <VoiceInputStateProvider value={voiceInput}>
-              <div
-                className={`chat-input-shell${isAgentBusy ? " chat-input-shell--busy" : ""}`}
-              >
+              <div className="chat-input-shell">
                 {isChatDropActive && (
                   <div className="chat-drop-overlay" aria-hidden="true">
                     <span className="material-symbols-outlined">upload_file</span>
@@ -1109,22 +1109,47 @@ export default function WorkspacePage() {
                 />
                 <div className="chat-input-actions">
                   <VoiceInputToggleButton />
-                  {isAgentBusy ? null : (
-                    <button
-                      title={sendTitle}
-                      aria-label="Send"
-                      onClick={() => void handleSubmit()}
-                      disabled={voiceBusy || !canSend}
-                    >
-                      <span className="material-symbols-outlined text-lg">
-                        {voiceInput.isPreparingModel
-                          ? "download"
-                          : voiceInput.isTranscribing
-                            ? "hourglass_top"
-                            : "arrow_upward"}
-                      </span>
-                    </button>
-                  )}
+                  <AnimatePresence initial={false} mode="wait">
+                    {showStopButton ? (
+                      <motion.button
+                        key="stop"
+                        type="button"
+                        className="chat-input-action-btn chat-input-action-btn--stop"
+                        title="Stop current run"
+                        aria-label="Stop agent"
+                        onClick={() => stopAgent(activeTabId)}
+                        initial={{ opacity: 0, scale: 0.92 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.92 }}
+                        transition={{ duration: 0.14, ease: "easeOut" }}
+                      >
+                        <span className="material-symbols-outlined text-lg">
+                          stop_circle
+                        </span>
+                      </motion.button>
+                    ) : (
+                      <motion.button
+                        key="send"
+                        type="button"
+                        title={sendTitle}
+                        aria-label="Send"
+                        onClick={() => void handleSubmit()}
+                        disabled={voiceBusy || !canSend}
+                        initial={{ opacity: 0, scale: 0.92 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.92 }}
+                        transition={{ duration: 0.14, ease: "easeOut" }}
+                      >
+                        <span className="material-symbols-outlined text-lg">
+                          {voiceInput.isPreparingModel
+                            ? "download"
+                            : voiceInput.isTranscribing
+                              ? "hourglass_top"
+                              : "arrow_upward"}
+                        </span>
+                      </motion.button>
+                    )}
+                  </AnimatePresence>
                 </div>
               </div>
             </VoiceInputStateProvider>

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -225,9 +225,6 @@
     border-color var(--t-base),
     background var(--t-base);
 }
-.chat-input-shell--busy {
-  padding-right: 46px;
-}
 .chat-input-shell:focus-within {
   border-color: color-mix(in srgb, var(--color-primary) 35%, transparent);
   background: color-mix(in srgb, var(--color-subtle) 50%, transparent);
@@ -280,6 +277,13 @@
 .chat-input-actions button:hover {
   color: var(--color-primary);
   background: color-mix(in srgb, var(--color-subtle) 60%, transparent);
+}
+.chat-input-action-btn--stop {
+  color: var(--color-error);
+}
+.chat-input-action-btn--stop:hover:not(:disabled) {
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 14%, transparent);
 }
 
 .busy-composer-strip {


### PR DESCRIPTION
## Summary
- show a stop action in the composer when the agent is busy and the input is empty
- keep the send action available while busy when the user has typed a follow-up
- add workspace composer tests for the stop and queueing states

## Testing
- npm run test -- --run src/WorkspacePage.test.tsx
- npm run lint -- src/WorkspacePage.tsx src/WorkspacePage.test.tsx
- npm run typecheck

Fixes #119