### PR TITLE
feat: add chat attention jump controls

### DIFF
--- a/src/components/AutoScrollArea.test.tsx
+++ b/src/components/AutoScrollArea.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AutoScrollArea from "./AutoScrollArea";
+
+function setElementRect(
+  element: Element,
+  rect: {
+    top: number;
+    bottom: number;
+    left?: number;
+    right?: number;
+    width?: number;
+    height?: number;
+  },
+) {
+  const left = rect.left ?? 0;
+  const width = rect.width ?? 320;
+  const height = rect.height ?? rect.bottom - rect.top;
+  const right = rect.right ?? left + width;
+
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      top: rect.top,
+      bottom: rect.bottom,
+      left,
+      right,
+      width,
+      height,
+      x: left,
+      y: rect.top,
+      toJSON: () => null,
+    }),
+  });
+}
+
+function setScrollerMetrics(
+  element: HTMLElement,
+  metrics: { clientHeight: number; scrollHeight: number; scrollTop: number },
+) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop,
+  });
+}
+
+describe("AutoScrollArea", () => {
+  const scrollIntoViewMock = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      ((callback: FrameRequestCallback) =>
+        window.setTimeout(() => callback(0), 0)) as typeof requestAnimationFrame,
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      ((id: number) => window.clearTimeout(id)) as typeof cancelAnimationFrame,
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    scrollIntoViewMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shows action arrows for off-screen targets and scrolls to the nearest one", () => {
+    const topScrollIntoView = vi.fn();
+    const bottomScrollIntoView = vi.fn();
+    const { container } = render(
+      <AutoScrollArea className="chat-messages">
+        <div data-testid="top-target" data-chat-attention-target="approval">
+          Approval above
+        </div>
+        <div data-testid="body">Visible content</div>
+        <div data-testid="bottom-target" data-chat-attention-target="cta">
+          Action below
+        </div>
+      </AutoScrollArea>,
+    );
+
+    const scroller = container.firstElementChild as HTMLDivElement;
+    const topTarget = screen.getByTestId("top-target");
+    const bottomTarget = screen.getByTestId("bottom-target");
+
+    setScrollerMetrics(scroller, {
+      clientHeight: 200,
+      scrollHeight: 900,
+      scrollTop: 300,
+    });
+    setElementRect(scroller, { top: 0, bottom: 200 });
+    setElementRect(topTarget, { top: -96, bottom: -24 });
+    setElementRect(bottomTarget, { top: 252, bottom: 332 });
+    Object.defineProperty(topTarget, "scrollIntoView", {
+      configurable: true,
+      value: topScrollIntoView,
+    });
+    Object.defineProperty(bottomTarget, "scrollIntoView", {
+      configurable: true,
+      value: bottomScrollIntoView,
+    });
+
+    act(() => {
+      fireEvent.scroll(scroller);
+      vi.runAllTimers();
+    });
+
+    const upArrow = screen.getByRole("button", {
+      name: "Jump to the previous approval request",
+    });
+    const downArrow = screen.getByRole("button", {
+      name: "Jump to the next action",
+    });
+
+    expect(upArrow.querySelector(".new-messages-marker__dot")).not.toBeNull();
+    expect(downArrow.querySelector(".new-messages-marker__dot")).not.toBeNull();
+
+    fireEvent.click(upArrow);
+    fireEvent.click(downArrow);
+
+    expect(topScrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    });
+    expect(bottomScrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    });
+  });
+
+  it("keeps the new-content arrow behavior and falls back to scrolling to bottom", () => {
+    const { container, rerender } = render(
+      <AutoScrollArea className="chat-messages">
+        <div>First</div>
+      </AutoScrollArea>,
+    );
+
+    const scroller = container.firstElementChild as HTMLDivElement;
+    setScrollerMetrics(scroller, {
+      clientHeight: 120,
+      scrollHeight: 280,
+      scrollTop: 40,
+    });
+    setElementRect(scroller, { top: 0, bottom: 120 });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    rerender(
+      <AutoScrollArea className="chat-messages">
+        <div>First</div>
+      </AutoScrollArea>,
+    );
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    scrollIntoViewMock.mockClear();
+
+    setScrollerMetrics(scroller, {
+      clientHeight: 120,
+      scrollHeight: 520,
+      scrollTop: 40,
+    });
+
+    rerender(
+      <AutoScrollArea className="chat-messages">
+        <div>First</div>
+        <div>Second</div>
+      </AutoScrollArea>,
+    );
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const downArrow = screen.getByRole("button", {
+      name: "Scroll to the newest messages",
+    });
+
+    expect(
+      downArrow.querySelector(".new-messages-marker__dot"),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Jump to the previous action" }),
+    ).toBeNull();
+
+    fireEvent.click(downArrow);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth" });
+  });
+});

