### PR TITLE
fix(tauri): register external tool commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod db;
 pub mod exec;
+pub mod external_tools;
 pub mod fs_ops;
 pub mod git;
 pub mod mcp;
@@ -50,6 +51,8 @@ pub fn run() {
             exec::exec_run,
             exec::exec_abort,
             exec::exec_stop,
+            external_tools::open_in_editor,
+            external_tools::open_shell,
             pty::spawn_pty,
             pty::write_pty,
             pty::resize_pty,


### PR DESCRIPTION
## Summary
- register the `external_tools` module in the Tauri app
- expose `open_in_editor` and `open_shell` through the Tauri invoke handler
- restore the quick actions introduced in #102

## Testing
- cargo test external_tools
- npm test -- WorkspacePage

## Context
- Regression from #102
- Originally tracked in #99