### PR TITLE
fix(approvals): add command allow and deny lists

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1662,6 +1662,243 @@ pub fn providers_save(providers: Vec<ProviderRecord>) -> Result<(), String> {
     Ok(())
 }
 
+/* ── Command List (disk-backed) ─────────────────────────────────────────── */
+
+fn command_list_config_path() -> Result<PathBuf, String> {
+    Ok(app_store_root()?.join("config").join("command-list.json"))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandListEntryRecord {
+    pub id: String,
+    pub pattern: String,
+    pub match_mode: String, // "exact" | "prefix" | "glob"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub source: String, // "user" | "default" | subagent id
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandListRecord {
+    pub allow: Vec<CommandListEntryRecord>,
+    pub deny: Vec<CommandListEntryRecord>,
+}
+
+fn default_allow_list() -> Vec<CommandListEntryRecord> {
+    vec![
+        CommandListEntryRecord {
+            id: "default-pwd".to_string(),
+            pattern: "pwd".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Print working directory".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-status".to_string(),
+            pattern: "git status".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Inspect repository status".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-branch-show-current".to_string(),
+            pattern: "git branch --show-current".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Show current branch".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-remote-v".to_string(),
+            pattern: "git remote -v".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("List configured remotes".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-rev-parse-show-toplevel".to_string(),
+            pattern: "git rev-parse --show-toplevel".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Show repository root".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-rev-parse-head".to_string(),
+            pattern: "git rev-parse --abbrev-ref HEAD".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Resolve current branch name".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-log".to_string(),
+            pattern: "git log".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Inspect commit history".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-show".to_string(),
+            pattern: "git show".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Inspect repository objects".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-git-ls-files".to_string(),
+            pattern: "git ls-files".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("List tracked files".to_string()),
+            source: "default".to_string(),
+        },
+    ]
+}
+
+fn default_deny_list() -> Vec<CommandListEntryRecord> {
+    vec![
+        CommandListEntryRecord {
+            id: "default-rm-rf".to_string(),
+            pattern: "rm -rf".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Recursive force delete".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-rm-rf-root".to_string(),
+            pattern: "rm -rf /".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Delete root filesystem".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-sudo-rm".to_string(),
+            pattern: "sudo rm".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Privileged delete".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-mkfs".to_string(),
+            pattern: "mkfs".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Format filesystem".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-dd".to_string(),
+            pattern: "dd if=".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Low-level disk write".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-chmod-777".to_string(),
+            pattern: "chmod -R 777".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Insecure recursive permission change".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-etc-overwrite".to_string(),
+            pattern: "> /etc/".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Overwrite system config".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-curl-sh".to_string(),
+            pattern: "curl * | sh".to_string(),
+            match_mode: "glob".to_string(),
+            description: Some("Pipe remote script to shell".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-wget-sh".to_string(),
+            pattern: "wget * | sh".to_string(),
+            match_mode: "glob".to_string(),
+            description: Some("Pipe remote script to shell".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-shutdown".to_string(),
+            pattern: "shutdown".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("System shutdown".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-reboot".to_string(),
+            pattern: "reboot".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("System reboot".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-kill-9".to_string(),
+            pattern: "kill -9".to_string(),
+            match_mode: "prefix".to_string(),
+            description: Some("Force kill processes".to_string()),
+            source: "default".to_string(),
+        },
+        CommandListEntryRecord {
+            id: "default-fork-bomb".to_string(),
+            pattern: ":(){:|:&};:".to_string(),
+            match_mode: "exact".to_string(),
+            description: Some("Fork bomb".to_string()),
+            source: "default".to_string(),
+        },
+    ]
+}
+
+#[tauri::command]
+pub fn command_list_load() -> Result<CommandListRecord, String> {
+    tool_log("command_list_load", "start", json!({}));
+    let path = command_list_config_path()?;
+    if !path.exists() {
+        let defaults = CommandListRecord {
+            allow: default_allow_list(),
+            deny: default_deny_list(),
+        };
+        // Write defaults to disk so future loads are idempotent.
+        let _ = command_list_save(defaults.clone());
+        tool_log("command_list_load", "ok", json!({ "reason": "defaults_written", "allowCount": defaults.allow.len(), "denyCount": defaults.deny.len() }));
+        return Ok(defaults);
+    }
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("INTERNAL: cannot read command list: {}", e))?;
+    let record: CommandListRecord = serde_json::from_str(&raw)
+        .map_err(|e| format!("INTERNAL: cannot parse command list: {}", e))?;
+    tool_log("command_list_load", "ok", json!({ "allowCount": record.allow.len(), "denyCount": record.deny.len() }));
+    Ok(record)
+}
+
+#[tauri::command]
+pub fn command_list_save(list: CommandListRecord) -> Result<(), String> {
+    tool_log("command_list_save", "start", json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }));
+    let path = command_list_config_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("INTERNAL: cannot create config dir: {}", e))?;
+    }
+    let raw = serde_json::to_string_pretty(&list)
+        .map_err(|e| format!("INTERNAL: cannot serialise command list: {}", e))?;
+    let tmp = path.with_extension(format!("json.tmp-{}", now_ms()));
+    fs::write(&tmp, raw.as_bytes())
+        .map_err(|e| format!("INTERNAL: cannot write command list tmp: {}", e))?;
+    match fs::rename(&tmp, &path) {
+        Ok(()) => {}
+        Err(e) => {
+            if path.exists() {
+                let _ = fs::remove_file(&tmp);
+            } else {
+                return Err(format!("INTERNAL: cannot rename command list file: {}", e));
+            }
+        }
+    }
+    tool_log("command_list_save", "ok", json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }));
+    Ok(())
+}
+
 /* ── Communication Profiles (disk-backed) ────────────────────────────────── */
 
 fn profiles_config_path() -> Result<PathBuf, String> {
@@ -1747,11 +1984,11 @@ mod tests {
     use std::sync::OnceLock;
     use tempfile::tempdir;
 
-    static PROVIDER_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    static HOME_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[test]
     fn test_providers_load_returns_empty_when_absent() {
-        let _guard = PROVIDER_TEST_LOCK
+        let _guard = HOME_TEST_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap();
@@ -1770,7 +2007,7 @@ mod tests {
 
     #[test]
     fn test_providers_roundtrip() {
-        let _guard = PROVIDER_TEST_LOCK
+        let _guard = HOME_TEST_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap();
@@ -2062,8 +2299,7 @@ mod tests {
 
     #[test]
     fn test_artifact_dedup_version_and_gc() {
-        static ENV_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let _guard = ENV_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _guard = HOME_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
 
         let tmp = tempdir().unwrap();
         let prev_home = std::env::var("HOME").ok();
@@ -2220,6 +2456,78 @@ mod tests {
                 "createdAt": 456,
             })
         );
+    }
+
+    #[test]
+    fn test_command_list_load_returns_defaults_when_absent() {
+        let _guard = HOME_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+
+        let result = command_list_load().expect("command_list_load should not error");
+        assert!(!result.allow.is_empty(), "Allow list should have safe default entries");
+        assert!(!result.deny.is_empty(), "Deny list should have default entries");
+        assert!(
+            result.allow.iter().any(|entry| entry.pattern == "git status"),
+            "Safe git status should be included by default"
+        );
+        // Check that the file was written to disk
+        let path = command_list_config_path().unwrap();
+        assert!(path.exists(), "command-list.json should be written on first load");
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn test_command_list_save_and_load_roundtrip() {
+        let _guard = HOME_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+
+        let list = CommandListRecord {
+            allow: vec![CommandListEntryRecord {
+                id: "entry-1".to_string(),
+                pattern: "npm test".to_string(),
+                match_mode: "exact".to_string(),
+                description: Some("Run tests".to_string()),
+                source: "user".to_string(),
+            }],
+            deny: vec![CommandListEntryRecord {
+                id: "entry-2".to_string(),
+                pattern: "rm -rf".to_string(),
+                match_mode: "prefix".to_string(),
+                description: None,
+                source: "default".to_string(),
+            }],
+        };
+
+        command_list_save(list.clone()).expect("command_list_save should succeed");
+        let loaded = command_list_load().expect("command_list_load should succeed");
+
+        assert_eq!(loaded.allow.len(), 1);
+        assert_eq!(loaded.allow[0].id, "entry-1");
+        assert_eq!(loaded.allow[0].pattern, "npm test");
+        assert_eq!(loaded.allow[0].match_mode, "exact");
+        assert_eq!(loaded.allow[0].description.as_deref(), Some("Run tests"));
+        assert_eq!(loaded.deny.len(), 1);
+        assert_eq!(loaded.deny[0].pattern, "rm -rf");
+        assert!(loaded.deny[0].description.is_none());
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,8 @@ pub fn run() {
             db::providers_save,
             db::profiles_load,
             db::profiles_save,
+            db::command_list_load,
+            db::command_list_save,
             mcp::mcp_servers_load,
             mcp::mcp_settings_load,
             mcp::mcp_servers_save,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import {
   themeNameAtom,
   agentAtomFamily,
 } from "@/agent/atoms";
-import { loadProviders, providersAtom, loadProfiles, profilesAtom } from "@/agent/db";
+import { loadProviders, providersAtom, loadProfiles, profilesAtom, loadCommandList, commandListAtom } from "@/agent/db";
 import {
   loadMcpServers,
   loadMcpSettings,
@@ -184,13 +184,15 @@ export default function App() {
       loadProfiles(),
       loadMcpServers(),
       loadMcpSettings(),
+      loadCommandList(),
     ]).then(
-      ([sessions, providers, profiles, mcpServers, mcpSettings]) => {
+      ([sessions, providers, profiles, mcpServers, mcpSettings, commandList]) => {
         // Load providers and profiles into global store early
         jotaiStore.set(providersAtom, providers);
         jotaiStore.set(profilesAtom, profiles);
         jotaiStore.set(mcpServersAtom, mcpServers);
         jotaiStore.set(mcpSettingsAtom, mcpSettings);
+        jotaiStore.set(commandListAtom, commandList);
 
         // Hydrate Jotai atoms before first render of agent components
         for (const s of sessions) {

--- a/src/agent/approvals.test.ts
+++ b/src/agent/approvals.test.ts
@@ -12,89 +12,227 @@ import {
   resolveWorktreeSetupAction,
   resolveWorktreeApproval,
   setApprovalReason,
+  isCommandInList,
+  matchesEntry,
 } from "./approvals";
+import type { CommandList, CommandListEntry } from "./db";
+
+// Helper: unwrap required from ApprovalResult for concise assertions
+function req(result: { required: boolean; dangerous: boolean }): boolean {
+  return result.required;
+}
 
 describe("approvals - requiresApproval", () => {
   it("should never require approval for inline tools", () => {
-    expect(requiresApproval("workspace_listDir", false, "no")).toBe(false);
-    expect(requiresApproval("agent_title_set", false, "no")).toBe(false);
-    expect(requiresApproval("agent_artifact_create", false, "no")).toBe(false);
-    expect(requiresApproval("agent_artifact_version", false, "no")).toBe(false);
-    expect(requiresApproval("agent_artifact_get", false, "no")).toBe(false);
-    expect(requiresApproval("agent_artifact_list", false, "no")).toBe(false);
+    expect(req(requiresApproval("workspace_listDir", false, "no"))).toBe(false);
+    expect(req(requiresApproval("agent_title_set", false, "no"))).toBe(false);
+    expect(req(requiresApproval("agent_artifact_create", false, "no"))).toBe(false);
+    expect(req(requiresApproval("agent_artifact_version", false, "no"))).toBe(false);
+    expect(req(requiresApproval("agent_artifact_get", false, "no"))).toBe(false);
+    expect(req(requiresApproval("agent_artifact_list", false, "no"))).toBe(false);
   });
 
   it("should respect autoApproveEdits flag", () => {
     // Without flag
-    expect(requiresApproval("workspace_writeFile", false, "no")).toBe(true);
-    expect(requiresApproval("workspace_editFile", false, "no")).toBe(true);
+    expect(req(requiresApproval("workspace_writeFile", false, "no"))).toBe(true);
+    expect(req(requiresApproval("workspace_editFile", false, "no"))).toBe(true);
     // With flag
-    expect(requiresApproval("workspace_writeFile", true, "no")).toBe(false);
-    expect(requiresApproval("workspace_editFile", true, "no")).toBe(false);
+    expect(req(requiresApproval("workspace_writeFile", true, "no"))).toBe(false);
+    expect(req(requiresApproval("workspace_editFile", true, "no"))).toBe(false);
   });
 
   it("should always auto-approve commands when mode is yes", () => {
-    expect(requiresApproval("exec_run", false, "yes")).toBe(false);
+    expect(req(requiresApproval("exec_run", false, "yes"))).toBe(false);
     expect(
-      requiresApproval(
+      req(requiresApproval(
         "exec_run",
         false,
         "yes",
         { requireUserApproval: true } as Record<string, unknown>,
-      ),
+      )),
     ).toBe(false);
   });
 
   it("should always require command approval when mode is no", () => {
-    expect(requiresApproval("exec_run", false, "no")).toBe(true);
+    expect(req(requiresApproval("exec_run", false, "no"))).toBe(true);
     expect(
-      requiresApproval(
+      req(requiresApproval(
         "exec_run",
         false,
         "no",
         { requireUserApproval: false } as Record<string, unknown>,
-      ),
+      )),
     ).toBe(true);
   });
 
   it("should respect agent command hint in mode=agent", () => {
     expect(
-      requiresApproval(
+      req(requiresApproval(
         "exec_run",
         false,
         "agent",
         { requireUserApproval: true } as Record<string, unknown>,
-      ),
+      )),
     ).toBe(true);
     expect(
-      requiresApproval(
+      req(requiresApproval(
         "exec_run",
         false,
         "agent",
         { requireUserApproval: false } as Record<string, unknown>,
-      ),
+      )),
     ).toBe(false);
   });
 
   it("should default to requiring approval when mode=agent and hint is missing/invalid", () => {
-    expect(requiresApproval("exec_run", false, "agent")).toBe(true);
+    expect(req(requiresApproval("exec_run", false, "agent"))).toBe(true);
     expect(
-      requiresApproval(
+      req(requiresApproval(
         "exec_run",
         false,
         "agent",
         { requireUserApproval: "yes please" } as Record<string, unknown>,
-      ),
+      )),
     ).toBe(true);
   });
 
   it("should default to requiring approval for unknown tools", () => {
-    expect(requiresApproval("unknown_dangerous_tool", true, "yes")).toBe(true);
+    expect(req(requiresApproval("unknown_dangerous_tool", true, "yes"))).toBe(true);
   });
 
   it("should not auto-approve unrelated tool categories", () => {
-    expect(requiresApproval("exec_run", true, "no")).toBe(true);
-    expect(requiresApproval("workspace_writeFile", false, "yes")).toBe(true);
+    expect(req(requiresApproval("exec_run", true, "no"))).toBe(true);
+    expect(req(requiresApproval("workspace_writeFile", false, "yes"))).toBe(true);
+  });
+});
+
+describe("approvals - matchesEntry", () => {
+  const makeEntry = (pattern: string, matchMode: CommandListEntry["matchMode"]): CommandListEntry => ({
+    id: "test",
+    pattern,
+    matchMode,
+    source: "user",
+  });
+
+  it("exact match", () => {
+    expect(matchesEntry("npm test", makeEntry("npm test", "exact"))).toBe(true);
+    expect(matchesEntry("npm test --watch", makeEntry("npm test", "exact"))).toBe(false);
+  });
+
+  it("prefix match", () => {
+    expect(matchesEntry("gh issue create", makeEntry("gh issue", "prefix"))).toBe(true);
+    expect(matchesEntry("git status", makeEntry("gh issue", "prefix"))).toBe(false);
+    expect(matchesEntry("ghissue create", makeEntry("gh", "prefix"))).toBe(false);
+  });
+
+  it("glob match", () => {
+    expect(matchesEntry("gh issue create", makeEntry("gh *", "glob"))).toBe(true);
+    expect(matchesEntry("npm test", makeEntry("gh *", "glob"))).toBe(false);
+    expect(matchesEntry("curl http://x.com | sh", makeEntry("curl * | sh", "glob"))).toBe(true);
+  });
+
+  it("normalizes extra whitespace", () => {
+    expect(matchesEntry("npm test", makeEntry("npm   test", "exact"))).toBe(true);
+    expect(matchesEntry("gh issue create", makeEntry("gh   issue", "prefix"))).toBe(true);
+  });
+});
+
+describe("approvals - command list integration", () => {
+  const allowEntry: CommandListEntry = { id: "a1", pattern: "npm", matchMode: "prefix", source: "user" };
+  const denyEntry: CommandListEntry = { id: "d1", pattern: "rm -rf", matchMode: "prefix", source: "default" };
+  const commandList: CommandList = { allow: [allowEntry], deny: [denyEntry] };
+
+  it("deny list always requires approval + marks dangerous", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "yes", // even with "yes" mode
+      { command: "rm", args: ["-rf", "/tmp/test"] },
+      commandList,
+    );
+    expect(result.required).toBe(true);
+    expect(result.dangerous).toBe(true);
+  });
+
+  it("deny list inspects shell payloads for wrapped commands", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "yes",
+      { command: "/bin/bash", args: ["-lc", "rm -rf /tmp/test"] },
+      commandList,
+    );
+    expect(result.required).toBe(true);
+    expect(result.dangerous).toBe(true);
+  });
+
+  it("deny list takes priority over allow list", () => {
+    const overlap: CommandList = {
+      allow: [{ id: "a2", pattern: "rm", matchMode: "prefix", source: "user" }],
+      deny: [{ id: "d2", pattern: "rm -rf", matchMode: "prefix", source: "default" }],
+    };
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "yes",
+      { command: "rm", args: ["-rf", "/tmp"] },
+      overlap,
+    );
+    expect(result.required).toBe(true);
+    expect(result.dangerous).toBe(true);
+  });
+
+  it("allow list skips approval when mode is agent", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "agent",
+      { command: "npm", args: ["test"] },
+      commandList,
+    );
+    expect(result.required).toBe(false);
+    expect(result.dangerous).toBe(false);
+  });
+
+  it("allow list skips approval when mode is yes", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "yes",
+      { command: "npm", args: ["run", "build"] },
+      commandList,
+    );
+    expect(result.required).toBe(false);
+    expect(result.dangerous).toBe(false);
+  });
+
+  it("allow list has no effect when mode is no", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "no",
+      { command: "npm", args: ["test"] },
+      commandList,
+    );
+    expect(result.required).toBe(true);
+    expect(result.dangerous).toBe(false);
+  });
+
+  it("command not in any list falls through to normal logic", () => {
+    const result = requiresApproval(
+      "exec_run",
+      false,
+      "agent",
+      { command: "git", args: ["status"], requireUserApproval: false },
+      commandList,
+    );
+    expect(result.required).toBe(false);
+    expect(result.dangerous).toBe(false);
+  });
+
+  it("isCommandInList works for prefix entries", () => {
+    expect(isCommandInList("npm install", [allowEntry])).toBe(true);
+    expect(isCommandInList("python main.py", [allowEntry])).toBe(false);
   });
 });
 