--- a/src/components/AutoScrollArea.tsx
+++ b/src/components/AutoScrollArea.tsx
@@ -6,6 +6,11 @@ import {
   type ReactNode,
   type CSSProperties,
 } from "react";
+import {
+  CHAT_ATTENTION_TARGET_ATTR,
+  parseChatAttentionTargetKind,
+  type ChatAttentionTargetKind,
+} from "./autoScrollAttention";
 
 interface AutoScrollAreaProps {
   children: ReactNode;
@@ -14,6 +19,26 @@ interface AutoScrollAreaProps {
   /** Distance from the bottom (px) within which auto-scroll is applied. @default 50 */
   threshold?: number;
 }
+
+interface OffscreenAttentionTarget {
+  target: HTMLElement | null;
+  kind: ChatAttentionTargetKind | null;
+}
+
+interface OffscreenAttentionState {
+  above: OffscreenAttentionTarget;
+  below: OffscreenAttentionTarget;
+}
+
+const EMPTY_ATTENTION_TARGET: OffscreenAttentionTarget = {
+  target: null,
+  kind: null,
+};
+
+const EMPTY_ATTENTION_STATE: OffscreenAttentionState = {
+  above: EMPTY_ATTENTION_TARGET,
+  below: EMPTY_ATTENTION_TARGET,
+};
 
 /**
  * A scrollable container that:
@@ -35,22 +60,103 @@ export default function AutoScrollArea({
   const endRef = useRef<HTMLDivElement>(null);
   const prevScrollHeight = useRef(0);
   const arrowRafRef = useRef<number | null>(null);
-  const [showArrow, setShowArrow] = useState(false);
+  const attentionRafRef = useRef<number | null>(null);
+  const [showNewContentArrow, setShowNewContentArrow] = useState(false);
+  const [attentionState, setAttentionState] =
+    useState<OffscreenAttentionState>(EMPTY_ATTENTION_STATE);
 
-  const scheduleArrowVisibility = useCallback((visible: boolean) => {
+  const scheduleNewContentArrow = useCallback((visible: boolean) => {
     if (arrowRafRef.current !== null) {
       cancelAnimationFrame(arrowRafRef.current);
     }
     arrowRafRef.current = requestAnimationFrame(() => {
-      setShowArrow((prev) => (prev === visible ? prev : visible));
+      setShowNewContentArrow((prev) => (prev === visible ? prev : visible));
       arrowRafRef.current = null;
     });
   }, []);
 
   const scrollToBottom = useCallback(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
-    setShowArrow(false);
+    setShowNewContentArrow(false);
   }, []);
+
+  const resolveOffscreenAttention = useCallback((): OffscreenAttentionState => {
+    const el = scrollRef.current;
+    if (!el) return EMPTY_ATTENTION_STATE;
+
+    const containerRect = el.getBoundingClientRect();
+    const topBoundary = containerRect.top + 8;
+    const bottomBoundary = containerRect.bottom - 8;
+    const targets = Array.from(
+      el.querySelectorAll<HTMLElement>(`[${CHAT_ATTENTION_TARGET_ATTR}]`),
+    );
+
+    let nearestAbove = EMPTY_ATTENTION_TARGET;
+    let nearestAboveDistance = Number.POSITIVE_INFINITY;
+    let nearestBelow = EMPTY_ATTENTION_TARGET;
+    let nearestBelowDistance = Number.POSITIVE_INFINITY;
+
+    for (const target of targets) {
+      const kind = parseChatAttentionTargetKind(
+        target.getAttribute(CHAT_ATTENTION_TARGET_ATTR) ?? undefined,
+      );
+      if (kind == null) continue;
+
+      const rect = target.getBoundingClientRect();
+      if (rect.bottom < topBoundary) {
+        const distance = topBoundary - rect.bottom;
+        if (distance < nearestAboveDistance) {
+          nearestAboveDistance = distance;
+          nearestAbove = { target, kind };
+        }
+        continue;
+      }
+
+      if (rect.top > bottomBoundary) {
+        const distance = rect.top - bottomBoundary;
+        if (distance < nearestBelowDistance) {
+          nearestBelowDistance = distance;
+          nearestBelow = { target, kind };
+        }
+      }
+    }
+
+    return { above: nearestAbove, below: nearestBelow };
+  }, []);
+
+  const scheduleAttentionUpdate = useCallback(() => {
+    if (attentionRafRef.current !== null) return;
+    attentionRafRef.current = requestAnimationFrame(() => {
+      attentionRafRef.current = null;
+      const nextState = resolveOffscreenAttention();
+      setAttentionState((prev) => {
+        if (
+          prev.above.target === nextState.above.target &&
+          prev.above.kind === nextState.above.kind &&
+          prev.below.target === nextState.below.target &&
+          prev.below.kind === nextState.below.kind
+        ) {
+          return prev;
+        }
+        return nextState;
+      });
+    });
+  }, [resolveOffscreenAttention]);
+
+  const scrollToAttention = useCallback(
+    (direction: "up" | "down") => {
+      const nextTarget =
+        direction === "up" ? attentionState.above.target : attentionState.below.target;
+      if (nextTarget) {
+        nextTarget.scrollIntoView({ behavior: "smooth", block: "center" });
+        return;
+      }
+      if (direction === "down") {
+        scrollToBottom();
+      }
+    },
+    [attentionState.above.target, attentionState.below.target, scrollToBottom],
+  );
 
   // Runs after every render. Detects any scrollHeight growth (new messages,
   // streaming text, tool output, etc.) and either auto-scrolls or shows the
@@ -69,48 +175,110 @@ export default function AutoScrollArea({
         prevScrollHeight.current - el.scrollTop - el.clientHeight < threshold;
       if (wasNearBottom) {
         endRef.current?.scrollIntoView({ behavior: "smooth" });
-        scheduleArrowVisibility(false);
+        scheduleNewContentArrow(false);
       } else {
-        scheduleArrowVisibility(true);
+        scheduleNewContentArrow(true);
       }
     }
     prevScrollHeight.current = sh;
-  }, [children, threshold, scheduleArrowVisibility]);
+    scheduleAttentionUpdate();
+  }, [children, threshold, scheduleAttentionUpdate, scheduleNewContentArrow]);
 
-  // Hide the arrow once the user manually scrolls back to the bottom.
+  // Hide the bottom arrow once the user scrolls back down and refresh the
+  // off-screen attention targets in both directions.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const onScroll = () => {
       const isNearBottom =
         el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
-      if (isNearBottom) setShowArrow(false);
+      if (isNearBottom) setShowNewContentArrow(false);
+      scheduleAttentionUpdate();
     };
     el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [threshold]);
+    window.addEventListener("resize", scheduleAttentionUpdate);
+    scheduleAttentionUpdate();
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", scheduleAttentionUpdate);
+    };
+  }, [threshold, scheduleAttentionUpdate]);
 
   useEffect(
     () => () => {
       if (arrowRafRef.current !== null) {
         cancelAnimationFrame(arrowRafRef.current);
       }
+      if (attentionRafRef.current !== null) {
+        cancelAnimationFrame(attentionRafRef.current);
+      }
     },
     [],
   );
 
+  const showUpArrow = attentionState.above.target != null;
+  const showDownArrow =
+    attentionState.below.target != null || showNewContentArrow;
+  const showUpDot = attentionState.above.target != null;
+  const showDownDot = attentionState.below.target != null;
+
   return (
     <div ref={scrollRef} className={className} style={style}>
+      <div className="new-messages-anchor new-messages-anchor--top">
+        {showUpArrow && (
+          <button
+            type="button"
+            className="new-messages-marker new-messages-marker--top"
+            onClick={() => scrollToAttention("up")}
+            title={
+              attentionState.above.kind === "approval"
+                ? "Jump to the previous approval request"
+                : "Jump to the previous action"
+            }
+            aria-label={
+              attentionState.above.kind === "approval"
+                ? "Jump to the previous approval request"
+                : "Jump to the previous action"
+            }
+          >
+            <span className="material-symbols-outlined text-xl">
+              arrow_upward
+            </span>
+            {showUpDot && <span className="new-messages-marker__dot" aria-hidden="true" />}
+          </button>
+        )}
+      </div>
       {children}
       {/* Zero-height sticky anchor at the bottom of the viewport.
           The button is absolutely positioned relative to it, so it
           overlays the content without adding any scrollable height. */}
