### PR TITLE
feat: group inline tool calls

### DIFF
--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -74,6 +74,7 @@ const workspaceMocks = vi.hoisted(() => ({
         },
     clearQueuedMessages: null as null | (() => void),
     errorDetails: null as unknown,
+    groupInlineToolCalls: true,
     queueMessage: null as null | ((message: string) => void),
     queueState: "idle" as "idle" | "draining" | "paused",
     queuedMessages: [] as Array<{ id: string; content: string; createdAtMs: number }>,
@@ -508,11 +509,14 @@ function emitTranscript(text: string) {
 }
 
 function applyLastPatch<T extends object>(state: T): T {
-  const updater = workspaceMocks.patchAgentStateMock.mock.calls.at(-1)?.[1];
-  if (typeof updater !== "function") {
-    throw new Error("Expected patchAgentState to be called with an updater");
+  const patch = workspaceMocks.patchAgentStateMock.mock.calls.at(-1)?.[1];
+  if (typeof patch === "function") {
+    return patch(state);
   }
-  return updater(state);
+  if (patch && typeof patch === "object") {
+    return { ...state, ...patch };
+  }
+  throw new Error("Expected patchAgentState to be called with a patch");
 }
 
 function makeExecRunResult(
@@ -541,6 +545,7 @@ function makeExecRunResult(
 type PatchedChatState = {
   chatMessages: Array<{ role?: string; content?: string }>;
   showDebug: boolean;
+  groupInlineToolCallsOverride?: boolean | null;
   status: string;
   error: unknown;
   errorAction?: unknown;
@@ -646,6 +651,7 @@ describe("WorkspacePage chat input", () => {
       error: null,
       errorAction: null,
       errorDetails: null,
+      groupInlineToolCalls: true,
       queueMessage: workspaceMocks.queueMessageMock,
       queueState: "idle",
       queuedMessages: [],
@@ -817,6 +823,7 @@ describe("WorkspacePage chat input", () => {
     expect(nextState.chatMessages[0]?.role).toBe("assistant");
     expect(nextState.chatMessages[0]?.content).toContain("**Available slash commands:**");
     expect(nextState.chatMessages[0]?.content).toContain("`/plan <task>`");
+    expect(nextState.chatMessages[0]?.content).toContain("`/toggle-group-tools`");
   });
 
   it("treats /? as an alias for /help", async () => {
@@ -911,6 +918,33 @@ describe("WorkspacePage chat input", () => {
       showDebug: false,
     });
     expect(nextState.showDebug).toBe(true);
+  });
+
+  it("toggles grouped inline tool calls for the current session", async () => {
+    render(<WorkspacePage />);
+
+    const textbox = screen.getByRole("textbox");
+    setTextboxRect(textbox);
+
+    emitTranscript("/toggle-group-tools");
+
+    await waitFor(() => {
+      expect(textbox.textContent).toBe("/toggle-group-tools");
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
+    const nextState = applyLastPatch<PatchedChatState>({
+      chatMessages: [],
+      showDebug: false,
+      groupInlineToolCallsOverride: null,
+      status: "idle",
+      error: null,
+      errorDetails: null,
+    });
+    expect(nextState.groupInlineToolCallsOverride).toBe(false);
+    expect(nextState.chatMessages).toHaveLength(0);
   });
 
   it("renders quick actions for the current cwd and invokes native launch commands", async () => {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -33,6 +33,7 @@ import ProjectSettingsModal, {
 import ToolCallDetailsModal from "@/components/ToolCallDetailsModal";
 import ModelPickerModal from "@/components/ModelPickerModal";
 import CompactToolCall from "@/components/CompactToolCall";
+import GroupedInlineToolCall from "@/components/GroupedInlineToolCall";
 import ReasoningThought from "@/components/ReasoningThought";
 import ProjectCommandBar from "@/components/ProjectCommandBar";
 import {
@@ -59,6 +60,11 @@ import {
 import { getAllSubagents, getSubagentThemeColorToken } from "@/agent/subagents";
 import { groupChatMessagesForBubbles } from "@/agent/chatBubbleGroups";
 import { useArtifactContentCache } from "@/components/artifact-pane/useSessionArtifacts";
+import {
+  buildToolCallRenderItems,
+  type ToolCallRenderKind,
+  type ToolCallRenderItem,
+} from "@/components/toolCallRenderItems";
 import { AnimatePresence, motion } from "framer-motion";
 import type { ToolCallDisplay } from "@/agent/types";
 import {
@@ -248,6 +254,28 @@ async function readWorktreeHandoffState(
     hasChanges,
     error,
   };
+}
+
+function renderCompactToolCall(
+  item: {
+    kind: "tool";
+    toolCall: ToolCallDisplay;
+    renderKind: ToolCallRenderKind;
+  },
+  cwd: string | undefined,
+  showDebug: boolean,
+  setToolDetailsModal: (toolCall: ToolCallDisplay) => void,
+) {
+  const toolCall = item.toolCall;
+  return (
+    <CompactToolCall
+      key={toolCall.id}
+      tc={toolCall}
+      onInspect={() => setToolDetailsModal(toolCall)}
+      cwd={cwd}
+      showDebug={showDebug}
+    />
+  );
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -961,6 +989,15 @@ export default function WorkspacePage() {
       return;
     }
 
+    if (text === "/toggle-group-tools") {
+      const nextValue = !agent.groupInlineToolCalls;
+      patchAgentState(activeTabId, {
+        groupInlineToolCallsOverride: nextValue,
+      });
+      setInput("");
+      return;
+    }
+
     if (text === "/model") {
       setModelPickerOpen(true);
       setInput("");
@@ -1249,6 +1286,10 @@ export default function WorkspacePage() {
                 >
                   {groupMessages.map((msg) => {
                       const visibleToolCalls = msg.toolCalls ?? [];
+                      const toolCallRenderItems = buildToolCallRenderItems(
+                        visibleToolCalls,
+                        agent.groupInlineToolCalls,
+                      );
                       const showReasoning =
                         !!msg.reasoning || !!msg.reasoningStreaming;
                       const reasoningExpanded =
@@ -1289,33 +1330,38 @@ export default function WorkspacePage() {
                           {/* Tool calls */}
                           {visibleToolCalls.length > 0 && (
                             <div className="mt-2 flex flex-col gap-1">
-                              {visibleToolCalls.map((tc) =>
-                                tc.tool === "user_input" &&
-                                tc.status === "awaiting_approval" ? (
-                                  <UserInputCard key={tc.id} toolCall={tc} tabId={activeTabId} />
-                                ) : tc.status === "awaiting_approval" ||
-                                  tc.status === "awaiting_worktree" ||
-                                  tc.status === "awaiting_branch_release" ||
-                                  tc.status === "awaiting_setup_action" ||
-                                  (tc.tool === "git_worktree_init" &&
-                                    tc.status === "running") ||
-                                  (tc.tool === "exec_run" &&
-                                    tc.status === "running") ? (
+                              {toolCallRenderItems.map((item, index) =>
+                                item.kind === "group" ? (
+                                  <GroupedInlineToolCall
+                                    key={`group:${item.toolCalls[0]?.id ?? index}`}
+                                    toolCalls={item.toolCalls}
+                                    onInspect={(toolCall) =>
+                                      setToolDetailsModal(toolCall)
+                                    }
+                                    cwd={agent.config.cwd}
+                                    showDebug={agent.showDebug ?? false}
+                                  />
+                                ) : item.renderKind === "user_input" ? (
+                                  <UserInputCard
+                                    key={item.toolCall.id}
+                                    toolCall={item.toolCall}
+                                    tabId={activeTabId}
+                                  />
+                                ) : item.renderKind === "approval" ? (
                                   <ToolCallApproval
-                                    key={tc.id}
-                                    toolCall={tc}
+                                    key={item.toolCall.id}
+                                    toolCall={item.toolCall}
                                     cwd={agent.config.cwd}
                                     tabId={activeTabId}
                                     onOpenProjectSettings={openCurrentProjectSettings}
                                   />
                                 ) : (
-                                  <CompactToolCall
-                                    key={tc.id}
-                                    tc={tc}
-                                    onInspect={() => setToolDetailsModal(tc)}
-                                    cwd={agent.config.cwd}
-                                    showDebug={agent.showDebug ?? false}
-                                  />
+                                  renderCompactToolCall(
+                                    item,
+                                    agent.config.cwd,
+                                    agent.showDebug ?? false,
+                                    setToolDetailsModal,
+                                  )
                                 ),
                               )}
                             </div>

--- a/src/agent/atoms.ts
+++ b/src/agent/atoms.ts
@@ -59,6 +59,12 @@ export const notifyOnAttentionAtom = atomWithStorage<boolean>(
   false,
 );
 
+/** Whether inline tool calls are grouped by default across sessions */
+export const groupInlineToolCallsAtom = atomWithStorage<boolean>(
+  "rakh.group-inline-tool-calls",
+  true,
+);
+
 /** Whether voice input is enabled in the chat composer */
 export const voiceInputEnabledAtom = atomWithStorage<boolean>(
   "rakh.voice-input-enabled",
@@ -142,6 +148,7 @@ function makeDefaultAgentState(): AgentState {
     reviewEdits: [],
     autoApproveEdits: false,
     autoApproveCommands: "no",
+    groupInlineToolCallsOverride: null,
     queuedMessages: [],
     queueState: "idle",
     showDebug: import.meta.env.DEV,
@@ -224,6 +231,20 @@ export const agentAutoApproveEditsAtomFamily = atomFamily((tabId: string) =>
 /** Auto-approve commands for a tab */
 export const agentAutoApproveCommandsAtomFamily = atomFamily((tabId: string) =>
   atom((get) => get(agentAtomFamily(tabId)).autoApproveCommands),
+);
+
+/** Per-tab override for grouped inline tools */
+export const agentGroupInlineToolCallsOverrideAtomFamily = atomFamily(
+  (tabId: string) =>
+    atom((get) => get(agentAtomFamily(tabId)).groupInlineToolCallsOverride),
+);
+
+/** Effective grouped inline tools setting for a tab */
+export const agentGroupInlineToolCallsAtomFamily = atomFamily((tabId: string) =>
+  atom((get) => {
+    const override = get(agentAtomFamily(tabId)).groupInlineToolCallsOverride;
+    return override ?? get(groupInlineToolCallsAtom);
+  }),
 );
 
 /** Queued user follow-ups for a tab */

--- a/src/agent/slashCommands.test.ts
+++ b/src/agent/slashCommands.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./subagents", () => ({
+  getAllSubagents: () => [
+    {
+      id: "planner",
+      name: "Planner",
+      description: "Writes execution plans.",
+      triggerCommand: "/plan",
+      triggerCommandDisplay: "/plan <task>",
+      triggerCommandTakesArguments: true,
+    },
+  ],
+}));
+
+import {
+  filterSlashCommands,
+  formatSlashCommandHelpMarkdown,
+  getSlashCommandCatalog,
+} from "./slashCommands";
+
+describe("slashCommands", () => {
+  it("includes the grouped tool toggle command in the catalog", () => {
+    const commands = getSlashCommandCatalog();
+
+    expect(
+      commands.some((command) => command.command === "/toggle-group-tools"),
+    ).toBe(true);
+  });
+
+  it("includes the grouped tool toggle command in help output", () => {
+    const helpMarkdown = formatSlashCommandHelpMarkdown(getSlashCommandCatalog());
+
+    expect(helpMarkdown).toContain("`/toggle-group-tools`");
+  });
+
+  it("surfaces the grouped tool toggle in slash autocomplete", () => {
+    const commands = getSlashCommandCatalog();
+
+    expect(filterSlashCommands(commands, "/toggle", 10)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "/toggle-group-tools" }),
+      ]),
+    );
+  });
+});

--- a/src/agent/slashCommands.ts
+++ b/src/agent/slashCommands.ts
@@ -24,6 +24,12 @@ const STATIC_SLASH_COMMANDS: SlashCommandDefinition[] = [
     takesArguments: false,
   },
   {
+    command: "/toggle-group-tools",
+    description: "Toggle grouped inline tool calls for the current session.",
+    insertText: "/toggle-group-tools ",
+    takesArguments: false,
+  },
+  {
     command: "/help",
     aliases: ["/?"],
     description: "Show this list.",
@@ -90,6 +96,7 @@ export function getSlashCommandCatalog(): SlashCommandDefinition[] {
   );
   pushUnique(staticByCommand.get("/model"));
   pushUnique(staticByCommand.get("/debug"));
+  pushUnique(staticByCommand.get("/toggle-group-tools"));
   pushUnique(staticByCommand.get("/help"));
 
   for (const definition of subagentCommands) {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -341,6 +341,8 @@ export interface AgentState {
   autoApproveEdits: boolean;
   /** Auto-approve commands for this tab */
   autoApproveCommands: AutoApproveCommandsMode;
+  /** Null follows the global grouped inline tools preference. */
+  groupInlineToolCallsOverride: boolean | null;
   /** Follow-up user notes queued while the agent is busy. */
   queuedMessages: QueuedUserMessage[];
   /** Whether queued follow-ups will auto-drain, stay paused, or are empty. */

--- a/src/agent/useAgents.ts
+++ b/src/agent/useAgents.ts
@@ -27,6 +27,7 @@ import {
   agentReviewEditsAtomFamily,
   agentAutoApproveEditsAtomFamily,
   agentAutoApproveCommandsAtomFamily,
+  agentGroupInlineToolCallsAtomFamily,
   agentQueuedMessagesAtomFamily,
   agentQueueStateAtomFamily,
   agentShowDebugAtomFamily,
@@ -153,6 +154,10 @@ export function useAgentAutoApproveCommands(tabId: string) {
   return useAtomValue(agentAutoApproveCommandsAtomFamily(tabId));
 }
 
+export function useAgentGroupInlineToolCalls(tabId: string) {
+  return useAtomValue(agentGroupInlineToolCallsAtomFamily(tabId));
+}
+
 export function useAgentQueuedMessages(tabId: string) {
   return useAtomValue(agentQueuedMessagesAtomFamily(tabId));
 }
@@ -259,6 +264,7 @@ export function useResetAgent() {
       reviewEdits: [],
       autoApproveEdits: false,
       autoApproveCommands: "no",
+      groupInlineToolCallsOverride: null,
       queuedMessages: [],
       queueState: "idle",
       showDebug: false,
@@ -315,6 +321,7 @@ export function useAgent(tabId: string) {
   const tabTitle = useAgentTabTitle(tabId);
   const autoApproveEdits = useAgentAutoApproveEdits(tabId);
   const autoApproveCommands = useAgentAutoApproveCommands(tabId);
+  const groupInlineToolCalls = useAgentGroupInlineToolCalls(tabId);
   const queuedMessages = useAgentQueuedMessages(tabId);
   const queueState = useAgentQueueState(tabId);
   const showDebug = useAgentShowDebug(tabId);
@@ -346,6 +353,7 @@ export function useAgent(tabId: string) {
     contextWindowKb,
     autoApproveEdits,
     autoApproveCommands,
+    groupInlineToolCalls,
     queuedMessages,
     queueState,
     showDebug,

--- a/src/components/CompactToolCall.tsx
+++ b/src/components/CompactToolCall.tsx
@@ -11,12 +11,11 @@ import {
   buildEditFileDiffFiles,
   buildWriteFileDiffFiles,
 } from "@/components/patchDiffFiles";
-import { getExecCommandBadge } from "@/components/compactToolCallStatus";
+import { CompactToolCallSummaryRow } from "@/components/compactToolCallSummary";
 import { deserializeDiff } from "@/components/diffSerialization";
 import type { EditFileChange } from "@/agent/tools/workspace";
-import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
 import { cn } from "@/utils/cn";
-import { Badge, StatusDot } from "@/components/ui";
+import { Badge } from "@/components/ui";
 
 /* ── Tools with dedicated inline previews ─────────────────────────────────── */
 const CUSTOM_EXPANDED_TOOLS = new Set([
@@ -45,29 +44,6 @@ const NON_EXPANDABLE_TOOLS = new Set([
   "agent_todo_remove",
 ]);
 
-const STATUS_DOT: Record<string, string> = {
-  pending: "pending",
-  running: "running",
-  done: "done",
-  error: "error",
-  denied: "error",
-  awaiting_branch_release: "error",
-  awaiting_setup_action: "error",
-};
-
-function truncateText(value: string, max = 56): string {
-  if (value.length <= max) return value;
-  return `${value.slice(0, Math.max(1, max - 1))}…`;
-}
-
-function stringifyScalar(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return "";
-}
-
 function normalizePath(path: unknown): string {
   if (typeof path !== "string" || path.trim().length === 0) return ".";
   return path;
@@ -75,193 +51,13 @@ function normalizePath(path: unknown): string {
 
 function describeLineRange(range: unknown): string | null {
   if (!range || typeof range !== "object") return null;
-  const r = range as Record<string, unknown>;
-  const start = typeof r.startLine === "number" ? r.startLine : null;
-  const end = typeof r.endLine === "number" ? r.endLine : null;
+  const record = range as Record<string, unknown>;
+  const start = typeof record.startLine === "number" ? record.startLine : null;
+  const end = typeof record.endLine === "number" ? record.endLine : null;
   if (start !== null && end !== null) return `L${start}-${end}`;
   if (start !== null) return `from L${start}`;
   if (end !== null) return `to L${end}`;
   return null;
-}
-
-function fallbackArgPreview(args: Record<string, unknown>): string | null {
-  const keys = Object.keys(args);
-  if (keys.length === 0) return null;
-
-  const firstKey = keys[0];
-  const firstValue = args[firstKey];
-
-  if (typeof firstValue === "string") {
-    return `${firstKey}: ${truncateText(firstValue)}`;
-  }
-  if (typeof firstValue === "number" || typeof firstValue === "boolean") {
-    return `${firstKey}: ${String(firstValue)}`;
-  }
-  if (Array.isArray(firstValue)) {
-    return `${firstKey}: ${firstValue.length} item${firstValue.length === 1 ? "" : "s"}`;
-  }
-  if (firstValue && typeof firstValue === "object") {
-    return `${firstKey}: {…}`;
-  }
-  return firstKey;
-}
-
-function buildCollapsedArgPreview(tc: ToolCallDisplay): string | null {
-  const { tool, args } = tc;
-  switch (tool) {
-    case "workspace_listDir": {
-      return `dir: ${normalizePath(args.path)}`;
-    }
-    case "workspace_stat": {
-      return `path: ${normalizePath(args.path)}`;
-    }
-    case "workspace_readFile": {
-      const path = normalizePath(args.path);
-      const range = describeLineRange(args.range);
-      return range ? `${path} (${range})` : path;
-    }
-    case "workspace_writeFile": {
-      const path = normalizePath(args.path);
-      const content = typeof args.content === "string" ? args.content : "";
-      return `${path} (${content.length} chars)`;
-    }
-    case "workspace_editFile": {
-      const path = normalizePath(args.path);
-      const count = Array.isArray(args.changes) ? args.changes.length : 0;
-      return `${path} (${count} change${count === 1 ? "" : "s"})`;
-    }
-    case "workspace_glob": {
-      const patterns = Array.isArray(args.patterns)
-        ? (args.patterns as unknown[]).map(stringifyScalar).filter(Boolean)
-        : [];
-      if (patterns.length === 0) return "patterns: none";
-      if (patterns.length === 1) return `pattern: ${truncateText(patterns[0])}`;
-      return `patterns: ${truncateText(patterns[0])} +${patterns.length - 1}`;
-    }
-    case "workspace_search": {
-      const pattern =
-        typeof args.pattern === "string" ? truncateText(args.pattern) : "";
-      const root = normalizePath(args.rootDir);
-      return pattern ? `/${pattern}/ in ${root}` : `in ${root}`;
-    }
-    case "exec_run": {
-      const command = typeof args.command === "string" ? args.command : "";
-      const argList = Array.isArray(args.args)
-        ? (args.args as unknown[]).map(stringifyScalar).filter(Boolean)
-        : [];
-      const full = [command, ...argList].filter(Boolean).join(" ");
-      return full ? truncateText(full, 64) : "command";
-    }
-    case "git_worktree_init": {
-      const branch =
-        typeof args.suggestedBranch === "string" ? args.suggestedBranch : "";
-      return branch ? `branch: ${truncateText(branch)}` : "init worktree";
-    }
-    case "agent_artifact_create": {
-      const kind = typeof args.kind === "string" ? args.kind : "artifact";
-      const summary = typeof args.summary === "string" ? args.summary : "";
-      return summary ? `${kind}: ${truncateText(summary)}` : kind;
-    }
-    case "agent_artifact_version": {
-      const artifactId =
-        typeof args.artifactId === "string" ? args.artifactId : "artifact";
-      return `${truncateText(artifactId, 44)} → new version`;
-    }
-    case "agent_artifact_get": {
-      const artifactId =
-        typeof args.artifactId === "string" ? args.artifactId : "artifact";
-      const version =
-        typeof args.version === "number" ? `@v${args.version}` : "@latest";
-      return `${truncateText(artifactId, 40)} ${version}`;
-    }
-    case "agent_artifact_list": {
-      const kind = typeof args.kind === "string" ? args.kind : "any";
-      return `kind: ${kind}`;
-    }
-    case "agent_todo_add": {
-      const text = typeof args.text === "string" ? args.text : "";
-      return text ? truncateText(text) : "add todo";
-    }
-    case "agent_todo_update": {
-      const id = typeof args.id === "string" ? args.id : "";
-      const patch =
-        args.patch && typeof args.patch === "object"
-          ? (args.patch as Record<string, unknown>)
-          : null;
-      const status =
-        patch && typeof patch.status === "string" ? patch.status : null;
-      const text =
-        patch && typeof patch.text === "string"
-          ? truncateText(patch.text, 36)
-          : null;
-      const update = [
-        status ? `status:${status}` : null,
-        text ? `text:${text}` : null,
-      ]
-        .filter(Boolean)
-        .join(" · ");
-      if (id && update) return `${id} (${update})`;
-      if (id) return id;
-      return update || "update todo";
-    }
-    case "agent_todo_list": {
-      const status = typeof args.status === "string" ? args.status : "any";
-      const limit =
-        typeof args.limit === "number" ? `, limit ${args.limit}` : "";
-      return `status: ${status}${limit}`;
-    }
-    case "agent_todo_remove": {
-      const id = typeof args.id === "string" ? args.id : "";
-      return id ? `id: ${id}` : "remove todo";
-    }
-    case "agent_title_set": {
-      const title = typeof args.title === "string" ? args.title : "";
-      return title ? truncateText(title) : "set title";
-    }
-    case "agent_title_get": {
-      return "read tab title";
-    }
-    case "agent_card_add": {
-      const kind = typeof args.kind === "string" ? args.kind : "card";
-      const title = typeof args.title === "string" ? truncateText(args.title, 28) : "";
-      if (kind === "summary") {
-        const markdown =
-          typeof args.markdown === "string"
-            ? truncateText(args.markdown.replace(/\s+/g, " "), 40)
-            : "";
-        if (title && markdown) return `${title} · ${markdown}`;
-        if (title) return `${title} · summary`;
-        return markdown || "summary card";
-      }
-
-      const artifactId =
-        typeof args.artifactId === "string" ? args.artifactId : "artifact";
-      const version =
-        typeof args.version === "number" ? ` @v${args.version}` : " @latest";
-      if (title) return `${title} · ${truncateText(artifactId, 28)}${version}`;
-      return `${truncateText(artifactId, 36)}${version}`;
-    }
-    case "user_input": {
-      const q =
-        typeof args.question === "string"
-          ? truncateText(args.question, 52)
-          : "";
-      const result =
-        tc.result && typeof tc.result === "object"
-          ? (tc.result as Record<string, unknown>)
-          : null;
-      const answer =
-        typeof result?.answer === "string"
-          ? truncateText(result.answer, 28)
-          : null;
-      const skipped = tc.status === "denied";
-      if (q && answer) return `${q} → "${answer}"`;
-      if (q && skipped) return `${q} → (skipped)`;
-      return q || "question";
-    }
-    default:
-      return fallbackArgPreview(args);
-  }
 }
 
 function stringifyValue(value: unknown): string {
@@ -1116,102 +912,22 @@ export default function CompactToolCall({
     tc.status !== "awaiting_branch_release" &&
     tc.status !== "awaiting_setup_action";
 
-  const icon = getToolCallIcon(tc);
-  const label = getToolCallLabel(tc);
-  const dotStatus = STATUS_DOT[tc.status] ?? "pending";
-  const statusDotVariant =
-    dotStatus === "pending"
-      ? "idle"
-      : dotStatus === "running"
-        ? "working"
-        : dotStatus === "done"
-          ? "done"
-          : "error";
-  const argPreview = buildCollapsedArgPreview(tc);
-  const execBadge = getExecCommandBadge(tc);
-
   /* ── Header row ──────────────────────────────────────────────────────────── */
   const headerRow = (
-    <div
-      className={cn(
-        "inline-tool-summary",
-        (isExpandable || isInspectable) && "inline-tool-summary--clickable",
-      )}
-      onClick={
+    <CompactToolCallSummaryRow
+      tc={tc}
+      expanded={expanded}
+      showExpandChevron={isExpandable}
+      showInspect={isInspectable}
+      onActivate={
         isExpandable
           ? () => setExpanded((v) => !v)
           : isInspectable
             ? onInspect
             : undefined
       }
-      role={isExpandable || isInspectable ? "button" : undefined}
-    >
-      {/* Status dot */}
-      <StatusDot
-        status={statusDotVariant}
-        className={cn("inline-tool-status", `inline-tool-status--${dotStatus}`)}
-      />
-
-      {/* Tool icon */}
-      <span className="material-symbols-outlined text-base opacity-65 shrink-0">
-        {icon}
-      </span>
-
-      <div className="inline-tool-summary-main">
-        {/* Human-readable label */}
-        <span
-          className={cn(
-            "inline-tool-label",
-            tc.status === "denied" && "text-error",
-          )}
-        >
-          {label}
-          {tc.status === "denied" && (
-            <span className="ml-1 opacity-80"> · DENIED</span>
-          )}
-        </span>
-        {argPreview && (
-          <span className="inline-tool-arg-preview" title={argPreview}>
-            {argPreview}
-          </span>
-        )}
-      </div>
-
-      {execBadge && (
-        <Badge
-          variant={execBadge.variant}
-          className="shrink-0"
-          title={execBadge.title}
-        >
-          {execBadge.label}
-        </Badge>
-      )}
-
-      {/* frame_bug — opens the details modal */}
-      {isInspectable && (
-        <span
-          className="material-symbols-outlined text-muted opacity-45 shrink-0 text-sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            onInspect();
-          }}
-        >
-          frame_bug
-        </span>
-      )}
-
-      {/* Expand / collapse chevron */}
-      {isExpandable && (
-        <span
-          className={cn(
-            "material-symbols-outlined text-muted opacity-40 shrink-0 text-md transition-transform duration-150",
-            expanded ? "rotate-180" : "rotate-0",
-          )}
-        >
-          expand_more
-        </span>
-      )}
-    </div>
+      onInspect={onInspect}
+    />
   );
 
   /* ── Expanded section ──────────────────────────────────────────────────── */

--- a/src/components/GroupedInlineToolCall.test.tsx
+++ b/src/components/GroupedInlineToolCall.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallDisplay } from "@/agent/types";
+import GroupedInlineToolCall from "./GroupedInlineToolCall";
+
+vi.mock("./CompactToolCall", () => ({
+  default: ({ tc }: { tc: ToolCallDisplay }) => (
+    <div data-testid="grouped-tool-child">{tc.id}</div>
+  ),
+}));
+
+function makeToolCall(
+  id: string,
+  tool: string,
+  args: Record<string, unknown>,
+): ToolCallDisplay {
+  return {
+    id,
+    tool,
+    args,
+    status: "done",
+  };
+}
+
+describe("GroupedInlineToolCall", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the latest tool call summary, unique icon strip, and count badge when collapsed", () => {
+    render(
+      <GroupedInlineToolCall
+        toolCalls={[
+          makeToolCall("tc-1", "workspace_listDir", { path: "src" }),
+          makeToolCall("tc-2", "workspace_readFile", { path: "README.md" }),
+          makeToolCall("tc-3", "workspace_readFile", { path: "package.json" }),
+          makeToolCall("tc-4", "workspace_glob", { patterns: ["*.ts"] }),
+        ]}
+        onInspect={vi.fn()}
+        showDebug={false}
+      />,
+    );
+
+    expect(screen.getByText("GLOB FILES")).not.toBeNull();
+    expect(screen.getByText("pattern: *.ts")).not.toBeNull();
+    expect(screen.getByText("4")).not.toBeNull();
+    expect(screen.getByTitle("LIST DIRECTORY")).not.toBeNull();
+    expect(screen.getAllByTitle("READ FILE")).toHaveLength(1);
+    expect(screen.getByTitle("GLOB FILES")).not.toBeNull();
+  });
+
+  it("expands to render all grouped tool calls", () => {
+    const { container } = render(
+      <GroupedInlineToolCall
+        toolCalls={[
+          makeToolCall("tc-1", "workspace_listDir", { path: "src" }),
+          makeToolCall("tc-2", "workspace_readFile", { path: "README.md" }),
+        ]}
+        onInspect={vi.fn()}
+        showDebug={false}
+      />,
+    );
+
+    const toggle = screen.getByRole("button");
+    fireEvent.click(toggle);
+
+    expect(
+      container.querySelector(".inline-tool-group__body--expanded"),
+    ).not.toBeNull();
+    expect(screen.getAllByTestId("grouped-tool-child")).toHaveLength(2);
+  });
+});

--- a/src/components/GroupedInlineToolCall.tsx
+++ b/src/components/GroupedInlineToolCall.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { ToolCallDisplay } from "@/agent/types";
+import CompactToolCall from "@/components/CompactToolCall";
+import { CompactToolCallSummaryRow } from "@/components/compactToolCallSummary";
+import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
+import { cn } from "@/utils/cn";
+import { Badge } from "@/components/ui";
+
+interface GroupedInlineToolCallProps {
+  toolCalls: ToolCallDisplay[];
+  onInspect: (toolCall: ToolCallDisplay) => void;
+  cwd?: string;
+  showDebug: boolean;
+}
+
+export default function GroupedInlineToolCall({
+  toolCalls,
+  onInspect,
+  cwd,
+  showDebug,
+}: GroupedInlineToolCallProps) {
+  const [expanded, setExpanded] = useState(false);
+  const latestToolCall = toolCalls[toolCalls.length - 1];
+  const uniqueToolTypes = toolCalls.filter((toolCall, index, allToolCalls) => {
+    const typeKey = toolCall.mcp
+      ? `mcp:${toolCall.mcp.serverId}:${toolCall.mcp.toolName}`
+      : toolCall.tool;
+    return (
+      allToolCalls.findIndex((candidate) => {
+        const candidateKey = candidate.mcp
+          ? `mcp:${candidate.mcp.serverId}:${candidate.mcp.toolName}`
+          : candidate.tool;
+        return candidateKey === typeKey;
+      }) === index
+    );
+  });
+
+  if (!latestToolCall) return null;
+
+  return (
+    <div className="inline-tool-group">
+      <CompactToolCallSummaryRow
+        tc={latestToolCall}
+        expanded={expanded}
+        showExpandChevron
+        onActivate={() => setExpanded((current) => !current)}
+        trailingContent={
+          <div className="inline-tool-group__summary-trailing">
+            <div
+              className="inline-tool-group__icon-strip"
+              aria-label={`${uniqueToolTypes.length} unique inline tool types`}
+            >
+              {uniqueToolTypes.map((toolCall) => (
+                <span
+                  key={toolCall.mcp ? `${toolCall.mcp.serverId}:${toolCall.mcp.toolName}` : toolCall.tool}
+                  className="material-symbols-outlined inline-tool-group__icon"
+                  title={getToolCallLabel(toolCall)}
+                >
+                  {getToolCallIcon(toolCall)}
+                </span>
+              ))}
+            </div>
+            <Badge variant="muted" className="shrink-0">
+              {toolCalls.length}
+            </Badge>
+          </div>
+        }
+      />
+
+      <div
+        className={cn(
+          "inline-tool-group__body",
+          expanded && "inline-tool-group__body--expanded",
+        )}
+        style={{ maxHeight: expanded ? "640px" : "0px" }}
+      >
+        <div className="inline-tool-group__body-inner">
+          {toolCalls.map((toolCall) => (
+            <CompactToolCall
+              key={toolCall.id}
+              tc={toolCall}
+              onInspect={() => onInspect(toolCall)}
+              cwd={cwd}
+              showDebug={showDebug}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/artifact-pane/DebugPane.test.tsx
+++ b/src/components/artifact-pane/DebugPane.test.tsx
@@ -146,6 +146,7 @@ function buildFixture() {
     reviewEdits: [],
     autoApproveEdits: false,
     autoApproveCommands: "no",
+    groupInlineToolCallsOverride: null,
     queuedMessages: [],
     queueState: "idle",
     showDebug: true,

--- a/src/components/compactToolCallSummary.tsx
+++ b/src/components/compactToolCallSummary.tsx
@@ -1,0 +1,339 @@
+import type { ReactNode } from "react";
+import type { ToolCallDisplay } from "@/agent/types";
+import { getExecCommandBadge } from "@/components/compactToolCallStatus";
+import { getToolCallIcon, getToolCallLabel } from "@/components/toolDisplay";
+import { cn } from "@/utils/cn";
+import { Badge, StatusDot } from "@/components/ui";
+
+const STATUS_DOT: Record<string, string> = {
+  pending: "pending",
+  running: "running",
+  done: "done",
+  error: "error",
+  denied: "error",
+  awaiting_branch_release: "error",
+  awaiting_setup_action: "error",
+};
+
+function truncateText(value: string, max = 56): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(1, max - 1))}...`;
+}
+
+function stringifyScalar(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function normalizePath(path: unknown): string {
+  if (typeof path !== "string" || path.trim().length === 0) return ".";
+  return path;
+}
+
+function describeLineRange(range: unknown): string | null {
+  if (!range || typeof range !== "object") return null;
+  const r = range as Record<string, unknown>;
+  const start = typeof r.startLine === "number" ? r.startLine : null;
+  const end = typeof r.endLine === "number" ? r.endLine : null;
+  if (start !== null && end !== null) return `L${start}-${end}`;
+  if (start !== null) return `from L${start}`;
+  if (end !== null) return `to L${end}`;
+  return null;
+}
+
+function fallbackArgPreview(args: Record<string, unknown>): string | null {
+  const keys = Object.keys(args);
+  if (keys.length === 0) return null;
+
+  const firstKey = keys[0];
+  const firstValue = args[firstKey];
+
+  if (typeof firstValue === "string") {
+    return `${firstKey}: ${truncateText(firstValue)}`;
+  }
+  if (typeof firstValue === "number" || typeof firstValue === "boolean") {
+    return `${firstKey}: ${String(firstValue)}`;
+  }
+  if (Array.isArray(firstValue)) {
+    return `${firstKey}: ${firstValue.length} item${firstValue.length === 1 ? "" : "s"}`;
+  }
+  if (firstValue && typeof firstValue === "object") {
+    return `${firstKey}: {...}`;
+  }
+  return firstKey;
+}
+
+export function buildCollapsedArgPreview(tc: ToolCallDisplay): string | null {
+  const { tool, args } = tc;
+  switch (tool) {
+    case "workspace_listDir": {
+      return `dir: ${normalizePath(args.path)}`;
+    }
+    case "workspace_stat": {
+      return `path: ${normalizePath(args.path)}`;
+    }
+    case "workspace_readFile": {
+      const path = normalizePath(args.path);
+      const range = describeLineRange(args.range);
+      return range ? `${path} (${range})` : path;
+    }
+    case "workspace_writeFile": {
+      const path = normalizePath(args.path);
+      const content = typeof args.content === "string" ? args.content : "";
+      return `${path} (${content.length} chars)`;
+    }
+    case "workspace_editFile": {
+      const path = normalizePath(args.path);
+      const count = Array.isArray(args.changes) ? args.changes.length : 0;
+      return `${path} (${count} change${count === 1 ? "" : "s"})`;
+    }
+    case "workspace_glob": {
+      const patterns = Array.isArray(args.patterns)
+        ? (args.patterns as unknown[]).map(stringifyScalar).filter(Boolean)
+        : [];
+      if (patterns.length === 0) return "patterns: none";
+      if (patterns.length === 1) return `pattern: ${truncateText(patterns[0])}`;
+      return `patterns: ${truncateText(patterns[0])} +${patterns.length - 1}`;
+    }
+    case "workspace_search": {
+      const pattern =
+        typeof args.pattern === "string" ? truncateText(args.pattern) : "";
+      const root = normalizePath(args.rootDir);
+      return pattern ? `/${pattern}/ in ${root}` : `in ${root}`;
+    }
+    case "exec_run": {
+      const command = typeof args.command === "string" ? args.command : "";
+      const argList = Array.isArray(args.args)
+        ? (args.args as unknown[]).map(stringifyScalar).filter(Boolean)
+        : [];
+      const full = [command, ...argList].filter(Boolean).join(" ");
+      return full ? truncateText(full, 64) : "command";
+    }
+    case "git_worktree_init": {
+      const branch =
+        typeof args.suggestedBranch === "string" ? args.suggestedBranch : "";
+      return branch ? `branch: ${truncateText(branch)}` : "init worktree";
+    }
+    case "agent_artifact_create": {
+      const kind = typeof args.kind === "string" ? args.kind : "artifact";
+      const summary = typeof args.summary === "string" ? args.summary : "";
+      return summary ? `${kind}: ${truncateText(summary)}` : kind;
+    }
+    case "agent_card_add": {
+      const kind = typeof args.kind === "string" ? args.kind : "card";
+      const title =
+        typeof args.title === "string" ? truncateText(args.title, 28) : "";
+      if (kind === "summary") {
+        const markdown =
+          typeof args.markdown === "string"
+            ? truncateText(args.markdown.replace(/\s+/g, " "), 40)
+            : "";
+        if (title && markdown) return `${title} - ${markdown}`;
+        if (title) return `${title} - summary`;
+        return markdown || "summary card";
+      }
+
+      const artifactId =
+        typeof args.artifactId === "string" ? args.artifactId : "artifact";
+      const version =
+        typeof args.version === "number" ? ` @v${args.version}` : " @latest";
+      if (title) return `${title} - ${truncateText(artifactId, 28)}${version}`;
+      return `${truncateText(artifactId, 36)}${version}`;
+    }
+    case "agent_artifact_version": {
+      const artifactId =
+        typeof args.artifactId === "string" ? args.artifactId : "artifact";
+      return `${truncateText(artifactId, 44)} -> new version`;
+    }
+    case "agent_artifact_get": {
+      const artifactId =
+        typeof args.artifactId === "string" ? args.artifactId : "artifact";
+      const version =
+        typeof args.version === "number" ? `@v${args.version}` : "@latest";
+      return `${truncateText(artifactId, 40)} ${version}`;
+    }
+    case "agent_artifact_list": {
+      const kind = typeof args.kind === "string" ? args.kind : "any";
+      return `kind: ${kind}`;
+    }
+    case "agent_todo_add": {
+      const text = typeof args.text === "string" ? args.text : "";
+      return text ? truncateText(text) : "add todo";
+    }
+    case "agent_todo_update": {
+      const id = typeof args.id === "string" ? args.id : "";
+      const patch =
+        args.patch && typeof args.patch === "object"
+          ? (args.patch as Record<string, unknown>)
+          : null;
+      const status =
+        patch && typeof patch.status === "string" ? patch.status : null;
+      const text =
+        patch && typeof patch.text === "string"
+          ? truncateText(patch.text, 36)
+          : null;
+      const update = [
+        status ? `status:${status}` : null,
+        text ? `text:${text}` : null,
+      ]
+        .filter(Boolean)
+        .join(" - ");
+      if (id && update) return `${id} (${update})`;
+      if (id) return id;
+      return update || "update todo";
+    }
+    case "agent_todo_list": {
+      const status = typeof args.status === "string" ? args.status : "any";
+      const limit =
+        typeof args.limit === "number" ? `, limit ${args.limit}` : "";
+      return `status: ${status}${limit}`;
+    }
+    case "agent_todo_remove": {
+      const id = typeof args.id === "string" ? args.id : "";
+      return id ? `id: ${id}` : "remove todo";
+    }
+    case "agent_title_set": {
+      const title = typeof args.title === "string" ? args.title : "";
+      return title ? truncateText(title) : "set title";
+    }
+    case "agent_title_get": {
+      return "read tab title";
+    }
+    case "user_input": {
+      const q =
+        typeof args.question === "string"
+          ? truncateText(args.question, 52)
+          : "";
+      const result =
+        tc.result && typeof tc.result === "object"
+          ? (tc.result as Record<string, unknown>)
+          : null;
+      const answer =
+        typeof result?.answer === "string"
+          ? truncateText(result.answer, 28)
+          : null;
+      const skipped = tc.status === "denied";
+      if (q && answer) return `${q} -> "${answer}"`;
+      if (q && skipped) return `${q} -> (skipped)`;
+      return q || "question";
+    }
+    default: {
+      return fallbackArgPreview(args);
+    }
+  }
+}
+
+export interface CompactToolCallSummaryRowProps {
+  tc: ToolCallDisplay;
+  expanded?: boolean;
+  showExpandChevron?: boolean;
+  showInspect?: boolean;
+  onActivate?: () => void;
+  onInspect?: () => void;
+  trailingContent?: ReactNode;
+  className?: string;
+}
+
+export function CompactToolCallSummaryRow({
+  tc,
+  expanded = false,
+  showExpandChevron = false,
+  showInspect = false,
+  onActivate,
+  onInspect,
+  trailingContent,
+  className,
+}: CompactToolCallSummaryRowProps) {
+  const interactive = typeof onActivate === "function";
+  const icon = getToolCallIcon(tc);
+  const label = getToolCallLabel(tc);
+  const dotStatus = STATUS_DOT[tc.status] ?? "pending";
+  const statusDotVariant =
+    dotStatus === "pending"
+      ? "idle"
+      : dotStatus === "running"
+        ? "working"
+        : dotStatus === "done"
+          ? "done"
+          : "error";
+  const argPreview = buildCollapsedArgPreview(tc);
+  const execBadge = getExecCommandBadge(tc);
+
+  return (
+    <div
+      className={cn(
+        "inline-tool-summary",
+        interactive && "inline-tool-summary--clickable",
+        className,
+      )}
+      onClick={onActivate}
+      role={interactive ? "button" : undefined}
+    >
+      <StatusDot
+        status={statusDotVariant}
+        className={cn("inline-tool-status", `inline-tool-status--${dotStatus}`)}
+      />
+
+      <span className="material-symbols-outlined text-base opacity-65 shrink-0">
+        {icon}
+      </span>
+
+      <div className="inline-tool-summary-main">
+        <span
+          className={cn(
+            "inline-tool-label",
+            tc.status === "denied" && "text-error",
+          )}
+        >
+          {label}
+          {tc.status === "denied" && (
+            <span className="ml-1 opacity-80"> - DENIED</span>
+          )}
+        </span>
+        {argPreview && (
+          <span className="inline-tool-arg-preview" title={argPreview}>
+            {argPreview}
+          </span>
+        )}
+      </div>
+
+      {execBadge && (
+        <Badge
+          variant={execBadge.variant}
+          className="shrink-0"
+          title={execBadge.title}
+        >
+          {execBadge.label}
+        </Badge>
+      )}
+
+      {trailingContent}
+
+      {showInspect && onInspect && (
+        <span
+          className="material-symbols-outlined text-muted opacity-45 shrink-0 text-sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            onInspect();
+          }}
+        >
+          frame_bug
+        </span>
+      )}
+
+      {showExpandChevron && (
+        <span
+          className={cn(
+            "material-symbols-outlined text-muted opacity-40 shrink-0 text-md transition-transform duration-150",
+            expanded ? "rotate-180" : "rotate-0",
+          )}
+        >
+          expand_more
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -8,6 +8,7 @@ import { TabsProvider, useTabs } from "@/contexts/TabsContext";
 import {
   appUpdaterStateAtom,
   defaultAppUpdaterState,
+  groupInlineToolCallsAtom,
   jotaiStore,
 } from "@/agent/atoms";
 import { providersAtom } from "@/agent/db";
@@ -148,6 +149,7 @@ describe("SettingsPage", () => {
     jotaiStore.set(providersAtom, []);
     jotaiStore.set(mcpServersAtom, []);
     jotaiStore.set(mcpSettingsAtom, { artifactizeReturnedFiles: false });
+    jotaiStore.set(groupInlineToolCallsAtom, true);
     jotaiStore.set(appUpdaterStateAtom, {
       ...defaultAppUpdaterState,
       status: "available",
@@ -222,6 +224,27 @@ describe("SettingsPage", () => {
     });
     expect(screen.getByText("Theme & Mode")).not.toBeNull();
     expect(screen.getByText("Theme")).not.toBeNull();
+  });
+
+  it("toggles the grouped inline tool call appearance preference", async () => {
+    renderSettingsPage("appearance");
+
+    await waitFor(() => {
+      expect(screen.getByText("Group inline tool calls")).not.toBeNull();
+    });
+
+    const toggle = screen.getByTitle("Group inline tool calls");
+    fireEvent.click(toggle);
+
+    expect(jotaiStore.get(groupInlineToolCallsAtom)).toBe(false);
+
+    cleanup();
+    renderSettingsPage("appearance");
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Group inline tool calls")).not.toBeNull();
+    });
+    expect(jotaiStore.get(groupInlineToolCallsAtom)).toBe(false);
   });
 
   it("renders the MCP settings section under AI and saves a tested server", async () => {

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -882,6 +882,22 @@ function AppearanceSection({
           <span>{controller.themeMode === "dark" ? "Light" : "Dark"}</span>
         </Button>
       </div>
+
+      <div className="settings-row">
+        <div className="settings-row-info">
+          <span className="settings-row-label">Group inline tool calls</span>
+          <span className="settings-row-desc">
+            Collapse consecutive auto-approved tool calls into a single
+            expandable block by default.
+          </span>
+        </div>
+        <ToggleSwitch
+          checked={controller.groupInlineToolCalls}
+          onChange={controller.setGroupInlineToolCalls}
+          className="settings-switch"
+          title="Group inline tool calls"
+        />
+      </div>
       </SectionCard>
 
       <SectionCard

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -6,6 +6,7 @@ import {
   notifyOnAttentionAtom,
   themeModeAtom,
   themeNameAtom,
+  groupInlineToolCallsAtom,
   globalCommunicationProfileAtom,
   voiceInputEnabledAtom,
   voiceModelPathAtom,
@@ -67,6 +68,8 @@ export interface SettingsControllerValue {
   toggleThemeMode: () => void;
   themeName: ThemeName;
   setThemeName: (name: ThemeName) => void;
+  groupInlineToolCalls: boolean;
+  setGroupInlineToolCalls: (enabled: boolean) => void;
   globalCommunicationProfile: string;
   setGlobalCommunicationProfile: (profile: string) => void;
   customProfiles: CommunicationProfileRecord[];
@@ -96,6 +99,9 @@ export function useSettingsController(): SettingsControllerValue {
   const [mcpSettings, setMcpSettings] = useAtom(mcpSettingsAtom);
   const [themeMode, setThemeMode] = useAtom(themeModeAtom);
   const [themeName, setThemeName] = useAtom(themeNameAtom);
+  const [groupInlineToolCalls, setGroupInlineToolCalls] = useAtom(
+    groupInlineToolCallsAtom,
+  );
   const [globalCommunicationProfile, setGlobalCommunicationProfile] = useAtom(
     globalCommunicationProfileAtom,
   );
@@ -233,6 +239,8 @@ export function useSettingsController(): SettingsControllerValue {
     toggleThemeMode,
     themeName,
     setThemeName,
+    groupInlineToolCalls,
+    setGroupInlineToolCalls,
     globalCommunicationProfile,
     setGlobalCommunicationProfile,
     customProfiles,

--- a/src/components/toolCallRenderItems.test.ts
+++ b/src/components/toolCallRenderItems.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCallDisplay } from "@/agent/types";
+import {
+  buildToolCallRenderItems,
+  getToolCallRenderKind,
+} from "./toolCallRenderItems";
+
+function makeToolCall(
+  id: string,
+  tool: string,
+  status: ToolCallDisplay["status"] = "done",
+): ToolCallDisplay {
+  return {
+    id,
+    tool,
+    args: {},
+    status,
+  };
+}
+
+describe("toolCallRenderItems", () => {
+  it("groups contiguous inline compact tool calls", () => {
+    const items = buildToolCallRenderItems(
+      [
+        makeToolCall("tc-1", "workspace_listDir"),
+        makeToolCall("tc-2", "workspace_readFile"),
+        makeToolCall("tc-3", "workspace_glob"),
+      ],
+      true,
+    );
+
+    expect(items).toEqual([
+      {
+        kind: "group",
+        toolCalls: [
+          expect.objectContaining({ id: "tc-1" }),
+          expect.objectContaining({ id: "tc-2" }),
+          expect.objectContaining({ id: "tc-3" }),
+        ],
+      },
+    ]);
+  });
+
+  it("leaves single inline compact tool calls ungrouped", () => {
+    const items = buildToolCallRenderItems(
+      [
+        makeToolCall("tc-1", "workspace_listDir"),
+        makeToolCall("tc-2", "exec_run"),
+      ],
+      true,
+    );
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-1" }),
+      }),
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-2" }),
+      }),
+    ]);
+  });
+
+  it("treats approval rows and user input as hard boundaries", () => {
+    const items = buildToolCallRenderItems(
+      [
+        makeToolCall("tc-1", "workspace_listDir"),
+        makeToolCall("tc-2", "workspace_readFile"),
+        makeToolCall("tc-3", "exec_run", "running"),
+        makeToolCall("tc-4", "workspace_glob"),
+        makeToolCall("tc-5", "user_input"),
+        makeToolCall("tc-6", "workspace_search"),
+        makeToolCall("tc-7", "workspace_stat"),
+      ],
+      true,
+    );
+
+    expect(items.map((item) => item.kind)).toEqual([
+      "group",
+      "tool",
+      "tool",
+      "tool",
+      "group",
+    ]);
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        kind: "group",
+        toolCalls: [
+          expect.objectContaining({ id: "tc-1" }),
+          expect.objectContaining({ id: "tc-2" }),
+        ],
+      }),
+    );
+    expect(items[4]).toEqual(
+      expect.objectContaining({
+        kind: "group",
+        toolCalls: [
+          expect.objectContaining({ id: "tc-6" }),
+          expect.objectContaining({ id: "tc-7" }),
+        ],
+      }),
+    );
+  });
+
+  it("returns individual rows when grouping is disabled", () => {
+    const items = buildToolCallRenderItems(
+      [
+        makeToolCall("tc-1", "workspace_listDir"),
+        makeToolCall("tc-2", "workspace_readFile"),
+      ],
+      false,
+    );
+
+    expect(items.every((item) => item.kind === "tool")).toBe(true);
+    expect(items).toHaveLength(2);
+  });
+
+  it("classifies awaiting user input separately from approval cards", () => {
+    expect(getToolCallRenderKind(makeToolCall("tc-1", "user_input", "awaiting_approval"))).toBe(
+      "user_input",
+    );
+    expect(getToolCallRenderKind(makeToolCall("tc-2", "workspace_writeFile", "awaiting_approval"))).toBe(
+      "approval",
+    );
+    expect(getToolCallRenderKind(makeToolCall("tc-3", "workspace_listDir"))).toBe(
+      "compact",
+    );
+  });
+});

--- a/src/components/toolCallRenderItems.ts
+++ b/src/components/toolCallRenderItems.ts
@@ -1,0 +1,92 @@
+import { isInlineTool } from "@/agent/approvals";
+import type { ToolCallDisplay } from "@/agent/types";
+
+export type ToolCallRenderKind = "user_input" | "approval" | "compact";
+
+export type ToolCallRenderItem =
+  | {
+      kind: "tool";
+      toolCall: ToolCallDisplay;
+      renderKind: ToolCallRenderKind;
+    }
+  | {
+      kind: "group";
+      toolCalls: ToolCallDisplay[];
+    };
+
+export function getToolCallRenderKind(tc: ToolCallDisplay): ToolCallRenderKind {
+  if (tc.tool === "user_input" && tc.status === "awaiting_approval") {
+    return "user_input";
+  }
+
+  if (
+    tc.status === "awaiting_approval" ||
+    tc.status === "awaiting_worktree" ||
+    tc.status === "awaiting_branch_release" ||
+    tc.status === "awaiting_setup_action" ||
+    (tc.tool === "git_worktree_init" && tc.status === "running") ||
+    (tc.tool === "exec_run" && tc.status === "running")
+  ) {
+    return "approval";
+  }
+
+  return "compact";
+}
+
+function canGroupInlineToolCall(tc: ToolCallDisplay): boolean {
+  return (
+    tc.tool !== "user_input" &&
+    isInlineTool(tc.tool) &&
+    getToolCallRenderKind(tc) === "compact"
+  );
+}
+
+function flushGroup(
+  items: ToolCallRenderItem[],
+  pendingGroup: ToolCallDisplay[],
+): ToolCallDisplay[] {
+  if (pendingGroup.length > 1) {
+    items.push({ kind: "group", toolCalls: pendingGroup });
+  } else if (pendingGroup.length === 1) {
+    items.push({
+      kind: "tool",
+      toolCall: pendingGroup[0],
+      renderKind: "compact",
+    });
+  }
+
+  return [];
+}
+
+export function buildToolCallRenderItems(
+  toolCalls: ToolCallDisplay[],
+  groupInlineToolCalls: boolean,
+): ToolCallRenderItem[] {
+  if (!groupInlineToolCalls) {
+    return toolCalls.map((toolCall) => ({
+      kind: "tool" as const,
+      toolCall,
+      renderKind: getToolCallRenderKind(toolCall),
+    }));
+  }
+
+  const items: ToolCallRenderItem[] = [];
+  let pendingGroup: ToolCallDisplay[] = [];
+
+  for (const toolCall of toolCalls) {
+    if (canGroupInlineToolCall(toolCall)) {
+      pendingGroup.push(toolCall);
+      continue;
+    }
+
+    pendingGroup = flushGroup(items, pendingGroup);
+    items.push({
+      kind: "tool",
+      toolCall,
+      renderKind: getToolCallRenderKind(toolCall),
+    });
+  }
+
+  flushGroup(items, pendingGroup);
+  return items;
+}

--- a/src/styles/components-messages.css
+++ b/src/styles/components-messages.css
@@ -242,7 +242,7 @@
 .msg-reasoning {
   margin-bottom: 10px;
   width: 100%;
-  border: 1px solid var(--color-border-subtle);
+  border: 1px solid var(--color-inset);
   border-radius: 6px;
   background: var(--color-inset);
 }

--- a/src/styles/components-tools.css
+++ b/src/styles/components-tools.css
@@ -125,6 +125,12 @@
   background: var(--color-inset);
 }
 
+.inline-tool-group {
+  border-radius: 8px;
+  background: var(--color-inset);
+  overflow: hidden;
+}
+
 /* ── Collapsed header row ──────────────────────────────────────────────── */
 .inline-tool-summary {
   display: flex;
@@ -198,6 +204,45 @@
   color: color-mix(in srgb, var(--color-muted) 88%, transparent);
   font-size: var(--text-xxs);
   letter-spacing: 0.01em;
+}
+
+.inline-tool-group__summary-trailing {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.inline-tool-group__icon-strip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: color-mix(in srgb, var(--color-muted) 82%, transparent);
+}
+
+.inline-tool-group__icon {
+  font-size: 15px;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.inline-tool-group__body {
+  overflow: hidden;
+  opacity: 0;
+  transition:
+    max-height var(--t-slow),
+    opacity var(--t-fast);
+}
+
+.inline-tool-group__body--expanded {
+  opacity: 1;
+}
+
+.inline-tool-group__body-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 0 4px;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add a global grouped-inline-tools preference plus an in-memory per-session slash-command override
- group contiguous inline compact tool calls into a collapsible block with a shared summary row and unique collapsed icons
- enable grouped tool calls by default and cover the new behavior with tests

## Testing
- npm run test -- src/agent/slashCommands.test.ts src/components/toolCallRenderItems.test.ts src/components/GroupedInlineToolCall.test.tsx src/components/settings/SettingsPage.test.tsx src/WorkspacePage.test.tsx src/components/artifact-pane/DebugPane.test.tsx
- npm run test -- src/components/settings/SettingsPage.test.tsx src/WorkspacePage.test.tsx
- npm run test -- src/WorkspacePage.test.tsx
- npm run test -- src/components/GroupedInlineToolCall.test.tsx
- npm run typecheck
- npm run lint

Fixes #117