--- a/src/agent/approvals.ts
+++ b/src/agent/approvals.ts
@@ -1,4 +1,5 @@
 import type { AutoApproveCommandsMode } from "./types";
+import type { CommandList, CommandListEntry } from "./db";
 
 /**
  * Tool approval system.
@@ -97,6 +98,142 @@ export const TOOL_APPROVAL_CONFIG = new Map<string, boolean>(
 const EDIT_TOOLS = new Set<string>(["workspace_writeFile", "workspace_editFile"]);
 /** Command tools that the auto-approve flag covers */
 const COMMAND_TOOLS = new Set<string>(["exec_run"]);
+const SHELL_PAYLOAD_FLAGS = new Set(["-c", "-lc", "--command", "-command", "/c", "/k"]);
+const SHELL_WRAPPER_COMMANDS = new Set([
+  "bash",
+  "sh",
+  "zsh",
+  "fish",
+  "cmd",
+  "cmd.exe",
+  "powershell",
+  "pwsh",
+]);
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Command list matching helpers
+───────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Matches a full command string against a single CommandListEntry pattern.
+ * Supports three match modes:
+ * - exact: full string equality
+ * - prefix: string starts with pattern
+ * - glob: simple glob with * wildcard support (no path separators required)
+ */
+export function matchesEntry(fullCmd: string, entry: CommandListEntry): boolean {
+  const normalizedCmd = normalizeCommandText(fullCmd);
+  const normalizedPattern = normalizeCommandText(entry.pattern);
+  if (!normalizedCmd || !normalizedPattern) return false;
+
+  const { matchMode } = entry;
+  switch (matchMode) {
+    case "exact":
+      return normalizedCmd === normalizedPattern;
+    case "prefix":
+      return normalizedCmd === normalizedPattern ||
+        normalizedCmd.startsWith(`${normalizedPattern} `);
+    case "glob": {
+      // Convert glob pattern to a RegExp: escape special chars, then replace * with .*
+      const regexStr = normalizedPattern
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*/g, ".*");
+      return new RegExp(`^${regexStr}$`).test(normalizedCmd);
+    }
+    default:
+      return false;
+  }
+}
+
+/** Returns true if the full command matches any entry in the list. */
+export function isCommandInList(
+  fullCmd: string,
+  entries: CommandListEntry[],
+): boolean {
+  return entries.some((e) => matchesEntry(fullCmd, e));
+}
+
+/** Returns the matching deny entry, or null if not denied. */
+export function getDenyEntry(
+  fullCmd: string,
+  commandList: CommandList,
+): CommandListEntry | null {
+  return commandList.deny.find((e) => matchesEntry(fullCmd, e)) ?? null;
+}
+
+/** Returns true if the command is in the allow list. */
+export function isCommandAllowed(
+  fullCmd: string,
+  commandList: CommandList,
+): boolean {
+  return isCommandInList(fullCmd, commandList.allow);
+}
+
+function normalizeCommandText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function getExecArgs(toolArgs?: Record<string, unknown>): { command: string; args: string[] } {
+  const command =
+    typeof toolArgs?.command === "string"
+      ? normalizeCommandText(toolArgs.command)
+      : "";
+  const args = Array.isArray(toolArgs?.args)
+    ? toolArgs.args.filter((arg): arg is string => typeof arg === "string")
+    : [];
+  return { command, args };
+}
+
+function getFullCommandText(toolArgs?: Record<string, unknown>): string {
+  const { command, args } = getExecArgs(toolArgs);
+  return normalizeCommandText([command, ...args].join(" "));
+}
+
+function getShellPayloadCommand(toolArgs?: Record<string, unknown>): string | null {
+  const { command, args } = getExecArgs(toolArgs);
+  if (!command) return null;
+
+  const commandBasename =
+    command.split(/[\\/]/).pop()?.toLowerCase() ?? command.toLowerCase();
+  if (!SHELL_WRAPPER_COMMANDS.has(commandBasename)) return null;
+
+  const payloadIndex = args.findIndex((arg) =>
+    SHELL_PAYLOAD_FLAGS.has(arg.toLowerCase()),
+  );
+  if (payloadIndex === -1) return null;
+
+  const payload = args[payloadIndex + 1];
+  return typeof payload === "string" ? normalizeCommandText(payload) : null;
+}
+
+function getDeniedCommandEntry(
+  toolArgs: Record<string, unknown> | undefined,
+  commandList: CommandList,
+): CommandListEntry | null {
+  const fullCommand = getFullCommandText(toolArgs);
+  if (fullCommand) {
+    const fullMatch = getDenyEntry(fullCommand, commandList);
+    if (fullMatch) return fullMatch;
+  }
+
+  const shellPayload = getShellPayloadCommand(toolArgs);
+  if (shellPayload) {
+    return getDenyEntry(shellPayload, commandList);
+  }
+
+  return null;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   ApprovalResult — enriched return type so callers know if dangerous
+───────────────────────────────────────────────────────────────────────────── */
+
+export interface ApprovalResult {
+  /** Whether the tool must be approved by the user before running. */
+  required: boolean;
+  /** Whether the command is on the deny list (show danger badge in UI). */
+  dangerous: boolean;
+}
 
 /** Returns true when the given tool must be approved before running. */
 export function requiresApproval(
@@ -104,24 +241,44 @@ export function requiresApproval(
   autoApproveEdits: boolean,
   autoApproveCommands: AutoApproveCommandsMode,
   toolArgs?: Record<string, unknown>,
-): boolean {
+  commandList?: CommandList,
+): ApprovalResult {
   // Inline tools never require approval.
-  if (isInlineTool(toolName)) return false;
+  if (isInlineTool(toolName)) return { required: false, dangerous: false };
   // Auto-approve overrides for edit tools
-  if (autoApproveEdits && EDIT_TOOLS.has(toolName)) return false;
+  if (autoApproveEdits && EDIT_TOOLS.has(toolName)) return { required: false, dangerous: false };
 
   // Command approval is tri-state and may consider a model-provided hint.
   if (COMMAND_TOOLS.has(toolName)) {
-    if (autoApproveCommands === "yes") return false;
-    if (autoApproveCommands === "no") return true;
+    const fullCmd = getFullCommandText(toolArgs);
 
-    // "agent": respect model hint, safe default is to ask.
+    // 1. Check deny list first — always requires approval + mark as dangerous.
+    if (commandList && fullCmd) {
+      const denyEntry = getDeniedCommandEntry(toolArgs, commandList);
+      if (denyEntry) {
+        return { required: true, dangerous: true };
+      }
+    }
+
+    // 2. If auto-run is "no", always ask (allow list has no effect).
+    if (autoApproveCommands === "no") return { required: true, dangerous: false };
+
+    // 3. Check allow list — auto-approve when autoApproveCommands is "agent" or "yes".
+    if (commandList && fullCmd && isCommandAllowed(fullCmd, commandList)) {
+      return { required: false, dangerous: false };
+    }
+
+    // 4. autoApproveCommands === "yes"
+    if (autoApproveCommands === "yes") return { required: false, dangerous: false };
+
+    // 5. "agent": respect model hint, safe default is to ask.
     const shouldRequireApproval = toolArgs?.requireUserApproval;
-    return shouldRequireApproval !== false;
+    return { required: shouldRequireApproval !== false, dangerous: false };
   }
 
   // Unknown tools default to requiring approval (safe default).
-  return TOOL_APPROVAL_CONFIG.get(toolName) ?? true;
+  const required = TOOL_APPROVAL_CONFIG.get(toolName) ?? true;
+  return { required, dangerous: false };
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────

--- a/src/agent/db.ts
+++ b/src/agent/db.ts
@@ -51,3 +51,31 @@ export async function deleteProfile(id: string): Promise<void> {
 }
 
 export const profilesAtom = atom<CommunicationProfileRecord[]>([]);
+
+/* ── Command List ─────────────────────────────────────────────────────────── */
+
+export type MatchMode = "exact" | "prefix" | "glob";
+
+export interface CommandListEntry {
+  id: string;
+  pattern: string;
+  matchMode: MatchMode;
+  description?: string;
+  /** "user" | "default" | subagent id */
+  source: string;
+}
+
+export interface CommandList {
+  allow: CommandListEntry[];
+  deny: CommandListEntry[];
+}
+
+export async function loadCommandList(): Promise<CommandList> {
+  return invoke<CommandList>("command_list_load");
+}
+
+export async function saveCommandList(list: CommandList): Promise<void> {
+  await invoke("command_list_save", { list });
+}
+
+export const commandListAtom = atom<CommandList>({ allow: [], deny: [] });

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -118,6 +118,7 @@ vi.mock("./atoms", () => ({
 vi.mock("./db", () => ({
   providersAtom: providersAtomMock,
   profilesAtom: profilesAtomMock,
+  commandListAtom: { kind: "command-list-atom" },
 }));
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
@@ -443,6 +444,9 @@ describe("runner", () => {
       if (atom === profilesAtomMock) {
         return [];
       }
+      if ((atom as { kind?: string })?.kind === "command-list-atom") {
+        return { allow: [], deny: [] };
+      }
       if (atom === globalCommunicationProfileAtomMock) {
         return "global-test-profile";
       }
@@ -455,7 +459,7 @@ describe("runner", () => {
       data: { branch: "feat/test" },
     });
 
-    requiresApprovalMock.mockReturnValue(false);
+    requiresApprovalMock.mockReturnValue({ required: false, dangerous: false });
     requestApprovalMock.mockResolvedValue(true);
     consumeApprovalReasonMock.mockReturnValue(undefined);
     dispatchToolMock.mockResolvedValue({ ok: true, data: { ok: true } });
@@ -1169,7 +1173,7 @@ describe("runner", () => {
       { deltas: ["follow-up"], toolCalls: [] },
     );
 
-    requiresApprovalMock.mockReturnValue(true);
+    requiresApprovalMock.mockReturnValue({ required: true, dangerous: false });
     requestApprovalMock.mockResolvedValue(false);
     consumeApprovalReasonMock.mockReturnValue("Denied for safety");
 
@@ -1177,7 +1181,7 @@ describe("runner", () => {
 
     expect(requiresApprovalMock).toHaveBeenCalledWith("exec_run", false, "no", {
       command: "pwd",
-    });
+    }, expect.objectContaining({ allow: [], deny: [] }));
 
     const state = states[tabId];
     expect(dispatchToolMock).not.toHaveBeenCalled();
@@ -1566,7 +1570,7 @@ describe("runner", () => {
       { deltas: ["All done."], toolCalls: [] },
     );
 
-    requiresApprovalMock.mockReturnValue(false);
+    requiresApprovalMock.mockReturnValue({ required: false, dangerous: false });
 
     dispatchToolMock.mockImplementation(async (...args: unknown[]) => {
       const callbacks = args[5] as
@@ -3083,7 +3087,7 @@ describe("runner", () => {
         return { ok: true, data: { ok: true } };
       });
 
-      requiresApprovalMock.mockReturnValue(false);
+      requiresApprovalMock.mockReturnValue({ required: false, dangerous: false });
 
       await runAgent(tabId, "run the planner");
 
@@ -3254,7 +3258,9 @@ describe("runner", () => {
       turns.push({ deltas: ["No security issues found."], toolCalls: [] });
 
       requiresApprovalMock.mockImplementation((toolName: string) => {
-        return toolName === "exec_run";
+        return toolName === "exec_run"
+          ? { required: true, dangerous: false }
+          : { required: false, dangerous: false };
       });
 
       dispatchToolMock.mockImplementation(async (...args: unknown[]) => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -61,6 +61,7 @@ import {
   cancelAllApprovals,
   consumeApprovalReason,
 } from "./approvals";
+import { commandListAtom } from "./db";
 import type {
   AttachedImage,
   AgentQueueState,
@@ -2526,15 +2527,18 @@ async function runSubagentLoop(
 
         // Approval gate — reads tab-level auto-approve flags (identical to main agent)
         const subState = getAgentState(tabId);
-        if (
-          requiresApproval(
-            tc.function.name,
-            subState.autoApproveEdits,
-            subState.autoApproveCommands,
-            preparedArgs,
-          )
-        ) {
-          updateToolCallById({ status: "awaiting_approval" });
+        const subApprovalResult = requiresApproval(
+          tc.function.name,
+          subState.autoApproveEdits,
+          subState.autoApproveCommands,
+          preparedArgs,
+          jotaiStore.get(commandListAtom),
+        );
+        if (subApprovalResult.required) {
+          updateToolCallById({
+            status: "awaiting_approval",
+            dangerous: subApprovalResult.dangerous,
+          });
           const approved = await requestApproval(tabId, tcId);
           if (!approved) {
             const reason = consumeApprovalReason(tabId, tcId);
@@ -3677,15 +3681,18 @@ async function agentLoop(
         }
 
         // ── Approval gate ─────────────────────────────────────────────────
-        if (
-          requiresApproval(
-            tc.function.name,
-            getAgentState(tabId).autoApproveEdits,
-            getAgentState(tabId).autoApproveCommands,
-            preArgs,
-          )
-        ) {
-          updateToolCallById({ status: "awaiting_approval" });
+        const mainApprovalResult = requiresApproval(
+          tc.function.name,
+          getAgentState(tabId).autoApproveEdits,
+          getAgentState(tabId).autoApproveCommands,
+          preArgs,
+          jotaiStore.get(commandListAtom),
+        );
+        if (mainApprovalResult.required) {
+          updateToolCallById({
+            status: "awaiting_approval",
+            dangerous: mainApprovalResult.dangerous,
+          });
 
           const approved = await requestApproval(tabId, tcId);
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -144,6 +144,11 @@ export interface ToolCallDisplay {
   /** Live stdout+stderr accumulated while the command is running. */
   streamingOutput?: string;
   /**
+   * True when this command is on the deny list — UI shows a danger warning badge.
+   * Only set when status is "awaiting_approval".
+   */
+  dangerous?: boolean;
+  /**
    * Cached DiffFile states for UI components to render exactly what was originally proposed.
    * Captured at execution time so that it survives subsequent edits to the same file.
    * Each entry is a SerializedDiff; decode with deserializeDiff() before passing to UI components.

--- a/src/components/ToolCallApproval.tsx
+++ b/src/components/ToolCallApproval.tsx
@@ -956,6 +956,7 @@ export default function ToolCallApproval({
 
   const icon = getToolCallIcon(toolCall);
   const label = getToolCallLabel(toolCall);
+  const isDangerous = toolCall.dangerous === true;
 
   const argEntries = Object.entries(args);
 
@@ -969,6 +970,18 @@ export default function ToolCallApproval({
         </div>
         <div className="text-xxs text-muted font-mono opacity-60">{tool}</div>
       </div>
+
+      {/* ── Dangerous command warning ─────────────────────────────────── */}
+      {isDangerous && (
+        <div className="px-3 py-2 border-b border-border-subtle flex items-center gap-2 bg-danger/10">
+          <span className="material-symbols-outlined text-base text-danger">
+            warning
+          </span>
+          <span className="text-xs text-danger font-medium">
+            Potentially dangerous — this command is on your deny list and always requires approval.
+          </span>
+        </div>
+      )}
 
       {/* ── Args block ──────────────────────────────────────────────────────────────────────── */}
       {tool === "workspace_editFile" ? (

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -32,6 +32,8 @@ import {
   saveProvider,
   type ProviderInstance,
   type CommunicationProfileRecord,
+  type CommandListEntry,
+  type MatchMode,
 } from "@/agent/db";
 import {
   saveMcpSettings,
@@ -1881,6 +1883,280 @@ function UpdatesSection({
   );
 }
 
+/* ── CommandListSection ───────────────────────────────────────────────────── */
+
+const MATCH_MODE_OPTIONS: { value: MatchMode; label: string }[] = [
+  { value: "prefix", label: "Starts with" },
+  { value: "exact", label: "Exact" },
+  { value: "glob", label: "Glob (*)" },
+];
+
+function CommandEntryForm({
+  initial,
+  onSave,
+  onCancel,
+}: {
+  initial?: CommandListEntry;
+  onSave: (entry: Omit<CommandListEntry, "id" | "source">) => void;
+  onCancel: () => void;
+}) {
+  const [pattern, setPattern] = useState(initial?.pattern ?? "");
+  const [matchMode, setMatchMode] = useState<MatchMode>(
+    initial?.matchMode ?? "prefix",
+  );
+  const [description, setDescription] = useState(initial?.description ?? "");
+
+  const handleSubmit = () => {
+    const trimmed = pattern.trim();
+    if (!trimmed) return;
+    onSave({ pattern: trimmed, matchMode, description: description.trim() || undefined });
+  };
+
+  return (
+    <Panel className="settings-provider-form">
+      <div className="settings-provider-form__grid">
+        <div className="settings-field">
+          <label className="settings-field-label">Pattern</label>
+          <TextField
+            value={pattern}
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="e.g. npm test or rm -rf *"
+            autoFocus
+            wrapClassName="settings-input-wrap"
+          />
+        </div>
+        <div className="settings-field">
+          <label className="settings-field-label">Match mode</label>
+          <SelectField
+            className="settings-input settings-provider-form__select"
+            value={matchMode}
+            onChange={(e) => setMatchMode(e.target.value as MatchMode)}
+          >
+            {MATCH_MODE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </SelectField>
+        </div>
+        <div className="settings-field settings-field--full-span">
+          <label className="settings-field-label">Description <span style={{fontWeight: 400}}>(optional)</span></label>
+          <TextField
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Short note for your own reference"
+            wrapClassName="settings-input-wrap"
+          />
+        </div>
+      </div>
+      <div className="settings-provider-form__footer">
+        <div className="settings-provider-form__status" />
+        <div className="settings-provider-form__actions">
+          <Button type="button" variant="ghost" size="xs" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="button" size="xs" onClick={handleSubmit} disabled={!pattern.trim()}>
+            Save
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
+function CommandEntryRow({
+  entry,
+  onEdit,
+  onDelete,
+}: {
+  entry: CommandListEntry;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const isDefault = entry.source === "default";
+  const isSubagent = entry.source !== "user" && entry.source !== "default";
+  const modeLabelMap: Record<MatchMode, string> = {
+    exact: "Exact",
+    prefix: "Starts with",
+    glob: "Glob",
+  };
+
+  return (
+    <Panel className="settings-provider-card">
+      <div className="settings-provider-card__copy">
+        <span className="settings-provider-card__title">
+          <code>{entry.pattern}</code>
+        </span>
+        <span className="settings-provider-card__meta">
+          {modeLabelMap[entry.matchMode]}
+          {entry.description ? ` · ${entry.description}` : ""}
+        </span>
+      </div>
+      <div className="settings-provider-card__actions">
+        {isDefault && (
+          <Badge variant="muted">built-in</Badge>
+        )}
+        {isSubagent && (
+          <Badge variant="primary">{entry.source}</Badge>
+        )}
+        <IconButton
+          className="settings-provider-card__icon-btn"
+          onClick={onEdit}
+          title="Edit entry"
+          aria-label="Edit entry"
+        >
+          <span className="material-symbols-outlined text-sm">edit</span>
+        </IconButton>
+        <IconButton
+          className="settings-provider-card__icon-btn settings-provider-card__icon-btn--danger"
+          onClick={onDelete}
+          title={isDefault ? "Remove built-in safety rule" : "Delete entry"}
+          aria-label="Delete entry"
+        >
+          <span className="material-symbols-outlined text-sm">delete</span>
+        </IconButton>
+      </div>
+    </Panel>
+  );
+}
+
+function CommandListSubpanel({
+  title,
+  description,
+  entries,
+  emptyIcon,
+  emptyTitle,
+  emptyDesc,
+  listName,
+  onAdd,
+  onEdit,
+  onDelete,
+}: {
+  title: string;
+  description: string;
+  entries: CommandListEntry[];
+  emptyIcon: string;
+  emptyTitle: string;
+  emptyDesc: string;
+  listName: "allow" | "deny";
+  onAdd: (listName: "allow" | "deny", entry: Omit<CommandListEntry, "id" | "source">) => void;
+  onEdit: (listName: "allow" | "deny", entry: CommandListEntry) => void;
+  onDelete: (listName: "allow" | "deny", id: string) => void;
+}) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  return (
+    <SectionCard
+      title={title}
+      description={description}
+      actions={
+        <Button
+          type="button"
+          size="xs"
+          onClick={() => { setIsAdding(true); setEditingId(null); }}
+          className="text-nowrap"
+        >
+          Add Entry
+        </Button>
+      }
+    >
+      <div className="settings-provider-list">
+        {isAdding ? (
+          <CommandEntryForm
+            onSave={(entry) => {
+              onAdd(listName, entry);
+              setIsAdding(false);
+            }}
+            onCancel={() => setIsAdding(false)}
+          />
+        ) : null}
+
+        {entries.length === 0 && !isAdding ? (
+          <Panel variant="inset" className="settings-empty-panel">
+            <span className="material-symbols-outlined settings-empty-panel__icon">{emptyIcon}</span>
+            <div className="settings-empty-panel__copy">
+              <span className="settings-empty-panel__title">{emptyTitle}</span>
+              <span className="settings-empty-panel__description">{emptyDesc}</span>
+            </div>
+          </Panel>
+        ) : null}
+
+        {entries.map((entry) =>
+          editingId === entry.id ? (
+            <CommandEntryForm
+              key={entry.id}
+              initial={entry}
+              onSave={(updated) => {
+                onEdit(listName, { ...entry, ...updated });
+                setEditingId(null);
+              }}
+              onCancel={() => setEditingId(null)}
+            />
+          ) : (
+            <CommandEntryRow
+              key={entry.id}
+              entry={entry}
+              onEdit={() => setEditingId(entry.id)}
+              onDelete={() => onDelete(listName, entry.id)}
+            />
+          ),
+        )}
+      </div>
+    </SectionCard>
+  );
+}
+
+function CommandListSection({
+  controller,
+}: {
+  controller: SettingsControllerValue;
+}) {
+  const handleAdd = async (
+    listName: "allow" | "deny",
+    entry: Omit<CommandListEntry, "id" | "source">,
+  ) => {
+    const { v4 } = await import("uuid");
+    const full: CommandListEntry = { ...entry, id: v4(), source: "user" };
+    await controller.addCommandEntry(listName, full);
+  };
+
+  const handleEdit = async (listName: "allow" | "deny", entry: CommandListEntry) => {
+    await controller.updateCommandEntry(listName, entry);
+  };
+
+  const handleDelete = async (listName: "allow" | "deny", id: string) => {
+    await controller.removeCommandEntry(listName, id);
+  };
+
+  return (
+    <div className="settings-page__section-stack">
+      <CommandListSubpanel
+        title="Allow List"
+        description="Commands on this list are auto-approved when auto-run is set to Agent or Yes. Has no effect when auto-run is Off."
+        entries={controller.commandList.allow}
+        emptyIcon="check_circle"
+        emptyTitle="No allowed commands"
+        emptyDesc="Add commands to skip approval prompts when auto-run is active."
+        listName="allow"
+        onAdd={(l, e) => { void handleAdd(l, e); }}
+        onEdit={(l, e) => { void handleEdit(l, e); }}
+        onDelete={(l, id) => { void handleDelete(l, id); }}
+      />
+      <CommandListSubpanel
+        title="Deny List"
+        description="Commands on this list always prompt for approval with a danger warning, even in auto-run mode."
+        entries={controller.commandList.deny}
+        emptyIcon="block"
+        emptyTitle="No denied commands"
+        emptyDesc="Add commands that should always require user confirmation."
+        listName="deny"
+        onAdd={(l, e) => { void handleAdd(l, e); }}
+        onEdit={(l, e) => { void handleEdit(l, e); }}
+        onDelete={(l, id) => { void handleDelete(l, id); }}
+      />
+    </div>
+  );
+}
+
 function renderSection(
   sectionId: SettingsSectionId,
   controller: SettingsControllerValue,
@@ -1896,6 +2172,8 @@ function renderSection(
       return <McpServersSection controller={controller} />;
     case "voice":
       return <VoiceSection controller={controller} />;
+    case "command-list":
+      return <CommandListSection controller={controller} />;
     case "updates":
       return <UpdatesSection controller={controller} />;
     default:

--- a/src/components/settings/model.ts
+++ b/src/components/settings/model.ts
@@ -7,6 +7,7 @@ export type SettingsSectionId =
   | "providers"
   | "mcp"
   | "voice"
+  | "command-list"
   | "updates";
 
 export type SettingsSectionGroupId = "general" | "ai" | "app";
@@ -72,6 +73,13 @@ export const SETTINGS_SECTIONS: SettingsSectionDefinition[] = [
     label: "Voice Input",
     description: "Microphone access and Whisper model state.",
     icon: "mic",
+  },
+  {
+    id: "command-list",
+    groupId: "ai",
+    label: "Command List",
+    description: "Allow or deny commands for automatic approval control.",
+    icon: "shield",
   },
   {
     id: "updates",

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -10,13 +10,17 @@ import {
   globalCommunicationProfileAtom,
   voiceInputEnabledAtom,
   voiceModelPathAtom,
+  jotaiStore,
   type AppUpdaterState,
 } from "@/agent/atoms";
 import {
   providersAtom,
   profilesAtom,
+  commandListAtom,
   type ProviderInstance,
   type CommunicationProfileRecord,
+  type CommandList,
+  type CommandListEntry,
 } from "@/agent/db";
 import {
   mcpServersAtom,
@@ -87,6 +91,11 @@ export interface SettingsControllerValue {
   voiceDownloadStatus: VoiceDownloadStatus;
   voiceDownloadError: string | null;
   toggleVoiceInput: (next: boolean) => Promise<void>;
+  commandList: CommandList;
+  saveCommandList: (list: CommandList) => Promise<void>;
+  addCommandEntry: (list: "allow" | "deny", entry: CommandListEntry) => Promise<void>;
+  removeCommandEntry: (list: "allow" | "deny", id: string) => Promise<void>;
+  updateCommandEntry: (list: "allow" | "deny", entry: CommandListEntry) => Promise<void>;
   appUpdater: AppUpdaterState;
   checkForUpdates: () => Promise<void>;
   installUpdate: () => Promise<void>;
@@ -106,6 +115,7 @@ export function useSettingsController(): SettingsControllerValue {
     globalCommunicationProfileAtom,
   );
   const [customProfiles, setCustomProfiles] = useAtom(profilesAtom);
+  const [commandList, setCommandList] = useAtom(commandListAtom);
   const [appUpdater] = useAtom(appUpdaterStateAtom);
   const [notifyOnAttention, setNotifyOnAttention] = useAtom(
     notifyOnAttentionAtom,
@@ -139,6 +149,57 @@ export function useSettingsController(): SettingsControllerValue {
       setCustomProfiles(await loadProfiles());
     },
     [setCustomProfiles],
+  );
+
+  const handleSaveCommandList = useCallback(
+    async (list: CommandList) => {
+      const { saveCommandList } = await import("@/agent/db");
+      await saveCommandList(list);
+      setCommandList(list);
+    },
+    [setCommandList],
+  );
+
+  const handleAddCommandEntry = useCallback(
+    async (listName: "allow" | "deny", entry: CommandListEntry) => {
+      const current = jotaiStore.get(commandListAtom);
+      const next: CommandList = {
+        ...current,
+        [listName]: [...current[listName], entry],
+      };
+      const { saveCommandList } = await import("@/agent/db");
+      await saveCommandList(next);
+      setCommandList(next);
+    },
+    [setCommandList],
+  );
+
+  const handleRemoveCommandEntry = useCallback(
+    async (listName: "allow" | "deny", id: string) => {
+      const current = jotaiStore.get(commandListAtom);
+      const next: CommandList = {
+        ...current,
+        [listName]: current[listName].filter((e) => e.id !== id),
+      };
+      const { saveCommandList } = await import("@/agent/db");
+      await saveCommandList(next);
+      setCommandList(next);
+    },
+    [setCommandList],
+  );
+
+  const handleUpdateCommandEntry = useCallback(
+    async (listName: "allow" | "deny", entry: CommandListEntry) => {
+      const current = jotaiStore.get(commandListAtom);
+      const next: CommandList = {
+        ...current,
+        [listName]: current[listName].map((e) => (e.id === entry.id ? entry : e)),
+      };
+      const { saveCommandList } = await import("@/agent/db");
+      await saveCommandList(next);
+      setCommandList(next);
+    },
+    [setCommandList],
   );
 
   const envKeysAvailable = useEnvProviderKeys();
@@ -258,6 +319,11 @@ export function useSettingsController(): SettingsControllerValue {
     voiceDownloadStatus: effectiveVoiceDownloadStatus,
     voiceDownloadError,
     toggleVoiceInput,
+    commandList,
+    saveCommandList: handleSaveCommandList,
+    addCommandEntry: handleAddCommandEntry,
+    removeCommandEntry: handleRemoveCommandEntry,
+    updateCommandEntry: handleUpdateCommandEntry,
     appUpdater,
     checkForUpdates: handleCheckForUpdates,
     installUpdate: handleInstallUpdate,


### PR DESCRIPTION
## Summary
- add persisted command allow and deny lists with settings UI and dangerous command warnings in approval cards
- harden command matching for token boundaries and shell-wrapped commands, and seed conservative built-in allow/deny defaults
- cover the new approval and persistence flows with frontend and Rust tests, and fix the command-list form layout

## Testing
- npm run lint
- npm run typecheck
- npm run test
- cd src-tauri && cargo test

Fixes #106