-      <div className="new-messages-anchor">
-        {showArrow && (
-          <button className="new-messages-marker" onClick={scrollToBottom}>
+      <div className="new-messages-anchor new-messages-anchor--bottom">
+        {showDownArrow && (
+          <button
+            type="button"
+            className="new-messages-marker new-messages-marker--bottom"
+            onClick={() => scrollToAttention("down")}
+            title={
+              attentionState.below.kind === "approval"
+                ? "Jump to the next approval request"
+                : attentionState.below.kind === "cta"
+                  ? "Jump to the next action"
+                  : "Scroll to the newest messages"
+            }
+            aria-label={
+              attentionState.below.kind === "approval"
+                ? "Jump to the next approval request"
+                : attentionState.below.kind === "cta"
+                  ? "Jump to the next action"
+                  : "Scroll to the newest messages"
+            }
+          >
             <span className="material-symbols-outlined text-xl">
               arrow_downward
             </span>
+            {showDownDot && (
+              <span className="new-messages-marker__dot" aria-hidden="true" />
+            )}
           </button>
         )}
       </div>

--- a/src/components/ConversationCards.test.tsx
+++ b/src/components/ConversationCards.test.tsx
@@ -78,6 +78,12 @@ describe("ConversationCards", () => {
     const artifact = makeArtifact();
     const { onExecutePlan } = renderConversationCards(artifact);
 
+    expect(
+      screen.getByText("Implementation plan").closest(".conversation-card")?.getAttribute(
+        "data-chat-attention-target",
+      ),
+    ).toBe("cta");
+
     fireEvent.click(screen.getByRole("button", { name: "Execute the plan" }));
 
     expect(onExecutePlan).toHaveBeenCalledWith(
@@ -112,5 +118,8 @@ describe("ConversationCards", () => {
     fireEvent.click(button);
 
     expect(onExecutePlan).not.toHaveBeenCalled();
+    expect(
+      button.closest(".conversation-card")?.hasAttribute("data-chat-attention-target"),
+    ).toBe(false);
   });
 });

--- a/src/components/ConversationCards.tsx
+++ b/src/components/ConversationCards.tsx
@@ -10,6 +10,7 @@ import type {
 import ArtifactDetailModal from "@/components/artifact-pane/ArtifactDetailModal";
 import { resolveArtifactRenderKind } from "@/components/artifact-pane/model";
 import { ArtifactRenderer } from "@/components/artifact-pane/renderers";
+import { getChatAttentionTargetProps } from "@/components/autoScrollAttention";
 import { Badge, Button, Panel } from "@/components/ui";
 
 function findArtifactGroup(
@@ -108,6 +109,10 @@ function ArtifactConversationCard({
     group?.kind === "plan";
   const [copyFeedbackToken, setCopyFeedbackToken] = useState(0);
   const copied = copyFeedbackToken > 0;
+  const attentionTargetProps =
+    isPlanArtifact && !executePlanDisabled
+      ? getChatAttentionTargetProps("cta")
+      : undefined;
 
   useEffect(() => {
     if (copyFeedbackToken === 0) return;
@@ -132,7 +137,11 @@ function ArtifactConversationCard({
 
   return (
     <>
-      <Panel variant="inset" className="conversation-card">
+      <Panel
+        variant="inset"
+        className="conversation-card"
+        {...attentionTargetProps}
+      >
         <div className="conversation-card-header">
           <div className="conversation-card-heading">
             <div className="conversation-card-chip-row">

--- a/src/components/ToolCallApproval.test.tsx
+++ b/src/components/ToolCallApproval.test.tsx
@@ -149,5 +149,11 @@ describe("ToolCallApproval", () => {
     );
 
     expect(screen.getByText("MCP / Filesystem / Read File")).not.toBeNull();
+    expect(
+      screen
+        .getByText("MCP / Filesystem / Read File")
+        .closest(".msg-card")
+        ?.getAttribute("data-chat-attention-target"),
+    ).toBe("approval");
   });
 });

--- a/src/components/ToolCallApproval.tsx
+++ b/src/components/ToolCallApproval.tsx
@@ -15,6 +15,10 @@ import {
 import type { EditFileChange } from "@/agent/tools/workspace";
 import type { DiffFile } from "@/components/DiffViewer";
 import { deserializeDiff } from "@/components/diffSerialization";
+import {
+  getChatAttentionTargetProps,
+  getToolCallAttentionTargetKind,
+} from "@/components/autoScrollAttention";
 import { Badge, Button, TextField } from "@/components/ui";
 import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
 
@@ -282,6 +286,9 @@ function WorktreeSetupFailureCard({
 }) {
   const [countdownPaused, setCountdownPaused] = useState(false);
   const [countdownSeconds, setCountdownSeconds] = useState(5);
+  const attentionTargetProps = getChatAttentionTargetProps(
+    getToolCallAttentionTargetKind(toolCall),
+  );
 
   useEffect(() => {
     if (countdownPaused) return;
@@ -301,7 +308,7 @@ function WorktreeSetupFailureCard({
   }, [countdownPaused, id, tabId]);
 
   return (
-    <div className="msg-card animate-fade-up mt-1.5">
+    <div className="msg-card animate-fade-up mt-1.5" {...attentionTargetProps}>
       <div className="msg-card-head">
         <div className="msg-card-label">
           <span className="material-symbols-outlined text-base text-warning">
@@ -446,10 +453,13 @@ function WorktreeToolCard({
   const isAwaitingSetupAction = toolCall.status === "awaiting_setup_action";
   const isSetupRunning = setupPhase === "running_setup";
   const isSetupPhaseVisible = setupCommand.length > 0 || isSetupRunning;
+  const attentionTargetProps = getChatAttentionTargetProps(
+    getToolCallAttentionTargetKind(toolCall),
+  );
 
   if (toolCall.status === "awaiting_worktree") {
     return (
-      <div className="msg-card animate-fade-up mt-1.5">
+      <div className="msg-card animate-fade-up mt-1.5" {...attentionTargetProps}>
         <div className="msg-card-head">
           <div className="msg-card-label">
             <span className="material-symbols-outlined text-base">
@@ -535,7 +545,7 @@ function WorktreeToolCard({
   }
 
   return (
-    <div className="msg-card animate-fade-up mt-1.5">
+    <div className="msg-card animate-fade-up mt-1.5" {...attentionTargetProps}>
       <div className="msg-card-head">
         <div className="msg-card-label">
           <span className="material-symbols-outlined text-base">
@@ -620,6 +630,9 @@ export default function ToolCallApproval({
   const [isStopping, setIsStopping] = useState(false);
   const isExecRunning = tool === "exec_run" && toolCall.status === "running";
   const showAllowSpinner = isApproving;
+  const attentionTargetProps = getChatAttentionTargetProps(
+    getToolCallAttentionTargetKind(toolCall),
+  );
 
   const streamingRef = useRef<HTMLPreElement>(null);
   useEffect(() => {
@@ -645,7 +658,7 @@ export default function ToolCallApproval({
   const argEntries = Object.entries(args);
 
   return (
-    <div className="msg-card animate-fade-up mt-1.5">
+    <div className="msg-card animate-fade-up mt-1.5" {...attentionTargetProps}>
       {/* ── Card header ───────────────────────────────────────────────── */}
       <div className="msg-card-head">
         <div className="msg-card-label">

--- a/src/components/UserInputCard.tsx
+++ b/src/components/UserInputCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { ToolCallDisplay } from "@/agent/types";
 import { resolveUserInput, cancelUserInput } from "@/agent/approvals";
+import { getChatAttentionTargetProps } from "@/components/autoScrollAttention";
 import { Button, TextField } from "@/components/ui";
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -37,7 +38,10 @@ export default function UserInputCard({ toolCall, tabId }: UserInputCardProps) {
   const skip = () => cancelUserInput(tabId, id);
 
   return (
-    <div className="msg-card animate-fade-up mt-1.5">
+    <div
+      className="msg-card animate-fade-up mt-1.5"
+      {...getChatAttentionTargetProps("approval")}
+    >
       {/* ── Header ─────────────────────────────────────────────────────── */}
       <div className="msg-card-head">
         <div className="msg-card-label">

--- a/src/components/autoScrollAttention.ts
+++ b/src/components/autoScrollAttention.ts
@@ -1,0 +1,31 @@
+import type { ToolCallDisplay } from "@/agent/types";
+
+export const CHAT_ATTENTION_TARGET_ATTR = "data-chat-attention-target" as const;
+
+export type ChatAttentionTargetKind = "approval" | "cta";
+
+export function getChatAttentionTargetProps(
+  kind: ChatAttentionTargetKind | null,
+): Record<typeof CHAT_ATTENTION_TARGET_ATTR, ChatAttentionTargetKind> | undefined {
+  if (kind == null) return undefined;
+  return { [CHAT_ATTENTION_TARGET_ATTR]: kind };
+}
+
+export function getToolCallAttentionTargetKind(
+  toolCall: ToolCallDisplay,
+): ChatAttentionTargetKind | null {
+  switch (toolCall.status) {
+    case "awaiting_approval":
+    case "awaiting_worktree":
+    case "awaiting_setup_action":
+      return "approval";
+    default:
+      return null;
+  }
+}
+
+export function parseChatAttentionTargetKind(
+  value: string | undefined,
+): ChatAttentionTargetKind | null {
+  return value === "approval" || value === "cta" ? value : null;
+}

--- a/src/styles/components-modals.css
+++ b/src/styles/components-modals.css
@@ -156,6 +156,7 @@
   flex-direction: column;
 }
 .chat-messages {
+  --auto-scroll-gap: 28px;
   flex: 1;
   overflow-y: auto;
   padding: 24px;
@@ -166,22 +167,28 @@
 
 /* ── New-messages jump button ────────────────────────────────────────────── */
 
-/* Zero-height sticky bar that anchors the button to the bottom of the
-   scroll viewport without occupying any scrollable space. */
+/* Zero-height sticky bar that anchors the buttons to the viewport edges
+   without consuming layout space inside the scroll flow. */
 .new-messages-anchor {
   position: sticky;
-  bottom: 0;
   height: 0;
   overflow: visible;
+  z-index: 10;
+}
+.new-messages-anchor--top {
+  top: 0;
+  margin-bottom: calc(-1 * var(--auto-scroll-gap, 0px));
+}
+.new-messages-anchor--bottom {
+  bottom: 0;
 }
 
 .new-messages-marker {
   position: absolute;
-  bottom: -10px;
   right: -10px;
-  z-index: 10;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   padding: 6px;
   border-radius: 9999px;
   border: 1px solid var(--color-primary-border);
@@ -191,15 +198,38 @@
     var(--color-surface)
   );
   color: var(--color-primary);
-  cursor: default;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--color-shadow) 18%, transparent);
+  cursor: pointer;
   animation: fadeUp 0.18s ease both;
   transition:
     background var(--t-fast),
-    border-color var(--t-fast);
+    border-color var(--t-fast),
+    transform var(--t-fast);
+}
+.new-messages-marker--top {
+  top: 8px;
+}
+.new-messages-marker--bottom {
+  bottom: -10px;
 }
 .new-messages-marker:hover {
   background: color-mix(in srgb, var(--color-primary) 22%, transparent);
   border-color: color-mix(in srgb, var(--color-primary) 50%, transparent);
+  transform: translateY(-1px);
+}
+.new-messages-marker:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 40%, transparent);
+  outline-offset: 2px;
+}
+.new-messages-marker__dot {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-error);
+  box-shadow: 0 0 0 2px var(--color-surface);
 }
 
 /* ═════════════════════════════════════════════════════════════════════════════

--- a/src/styles/layout-workspace.css
+++ b/src/styles/layout-workspace.css
@@ -162,6 +162,7 @@
   flex-direction: column;
 }
 .chat-messages {
+  --auto-scroll-gap: 28px;
   flex: 1;
   overflow-y: auto;
   padding: 24px;
@@ -172,22 +173,28 @@
 
 /* ── New-messages jump button ────────────────────────────────────────────── */
 
-/* Zero-height sticky bar that anchors the button to the bottom of the
-   scroll viewport without occupying any scrollable space. */
+/* Zero-height sticky bar that anchors the buttons to the viewport edges
+   without consuming layout space inside the scroll flow. */
 .new-messages-anchor {
   position: sticky;
-  bottom: 0;
   height: 0;
   overflow: visible;
+  z-index: 10;
+}
+.new-messages-anchor--top {
+  top: 0;
+  margin-bottom: calc(-1 * var(--auto-scroll-gap, 0px));
+}
+.new-messages-anchor--bottom {
+  bottom: 0;
 }
 
 .new-messages-marker {
   position: absolute;
-  bottom: -10px;
   right: -10px;
-  z-index: 10;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   padding: 6px;
   border-radius: 9999px;
   border: 1px solid var(--color-primary-border);
@@ -197,15 +204,38 @@
     var(--color-surface)
   );
   color: var(--color-primary);
-  cursor: default;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--color-shadow) 18%, transparent);
+  cursor: pointer;
   animation: fadeUp 0.18s ease both;
   transition:
     background var(--t-fast),
-    border-color var(--t-fast);
+    border-color var(--t-fast),
+    transform var(--t-fast);
+}
+.new-messages-marker--top {
+  top: 8px;
+}
+.new-messages-marker--bottom {
+  bottom: -10px;
 }
 .new-messages-marker:hover {
   background: color-mix(in srgb, var(--color-primary) 22%, transparent);
   border-color: color-mix(in srgb, var(--color-primary) 50%, transparent);
+  transform: translateY(-1px);
+}
+.new-messages-marker:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 40%, transparent);
+  outline-offset: 2px;
+}
+.new-messages-marker__dot {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-error);
+  box-shadow: 0 0 0 2px var(--color-surface);
 }
 
 /* ── Chat input ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- add up/down jump controls for off-screen approvals and execute-plan CTAs in the chat pane
- preserve the existing new-content jump-to-bottom behavior and add red dots when attention is off-screen
- cover the new scroll behavior with focused component tests

## Testing
- npm run test -- --run src/components/AutoScrollArea.test.tsx src/components/ConversationCards.test.tsx src/components/ToolCallApproval.test.tsx
- npm run typecheck

## Issue
- Partial for #107
