### PR TITLE
feat(logging): add infrastructure-first structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ artifacts, and specialized subagents.
 - Automatic git worktree setup before agent-driven code changes
 - Built-in subagents for planning, review, security, copy, and GitHub tasks
 - Durable artifacts for plans, reports, and other structured outputs
+- Structured JSONL logging with per-run traces and backend persistence
 - Integrated terminal, voice input, theme system, and session restore
 
 ## Built with
@@ -58,6 +59,17 @@ Run the desktop app in development:
 
 ```bash
 npm run tauri:dev
+```
+
+Structured logs are written by the desktop runtime to:
+
+- release: `~/.rakh/logs/rakh.log`
+- debug: `~/.rakh-dev/logs/rakh.log`
+
+Example:
+
+```bash
+tail -f ~/.rakh/logs/rakh.log | grep '"tool-calls"'
 ```
 
 ## Provider setup
@@ -126,6 +138,7 @@ cd src-tauri && cargo test
 ## Docs
 
 - `docs/artifacts.md` - durable artifact model and validation flow
+- `docs/logging.md` - structured log schema, storage, query APIs, and CLI usage
 - `docs/macos-release-signing.md` - Apple signing and notarization credentials for macOS releases
 - `docs/subagents.md` - subagent registry, contracts, and execution model
 - `docs/tauri-updater-release.md` - updater signing, GitHub secrets, and rollout checks

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,7 @@
 
 - [`docs/architecture.md`](./architecture.md): system overview, runtime flow, and code map
 - [`docs/artifacts.md`](./artifacts.md): durable artifact model and validation flow
+- [`docs/logging.md`](./logging.md): structured log schema, storage, and query/export APIs
 - [`docs/subagents.md`](./subagents.md): subagent registry, contracts, and execution model
 
 ## Overview
@@ -31,8 +32,11 @@ graph TB
     Tauri --> SQLite["SQLite session + artifact DB"]
     Tauri --> Whisper["Whisper voice commands"]
     Runner --> Artifacts["Artifact wrappers"]
+    Runner --> Logs["Structured logger<br/>trace + correlation context"]
     Artifacts --> SQLite
+    Logs --> Tauri
     SQLite --> Blobs["Artifact blobs<br/>release: ~/.rakh/artifacts/blobs/sha256<br/>debug: ~/.rakh-dev/artifacts/blobs/sha256"]
+    Tauri --> LogFiles["JSONL logs<br/>release: ~/.rakh/logs/rakh.log<br/>debug: ~/.rakh-dev/logs/rakh.log"]
 ```
 
 ## Frontend architecture
@@ -125,6 +129,23 @@ High-level flow for a workspace turn:
 The runner supports multiple concurrent tabs by keeping a separate abort
 controller and run counter per tab.
 
+### Structured logging
+
+The runner and the backend command layer now share a structured log contract.
+Frontend events are emitted through [`src/logging/client.ts`](../src/logging/client.ts),
+which forwards entries to Tauri in desktop mode and falls back to structured
+console output in plain web mode.
+
+Trace propagation rules:
+
+- each main agent run gets a dedicated `traceId` derived from the `runId`
+- subagents derive child traces from the parent trace
+- tool call ids become `correlationId`
+- assistant message and stream lifecycle events attach to the same trace tree
+
+This gives one JSONL timeline across runner lifecycle events, tool dispatch,
+MCP transport, artifact persistence, and backend command execution.
+
 ### Tools, approvals, and review diffs
 
 Tool schemas live in
@@ -186,6 +207,8 @@ Current backend modules:
 - [`src-tauri/src/pty.rs`](../src-tauri/src/pty.rs): interactive terminal PTY
   lifecycle used by the xterm.js terminal
 - [`src-tauri/src/git.rs`](../src-tauri/src/git.rs): worktree creation command
+- [`src-tauri/src/logging.rs`](../src-tauri/src/logging.rs): JSONL log store,
+  rotation, query/export/clear commands, and `log_entry` event emission
 - [`src-tauri/src/mcp.rs`](../src-tauri/src/mcp.rs): global MCP config
   persistence plus per-run MCP transport/session management
 - [`src-tauri/src/whisper.rs`](../src-tauri/src/whisper.rs): local Whisper
@@ -198,6 +221,10 @@ The backend already uses Tauri events for streaming-style UI updates. PTY and
 exec output are emitted as app events, and artifact writes now emit an
 `artifact_changed` event after successful create/version persistence so the
 frontend can refresh the artifact pane without polling.
+
+Structured logging uses the same event channel pattern. Every successful write
+also emits a `log_entry` event so future log viewers or diagnostics panes can
+tail new entries without polling.
 
 ## Persistence and storage
 
@@ -213,6 +240,8 @@ Rakh persists data in multiple places by design:
 - debug/dev artifact content blobs: `~/.rakh-dev/artifacts/blobs/sha256`
 - release git worktrees created by the agent: `~/.rakh/worktrees/<owner>/<repo>/<branch>`
 - debug/dev git worktrees created by the agent: `~/.rakh-dev/worktrees/<owner>/<repo>/<branch>`
+- release structured logs: `~/.rakh/logs/rakh.log`
+- debug/dev structured logs: `~/.rakh-dev/logs/rakh.log`
 
 Session persistence is front-to-back:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,152 @@
+# Structured Logging
+
+Rakh now writes structured JSONL logs through a single backend-owned pipeline.
+Frontend and backend entries share the same schema and land in the same log
+files.
+
+## Log locations
+
+- release: `~/.rakh/logs/rakh.log`
+- debug / `npm run tauri:dev`: `~/.rakh-dev/logs/rakh.log`
+
+Exports are written under:
+
+- release: `~/.rakh/logs/exports/`
+- debug: `~/.rakh-dev/logs/exports/`
+
+The plain web Vite runtime does not persist logs to disk. It falls back to
+structured `console` output instead.
+
+## Rotation and retention
+
+- active file: `rakh.log`
+- archives: `rakh.log.1` through `rakh.log.5`
+- rotation threshold: `10 MiB`
+- retention: keep `5` archives
+
+In debug builds, each persisted JSONL line is also mirrored to `stderr` to keep
+local development ergonomics intact.
+
+## Entry schema
+
+Every log line is a JSON object with this shape:
+
+- `id`
+- `timestamp`
+- `timestampMs`
+- `level`
+- `source`
+- `tags`
+- `event`
+- `message`
+- `traceId?`
+- `correlationId?`
+- `parentId?`
+- `depth`
+- `kind`
+- `expandable`
+- `durationMs?`
+- `data?`
+
+### Field notes
+
+- `source`: `frontend` or `backend`
+- `level`: `trace`, `debug`, `info`, `warn`, `error`
+- `kind`: `start`, `end`, `event`, `error`
+- `traceId`: end-to-end execution trace. Main agent loops use the run id as the
+  base trace seed.
+- `correlationId`: tool-call level join key. Rakh uses tool call ids here.
+- `parentId`: logical parent log record for start/end trees.
+- `depth`: nesting level for runs, turns, tools, and subagents.
+- `data`: JSON-safe metadata only. Secrets and large binary payloads should stay
+  redacted or truncated.
+
+## Context schema
+
+Agent-originated calls can carry this shared context:
+
+- `sessionId?`
+- `tabId?`
+- `traceId?`
+- `correlationId?`
+- `parentId?`
+- `depth?`
+- `agentId?`
+- `toolName?`
+
+The runner threads this context into:
+
+- workspace tools
+- `exec_run`
+- `git_worktree_init`
+- MCP prepare/call/shutdown
+- artifact create/version/get/list
+
+## Canonical tags
+
+Issue `#133` keeps this v1 tag set:
+
+- `backend`
+- `frontend`
+- `db`
+- `streaming`
+- `tokens`
+- `tool-calls`
+- `agent-loop`
+- `messages`
+- `system`
+
+`streaming` and `tokens` entries are verbose logs and are only emitted when the
+session debug toggle is enabled.
+
+## Backend APIs
+
+The Tauri backend exposes:
+
+- `logs_write(entry)`
+- `logs_query(filter)`
+- `logs_export(filter)`
+- `logs_clear()`
+
+`logs_query()` supports:
+
+- `tags`
+- `tagMode: "and" | "or"`
+- `levels`
+- `traceId`
+- `correlationId`
+- `source`
+- `sinceMs`
+- `untilMs`
+- `limit`
+
+Query results are returned newest-first. The default limit is `500`.
+
+The backend also emits a live `log_entry` event after each successful write.
+
+## Operational usage
+
+Tail the active log:
+
+```bash
+tail -f ~/.rakh/logs/rakh.log
+```
+
+Filter tool-call activity:
+
+```bash
+tail -f ~/.rakh/logs/rakh.log | grep '"tool-calls"'
+```
+
+Filter one trace:
+
+```bash
+grep '"traceId":"trace:run_2026-03-12T00-00-00Z_0001:main"' ~/.rakh/logs/rakh.log
+```
+
+## Implementation map
+
+- frontend client: [`src/logging/client.ts`](../src/logging/client.ts)
+- shared TS types: [`src/logging/types.ts`](../src/logging/types.ts)
+- backend store and Tauri commands: [`src-tauri/src/logging.rs`](../src-tauri/src/logging.rs)
+- runner trace propagation: [`src/agent/runner.ts`](../src/agent/runner.ts)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -64,6 +64,7 @@ name = "app"
 version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
+ "chrono",
  "glob",
  "grep",
  "hound",
@@ -84,6 +85,8 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "vte",
  "whisper-rs",
@@ -2746,6 +2749,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5239,6 +5260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5565,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5701,6 +5770,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 rmcp = { version = "1.1.1", features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 vte = "0.15.0"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,6 +1,7 @@
+use crate::logging::LogContext;
 #[cfg(not(test))]
 use crate::shell_env::{login_shell_candidates, run_login_shell_script};
-use crate::utils::{app_store_root, non_empty_env_var, now_ms, tool_log};
+use crate::utils::{app_store_root, non_empty_env_var, now_ms, tool_log, tool_log_with_context};
 use portable_pty::MasterPty;
 use rusqlite::{params, types::Value as SqlValue, Connection, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
@@ -710,12 +711,14 @@ pub fn init_db() -> Result<Connection, String> {
     );
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN show_debug INTEGER NOT NULL DEFAULT 0;");
-    let _ = conn
-        .execute_batch("ALTER TABLE sessions ADD COLUMN queued_messages TEXT NOT NULL DEFAULT '[]';");
+    let _ = conn.execute_batch(
+        "ALTER TABLE sessions ADD COLUMN queued_messages TEXT NOT NULL DEFAULT '[]';",
+    );
     let _ = conn
         .execute_batch("ALTER TABLE sessions ADD COLUMN queue_state TEXT NOT NULL DEFAULT 'idle';");
-    let _ = conn
-        .execute_batch("ALTER TABLE sessions ADD COLUMN communication_profile TEXT NOT NULL DEFAULT 'pragmatic';");
+    let _ = conn.execute_batch(
+        "ALTER TABLE sessions ADD COLUMN communication_profile TEXT NOT NULL DEFAULT 'pragmatic';",
+    );
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS artifact_blobs (
@@ -1111,9 +1114,10 @@ pub fn db_artifact_create(
     input: ArtifactCreateInput,
     app_handle: AppHandle,
     state: State<'_, AppState>,
+    log_context: Option<LogContext>,
 ) -> Result<ArtifactManifest, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "db_artifact_create",
         "start",
         json!({
@@ -1123,6 +1127,7 @@ pub fn db_artifact_create(
             "kind": input.kind,
             "contentFormat": input.content_format
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<ArtifactManifest, String> = (|| {
@@ -1211,7 +1216,7 @@ pub fn db_artifact_create(
         Ok(v) => {
             let payload = artifact_change_event_from_manifest(v, ArtifactChangeKind::Created);
             let _ = app_handle.emit("artifact_changed", &payload);
-            tool_log(
+            tool_log_with_context(
                 "db_artifact_create",
                 "ok",
                 json!({
@@ -1220,15 +1225,17 @@ pub fn db_artifact_create(
                     "version": v.version,
                     "blobHash": v.blob_hash
                 }),
+                log_context.as_ref(),
             )
         }
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "db_artifact_create",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -1243,9 +1250,10 @@ pub fn db_artifact_version(
     input: ArtifactVersionInput,
     app_handle: AppHandle,
     state: State<'_, AppState>,
+    log_context: Option<LogContext>,
 ) -> Result<ArtifactManifest, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "db_artifact_version",
         "start",
         json!({
@@ -1254,6 +1262,7 @@ pub fn db_artifact_version(
             "agentId": agent_id,
             "artifactId": input.artifact_id
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<ArtifactManifest, String> = (|| {
@@ -1352,7 +1361,7 @@ pub fn db_artifact_version(
         Ok(v) => {
             let payload = artifact_change_event_from_manifest(v, ArtifactChangeKind::Versioned);
             let _ = app_handle.emit("artifact_changed", &payload);
-            tool_log(
+            tool_log_with_context(
                 "db_artifact_version",
                 "ok",
                 json!({
@@ -1361,15 +1370,17 @@ pub fn db_artifact_version(
                     "version": v.version,
                     "blobHash": v.blob_hash
                 }),
+                log_context.as_ref(),
             )
         }
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "db_artifact_version",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -1383,9 +1394,10 @@ pub fn db_artifact_get(
     version: Option<i64>,
     include_content: Option<bool>,
     state: State<'_, AppState>,
+    log_context: Option<LogContext>,
 ) -> Result<ArtifactManifest, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "db_artifact_get",
         "start",
         json!({
@@ -1393,6 +1405,7 @@ pub fn db_artifact_get(
             "artifactId": artifact_id,
             "version": version
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<ArtifactManifest, String> = (|| {
@@ -1435,7 +1448,7 @@ pub fn db_artifact_get(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "db_artifact_get",
             "ok",
             json!({
@@ -1443,14 +1456,16 @@ pub fn db_artifact_get(
                 "artifactId": v.artifact_id,
                 "version": v.version
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "db_artifact_get",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -1462,9 +1477,10 @@ pub fn db_artifact_list(
     session_id: String,
     input: ArtifactListInput,
     state: State<'_, AppState>,
+    log_context: Option<LogContext>,
 ) -> Result<Vec<ArtifactManifest>, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "db_artifact_list",
         "start",
         json!({
@@ -1475,6 +1491,7 @@ pub fn db_artifact_list(
             "latestOnly": input.latest_only,
             "limit": input.limit
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Vec<ArtifactManifest>, String> = (|| {
@@ -1541,21 +1558,23 @@ pub fn db_artifact_list(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "db_artifact_list",
             "ok",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "count": v.len()
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "db_artifact_list",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -1624,7 +1643,11 @@ pub fn providers_load() -> Result<Vec<ProviderRecord>, String> {
     tool_log("providers_load", "start", json!({}));
     let path = providers_config_path()?;
     if !path.exists() {
-        tool_log("providers_load", "ok", json!({ "count": 0, "reason": "file_absent" }));
+        tool_log(
+            "providers_load",
+            "ok",
+            json!({ "count": 0, "reason": "file_absent" }),
+        );
         return Ok(vec![]);
     }
     let raw =
@@ -1637,7 +1660,11 @@ pub fn providers_load() -> Result<Vec<ProviderRecord>, String> {
 
 #[tauri::command]
 pub fn providers_save(providers: Vec<ProviderRecord>) -> Result<(), String> {
-    tool_log("providers_save", "start", json!({ "count": providers.len() }));
+    tool_log(
+        "providers_save",
+        "start",
+        json!({ "count": providers.len() }),
+    );
     let path = providers_config_path()?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1861,20 +1888,32 @@ pub fn command_list_load() -> Result<CommandListRecord, String> {
         };
         // Write defaults to disk so future loads are idempotent.
         let _ = command_list_save(defaults.clone());
-        tool_log("command_list_load", "ok", json!({ "reason": "defaults_written", "allowCount": defaults.allow.len(), "denyCount": defaults.deny.len() }));
+        tool_log(
+            "command_list_load",
+            "ok",
+            json!({ "reason": "defaults_written", "allowCount": defaults.allow.len(), "denyCount": defaults.deny.len() }),
+        );
         return Ok(defaults);
     }
     let raw = fs::read_to_string(&path)
         .map_err(|e| format!("INTERNAL: cannot read command list: {}", e))?;
     let record: CommandListRecord = serde_json::from_str(&raw)
         .map_err(|e| format!("INTERNAL: cannot parse command list: {}", e))?;
-    tool_log("command_list_load", "ok", json!({ "allowCount": record.allow.len(), "denyCount": record.deny.len() }));
+    tool_log(
+        "command_list_load",
+        "ok",
+        json!({ "allowCount": record.allow.len(), "denyCount": record.deny.len() }),
+    );
     Ok(record)
 }
 
 #[tauri::command]
 pub fn command_list_save(list: CommandListRecord) -> Result<(), String> {
-    tool_log("command_list_save", "start", json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }));
+    tool_log(
+        "command_list_save",
+        "start",
+        json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }),
+    );
     let path = command_list_config_path()?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1895,7 +1934,11 @@ pub fn command_list_save(list: CommandListRecord) -> Result<(), String> {
             }
         }
     }
-    tool_log("command_list_save", "ok", json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }));
+    tool_log(
+        "command_list_save",
+        "ok",
+        json!({ "allowCount": list.allow.len(), "denyCount": list.deny.len() }),
+    );
     Ok(())
 }
 
@@ -1936,14 +1979,18 @@ pub fn profiles_load() -> Result<Vec<CommunicationProfileRecord>, String> {
             },
         ];
         // We will do a full population of the snippets in the next step
-        tool_log("profiles_load", "ok", json!({ "count": default_profiles.len(), "reason": "defaults_created" }));
-        
+        tool_log(
+            "profiles_load",
+            "ok",
+            json!({ "count": default_profiles.len(), "reason": "defaults_created" }),
+        );
+
         let _ = profiles_save(default_profiles.clone());
-        
+
         return Ok(default_profiles);
     }
-    let raw = fs::read_to_string(&path)
-        .map_err(|e| format!("INTERNAL: cannot read profiles: {}", e))?;
+    let raw =
+        fs::read_to_string(&path).map_err(|e| format!("INTERNAL: cannot read profiles: {}", e))?;
     let records: Vec<CommunicationProfileRecord> = serde_json::from_str(&raw)
         .map_err(|e| format!("INTERNAL: cannot parse profiles: {}", e))?;
     tool_log("profiles_load", "ok", json!({ "count": records.len() }));
@@ -2299,7 +2346,10 @@ mod tests {
 
     #[test]
     fn test_artifact_dedup_version_and_gc() {
-        let _guard = HOME_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _guard = HOME_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
 
         let tmp = tempdir().unwrap();
         let prev_home = std::env::var("HOME").ok();
@@ -2402,8 +2452,7 @@ mod tests {
             content: None,
         };
 
-        let event =
-            artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Created);
+        let event = artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Created);
 
         assert_eq!(
             serde_json::to_value(event).unwrap(),
@@ -2440,8 +2489,7 @@ mod tests {
             content: None,
         };
 
-        let event =
-            artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Versioned);
+        let event = artifact_change_event_from_manifest(&manifest, ArtifactChangeKind::Versioned);
 
         assert_eq!(
             serde_json::to_value(event).unwrap(),
@@ -2469,15 +2517,27 @@ mod tests {
         std::env::set_var("HOME", tmp.path());
 
         let result = command_list_load().expect("command_list_load should not error");
-        assert!(!result.allow.is_empty(), "Allow list should have safe default entries");
-        assert!(!result.deny.is_empty(), "Deny list should have default entries");
         assert!(
-            result.allow.iter().any(|entry| entry.pattern == "git status"),
+            !result.allow.is_empty(),
+            "Allow list should have safe default entries"
+        );
+        assert!(
+            !result.deny.is_empty(),
+            "Deny list should have default entries"
+        );
+        assert!(
+            result
+                .allow
+                .iter()
+                .any(|entry| entry.pattern == "git status"),
             "Safe git status should be included by default"
         );
         // Check that the file was written to disk
         let path = command_list_config_path().unwrap();
-        assert!(path.exists(), "command-list.json should be written on first load");
+        assert!(
+            path.exists(),
+            "command-list.json should be written on first load"
+        );
 
         match prev_home {
             Some(v) => std::env::set_var("HOME", v),

--- a/src-tauri/src/exec.rs
+++ b/src-tauri/src/exec.rs
@@ -1,5 +1,6 @@
+use crate::logging::LogContext;
 use crate::shell_env::resolved_login_shell_env;
-use crate::utils::{tool_log, truncate_bytes};
+use crate::utils::{tool_log, tool_log_with_context, truncate_bytes};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
@@ -167,6 +168,7 @@ pub async fn exec_run_inner(
     max_stderr_bytes: usize,
     stdin: Option<String>,
     run_id: Option<String>,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let start = Instant::now();
@@ -187,7 +189,7 @@ pub async fn exec_run_inner(
 
         let env_keys: Vec<String> = env.keys().cloned().collect();
 
-        tool_log(
+        tool_log_with_context(
             "exec_run",
             "start",
             json!({
@@ -203,6 +205,7 @@ pub async fn exec_run_inner(
                 "resolvedBin": resolved_bin,
                 "path": path_env
             }),
+            log_context.as_ref(),
         );
 
         if !command_uses_explicit_path(&command) && resolved_program.is_none() {
@@ -212,7 +215,7 @@ pub async fn exec_run_inner(
                 format!("Command failed to start: {:?} not found in PATH", command)
             };
 
-            tool_log(
+            tool_log_with_context(
                 "exec_run",
                 "err",
                 json!({
@@ -221,6 +224,7 @@ pub async fn exec_run_inner(
                     "ioErrorKind": format!("{:?}", std::io::ErrorKind::NotFound),
                     "cwdExists": cwd_exists
                 }),
+                log_context.as_ref(),
             );
 
             return Err(msg);
@@ -277,7 +281,7 @@ pub async fn exec_run_inner(
                 format!("Command failed to start: {}", e)
             };
 
-            tool_log(
+            tool_log_with_context(
                 "exec_run",
                 "err",
                 json!({
@@ -286,6 +290,7 @@ pub async fn exec_run_inner(
                     "ioErrorKind": format!("{:?}", kind),
                     "cwdExists": cwd_exists
                 }),
+                log_context.as_ref(),
             );
 
             msg
@@ -477,7 +482,7 @@ pub async fn exec_run_inner(
             "terminatedByUser": terminated_by_user,
         });
 
-        tool_log(
+        tool_log_with_context(
             "exec_run",
             "ok",
             json!({
@@ -489,6 +494,7 @@ pub async fn exec_run_inner(
                 "truncatedStderr": trunc_err,
                 "terminatedByUser": terminated_by_user
             }),
+            log_context.as_ref(),
         );
 
         Ok(result)
@@ -509,6 +515,7 @@ pub async fn exec_run(
     max_stderr_bytes: usize,
     stdin: Option<String>,
     run_id: Option<String>,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     exec_run_inner(
         Some(app),
@@ -521,6 +528,7 @@ pub async fn exec_run(
         max_stderr_bytes,
         stdin,
         run_id,
+        log_context,
     )
     .await
 }
@@ -691,6 +699,7 @@ mod tests {
             1024,
             None,
             None,
+            None,
         ))
         .unwrap();
         assert_eq!(res["exitCode"], 0);
@@ -709,6 +718,7 @@ mod tests {
             1024,
             None,
             None,
+            None,
         ))
         .unwrap();
         assert_eq!(fail_res["exitCode"], 42);
@@ -723,6 +733,7 @@ mod tests {
             100,
             1024,
             1024,
+            None,
             None,
             None,
         ));

--- a/src-tauri/src/fs_ops.rs
+++ b/src-tauri/src/fs_ops.rs
@@ -1,5 +1,6 @@
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-use crate::utils::tool_log;
+use crate::logging::LogContext;
+use crate::utils::{tool_log, tool_log_with_context};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::{json, Value};
 use std::fs;
 use std::io::{self, BufRead, Read};
@@ -7,9 +8,14 @@ use std::path::PathBuf;
 use std::time::{Instant, UNIX_EPOCH};
 
 #[tauri::command]
-pub fn list_dir(path: String, include_hidden: bool, max_entries: usize) -> Result<Value, String> {
+pub fn list_dir(
+    path: String,
+    include_hidden: bool,
+    max_entries: usize,
+    log_context: Option<LogContext>,
+) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "list_dir",
         "start",
         json!({
@@ -17,6 +23,7 @@ pub fn list_dir(path: String, include_hidden: bool, max_entries: usize) -> Resul
             "includeHidden": include_hidden,
             "maxEntries": max_entries
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -67,7 +74,7 @@ pub fn list_dir(path: String, include_hidden: bool, max_entries: usize) -> Resul
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "list_dir",
             "ok",
             json!({
@@ -75,14 +82,16 @@ pub fn list_dir(path: String, include_hidden: bool, max_entries: usize) -> Resul
                 "entryCount": v["entries"].as_array().map(|a| a.len()).unwrap_or(0),
                 "truncated": v["truncated"]
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "list_dir",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -90,9 +99,14 @@ pub fn list_dir(path: String, include_hidden: bool, max_entries: usize) -> Resul
 }
 
 #[tauri::command]
-pub fn stat_file(path: String) -> Result<Value, String> {
+pub fn stat_file(path: String, log_context: Option<LogContext>) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log("stat_file", "start", json!({ "path": path }));
+    tool_log_with_context(
+        "stat_file",
+        "start",
+        json!({ "path": path }),
+        log_context.as_ref(),
+    );
 
     let result: Result<Value, String> = (|| {
         let p = PathBuf::from(&path);
@@ -127,7 +141,7 @@ pub fn stat_file(path: String) -> Result<Value, String> {
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "stat_file",
             "ok",
             json!({
@@ -135,14 +149,16 @@ pub fn stat_file(path: String) -> Result<Value, String> {
                 "exists": v["exists"],
                 "kind": v.get("kind").cloned().unwrap_or(json!(null))
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "stat_file",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -155,9 +171,10 @@ pub fn read_file(
     start_line: Option<u64>,
     end_line: Option<u64>,
     max_bytes: u64,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "read_file",
         "start",
         json!({
@@ -166,6 +183,7 @@ pub fn read_file(
             "endLine": end_line,
             "maxBytes": max_bytes
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -231,7 +249,7 @@ pub fn read_file(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "read_file",
             "ok",
             json!({
@@ -240,14 +258,16 @@ pub fn read_file(
                 "truncated": v["truncated"],
                 "contentBytes": v["content"].as_str().map(|s| s.len()).unwrap_or(0)
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "read_file",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -260,9 +280,10 @@ pub fn write_file(
     content: String,
     mode: String,
     create_dirs: bool,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "write_file",
         "start",
         json!({
@@ -271,6 +292,7 @@ pub fn write_file(
             "createDirs": create_dirs,
             "contentBytes": content.as_bytes().len()
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -302,7 +324,7 @@ pub fn write_file(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "write_file",
             "ok",
             json!({
@@ -311,14 +333,16 @@ pub fn write_file(
                 "created": v["created"],
                 "overwritten": v["overwritten"]
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "write_file",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -359,9 +383,10 @@ pub fn glob_files(
     max_matches: usize,
     include_dirs: bool,
     include_hidden: bool,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "glob_files",
         "start",
         json!({
@@ -371,6 +396,7 @@ pub fn glob_files(
             "includeDirs": include_dirs,
             "includeHidden": include_hidden
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -449,7 +475,7 @@ pub fn glob_files(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "glob_files",
             "ok",
             json!({
@@ -457,14 +483,16 @@ pub fn glob_files(
                 "matchCount": v["matches"].as_array().map(|a| a.len()).unwrap_or(0),
                 "truncated": v["truncated"]
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "glob_files",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -548,9 +576,10 @@ pub fn search_files_grep(
     include_hidden: bool,
     context_lines: usize,
     follow_symlinks: bool,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "search_files_grep",
         "start",
         json!({
@@ -564,6 +593,7 @@ pub fn search_files_grep(
             "contextLines": context_lines,
             "followSymlinks": follow_symlinks
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -740,7 +770,7 @@ pub fn search_files_grep(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "search_files_grep",
             "ok",
             json!({
@@ -749,14 +779,16 @@ pub fn search_files_grep(
                 "searchedFiles": v["searchedFiles"],
                 "truncated": v["truncated"]
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "search_files_grep",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 
@@ -808,6 +840,7 @@ mod tests {
             "hello world\nline2".to_string(),
             "create".to_string(),
             false,
+            None,
         )
         .unwrap();
         assert_eq!(write_res["created"], true);
@@ -820,22 +853,29 @@ mod tests {
             "fail".to_string(),
             "create".to_string(),
             false,
+            None,
         );
         assert!(fail_res.is_err());
 
         // 3. Test reading the entire file
-        let read_res = read_file(path_str.clone(), None, None, 1000).unwrap();
+        let read_res = read_file(path_str.clone(), None, None, 1000, None).unwrap();
         assert_eq!(read_res["content"], "hello world\nline2");
         assert_eq!(read_res["truncated"], false);
 
         // 4. Test reading with line ranges
-        let read_line_res = read_file(path_str.clone(), Some(1), Some(1), 1000).unwrap();
+        let read_line_res = read_file(path_str.clone(), Some(1), Some(1), 1000, None).unwrap();
         assert_eq!(read_line_res["content"], "hello world");
         assert_eq!(read_line_res["lineCount"], 2);
 
         // 5. Test reading a missing file should error
         let missing_path = dir.path().join("does_not_exist.txt");
-        let missing_res = read_file(missing_path.to_string_lossy().to_string(), None, None, 1000);
+        let missing_res = read_file(
+            missing_path.to_string_lossy().to_string(),
+            None,
+            None,
+            1000,
+            None,
+        );
         assert!(missing_res.is_err());
     }
 
@@ -850,13 +890,13 @@ mod tests {
         let path_str = dir.path().to_string_lossy().to_string();
 
         // 1. Without hidden files
-        let res1 = list_dir(path_str.clone(), false, 100).unwrap();
+        let res1 = list_dir(path_str.clone(), false, 100, None).unwrap();
         let entries = res1["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["name"], "test.txt");
 
         // 2. With hidden files
-        let res2 = list_dir(path_str.clone(), true, 100).unwrap();
+        let res2 = list_dir(path_str.clone(), true, 100, None).unwrap();
         let entries2 = res2["entries"].as_array().unwrap();
         assert_eq!(entries2.len(), 2);
     }
@@ -886,6 +926,7 @@ mod tests {
             100,
             false,
             false,
+            None,
         )
         .unwrap();
         let matches: Vec<&str> = res["matches"]
@@ -912,6 +953,7 @@ mod tests {
             100,
             false,
             false,
+            None,
         )
         .unwrap();
         let all_matches: Vec<&str> = res_all["matches"]
@@ -942,6 +984,7 @@ mod tests {
             100,
             false,
             false,
+            None,
         )
         .unwrap();
         let neg_matches: Vec<&str> = res_neg["matches"]
@@ -957,8 +1000,15 @@ mod tests {
         );
 
         // 4. include_hidden enables hidden file/dir matches
-        let res_hidden =
-            glob_files(vec!["**/*".to_string()], path_str.clone(), 100, false, true).unwrap();
+        let res_hidden = glob_files(
+            vec!["**/*".to_string()],
+            path_str.clone(),
+            100,
+            false,
+            true,
+            None,
+        )
+        .unwrap();
         let hidden_matches: Vec<&str> = res_hidden["matches"]
             .as_array()
             .unwrap()
@@ -975,8 +1025,15 @@ mod tests {
         );
 
         // 5. max_matches truncation
-        let res_trunc =
-            glob_files(vec!["*.rs".to_string()], path_str.clone(), 1, false, false).unwrap();
+        let res_trunc = glob_files(
+            vec!["*.rs".to_string()],
+            path_str.clone(),
+            1,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
         assert_eq!(res_trunc["truncated"], true);
         assert_eq!(res_trunc["matches"].as_array().unwrap().len(), 1);
     }
@@ -1016,6 +1073,7 @@ mod tests {
             false,
             0,
             false,
+            None,
         )
         .unwrap();
         let grep_matches = grep_res["matches"].as_array().unwrap();

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,4 +1,5 @@
-use crate::utils::{app_store_root, tool_log};
+use crate::logging::LogContext;
+use crate::utils::{app_store_root, tool_log_with_context};
 use serde_json::{json, Value};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -78,9 +79,10 @@ pub fn git_worktree_add(
     repo_path: String,
     repo_slug: String,
     branch: String,
+    log_context: Option<LogContext>,
 ) -> Result<Value, String> {
     let start = Instant::now();
-    tool_log(
+    tool_log_with_context(
         "git_worktree_add",
         "start",
         json!({
@@ -88,6 +90,7 @@ pub fn git_worktree_add(
             "repoSlug": repo_slug,
             "branch": branch
         }),
+        log_context.as_ref(),
     );
 
     let result: Result<Value, String> = (|| {
@@ -135,7 +138,7 @@ pub fn git_worktree_add(
     })();
 
     match &result {
-        Ok(v) => tool_log(
+        Ok(v) => tool_log_with_context(
             "git_worktree_add",
             "ok",
             json!({
@@ -143,14 +146,16 @@ pub fn git_worktree_add(
                 "path": v["path"],
                 "branch": v["branch"]
             }),
+            log_context.as_ref(),
         ),
-        Err(e) => tool_log(
+        Err(e) => tool_log_with_context(
             "git_worktree_add",
             "err",
             json!({
                 "durationMs": start.elapsed().as_millis() as u64,
                 "error": e
             }),
+            log_context.as_ref(),
         ),
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ pub mod exec;
 pub mod external_tools;
 pub mod fs_ops;
 pub mod git;
+pub mod logging;
 pub mod mcp;
 pub mod pty;
 pub mod shell_env;
@@ -10,6 +11,7 @@ pub mod utils;
 pub mod whisper;
 
 use db::{init_db, AppState};
+use logging::init_runtime_logging;
 use mcp::McpRunState;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -26,6 +28,7 @@ pub fn run() {
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
+            init_runtime_logging(app.handle().clone())?;
             Ok(())
         })
         .manage(AppState {
@@ -71,6 +74,10 @@ pub fn run() {
             db::profiles_save,
             db::command_list_load,
             db::command_list_save,
+            logging::logs_write,
+            logging::logs_query,
+            logging::logs_export,
+            logging::logs_clear,
             mcp::mcp_servers_load,
             mcp::mcp_settings_load,
             mcp::mcp_servers_save,

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,0 +1,927 @@
+use crate::utils::{app_store_root, now_ms};
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use tauri::{AppHandle, Emitter};
+use tracing_subscriber::filter::LevelFilter;
+use uuid::Uuid;
+
+const ACTIVE_LOG_NAME: &str = "rakh.log";
+const LOG_ROTATE_BYTES: u64 = 10 * 1024 * 1024;
+const LOG_ARCHIVE_COUNT: usize = 5;
+const DEFAULT_QUERY_LIMIT: usize = 500;
+
+static LOG_STORE: OnceLock<Arc<LogStore>> = OnceLock::new();
+static TRACING_INIT: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogSource {
+    Backend,
+    Frontend,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogKind {
+    Start,
+    End,
+    Event,
+    Error,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TagMode {
+    And,
+    Or,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogEntry {
+    pub id: String,
+    pub timestamp: String,
+    pub timestamp_ms: i64,
+    pub level: LogLevel,
+    pub source: LogSource,
+    pub tags: Vec<String>,
+    pub event: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    pub depth: u32,
+    pub kind: LogKind,
+    pub expandable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogQueryFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_mode: Option<TagMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub levels: Option<Vec<LogLevel>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<LogSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub until_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogExportResult {
+    pub path: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogClearResult {
+    pub removed_files: usize,
+}
+
+#[derive(Debug)]
+pub struct LogStore {
+    logs_dir: PathBuf,
+    exports_dir: PathBuf,
+    active_path: PathBuf,
+    app_handle: Mutex<Option<AppHandle>>,
+    write_lock: Mutex<()>,
+}
+
+impl LogStore {
+    pub fn new(logs_dir: PathBuf) -> Result<Self, String> {
+        fs::create_dir_all(&logs_dir)
+            .map_err(|error| format!("Cannot create logs dir {}: {}", logs_dir.display(), error))?;
+        let exports_dir = logs_dir.join("exports");
+        fs::create_dir_all(&exports_dir).map_err(|error| {
+            format!(
+                "Cannot create log export dir {}: {}",
+                exports_dir.display(),
+                error
+            )
+        })?;
+
+        Ok(Self {
+            active_path: logs_dir.join(ACTIVE_LOG_NAME),
+            logs_dir,
+            exports_dir,
+            app_handle: Mutex::new(None),
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    pub fn runtime_logs_dir() -> Result<PathBuf, String> {
+        Ok(app_store_root()?.join("logs"))
+    }
+
+    pub fn set_app_handle(&self, app_handle: AppHandle) {
+        *self.app_handle.lock().unwrap() = Some(app_handle);
+    }
+
+    pub fn active_path(&self) -> &Path {
+        &self.active_path
+    }
+
+    fn archived_path(&self, index: usize) -> PathBuf {
+        self.logs_dir.join(format!("{}.{}", ACTIVE_LOG_NAME, index))
+    }
+
+    fn all_paths(&self) -> Vec<PathBuf> {
+        let mut paths = vec![self.active_path.clone()];
+        for index in 1..=LOG_ARCHIVE_COUNT {
+            paths.push(self.archived_path(index));
+        }
+        paths
+    }
+
+    fn rotate_if_needed(&self, pending_bytes: u64) -> Result<(), String> {
+        let current_size = fs::metadata(&self.active_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        if current_size + pending_bytes <= LOG_ROTATE_BYTES {
+            return Ok(());
+        }
+
+        let oldest = self.archived_path(LOG_ARCHIVE_COUNT);
+        if oldest.exists() {
+            fs::remove_file(&oldest).map_err(|error| {
+                format!("Cannot remove archived log {}: {}", oldest.display(), error)
+            })?;
+        }
+
+        for index in (1..LOG_ARCHIVE_COUNT).rev() {
+            let src = self.archived_path(index);
+            if !src.exists() {
+                continue;
+            }
+            let dst = self.archived_path(index + 1);
+            fs::rename(&src, &dst).map_err(|error| {
+                format!(
+                    "Cannot rotate log archive {} -> {}: {}",
+                    src.display(),
+                    dst.display(),
+                    error
+                )
+            })?;
+        }
+
+        if self.active_path.exists() {
+            let dst = self.archived_path(1);
+            fs::rename(&self.active_path, &dst).map_err(|error| {
+                format!(
+                    "Cannot rotate active log {} -> {}: {}",
+                    self.active_path.display(),
+                    dst.display(),
+                    error
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    pub fn append_entry(&self, entry: LogEntry) -> Result<(), String> {
+        let _guard = self.write_lock.lock().unwrap();
+        let normalized = normalize_entry(entry);
+        let line = serde_json::to_string(&normalized)
+            .map_err(|error| format!("Cannot serialize log entry: {}", error))?;
+        self.rotate_if_needed((line.len() + 1) as u64)?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.active_path)
+            .map_err(|error| {
+                format!(
+                    "Cannot open active log {}: {}",
+                    self.active_path.display(),
+                    error
+                )
+            })?;
+        file.write_all(line.as_bytes())
+            .and_then(|_| file.write_all(b"\n"))
+            .map_err(|error| {
+                format!(
+                    "Cannot append to active log {}: {}",
+                    self.active_path.display(),
+                    error
+                )
+            })?;
+        file.flush().map_err(|error| {
+            format!(
+                "Cannot flush active log {}: {}",
+                self.active_path.display(),
+                error
+            )
+        })?;
+
+        if cfg!(debug_assertions) {
+            eprintln!("{}", line);
+        }
+
+        if let Some(app_handle) = self.app_handle.lock().unwrap().clone() {
+            let _ = app_handle.emit("log_entry", &normalized);
+        }
+        Ok(())
+    }
+
+    fn read_entries_from_path(path: &Path) -> Result<Vec<LogEntry>, String> {
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(path)
+            .map_err(|error| format!("Cannot open log file {}: {}", path.display(), error))?;
+        let reader = BufReader::new(file);
+        let mut entries = Vec::new();
+        for line in reader.lines() {
+            let line = line.map_err(|error| {
+                format!("Cannot read log line from {}: {}", path.display(), error)
+            })?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<LogEntry>(trimmed) {
+                Ok(entry) => entries.push(normalize_entry(entry)),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "rakh::logging",
+                        path = %path.display(),
+                        error = %error,
+                        "Skipping malformed log entry"
+                    );
+                }
+            }
+        }
+        Ok(entries)
+    }
+
+    pub fn load_entries(&self) -> Result<Vec<LogEntry>, String> {
+        let _guard = self.write_lock.lock().unwrap();
+        let mut entries = Vec::new();
+        for path in self.all_paths() {
+            entries.extend(Self::read_entries_from_path(&path)?);
+        }
+        entries.sort_by(|left, right| {
+            right
+                .timestamp_ms
+                .cmp(&left.timestamp_ms)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+        Ok(entries)
+    }
+
+    pub fn query(&self, filter: LogQueryFilter) -> Result<Vec<LogEntry>, String> {
+        let limit = filter.limit.unwrap_or(DEFAULT_QUERY_LIMIT);
+        let tag_mode = filter.tag_mode.unwrap_or(TagMode::Or);
+        let filter_tags = normalize_tags(filter.tags.unwrap_or_default());
+        let entries = self
+            .load_entries()?
+            .into_iter()
+            .filter(|entry| {
+                if let Some(source) = &filter.source {
+                    if &entry.source != source {
+                        return false;
+                    }
+                }
+                if let Some(levels) = &filter.levels {
+                    if !levels.contains(&entry.level) {
+                        return false;
+                    }
+                }
+                if let Some(trace_id) = &filter.trace_id {
+                    if entry.trace_id.as_deref() != Some(trace_id.as_str()) {
+                        return false;
+                    }
+                }
+                if let Some(correlation_id) = &filter.correlation_id {
+                    if entry.correlation_id.as_deref() != Some(correlation_id.as_str()) {
+                        return false;
+                    }
+                }
+                if let Some(since_ms) = filter.since_ms {
+                    if entry.timestamp_ms < since_ms {
+                        return false;
+                    }
+                }
+                if let Some(until_ms) = filter.until_ms {
+                    if entry.timestamp_ms > until_ms {
+                        return false;
+                    }
+                }
+                if filter_tags.is_empty() {
+                    return true;
+                }
+                match tag_mode {
+                    TagMode::And => filter_tags.iter().all(|tag| entry.tags.contains(tag)),
+                    TagMode::Or => filter_tags.iter().any(|tag| entry.tags.contains(tag)),
+                }
+            })
+            .take(limit)
+            .collect();
+        Ok(entries)
+    }
+
+    pub fn export(&self, filter: LogQueryFilter) -> Result<LogExportResult, String> {
+        fs::create_dir_all(&self.exports_dir).map_err(|error| {
+            format!(
+                "Cannot create log export dir {}: {}",
+                self.exports_dir.display(),
+                error
+            )
+        })?;
+        let entries = self.query(filter)?;
+        let export_path = self
+            .exports_dir
+            .join(format!("rakh-logs-{}.jsonl", now_ms()));
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&export_path)
+            .map_err(|error| {
+                format!(
+                    "Cannot create log export {}: {}",
+                    export_path.display(),
+                    error
+                )
+            })?;
+        for entry in &entries {
+            let line = serde_json::to_string(entry)
+                .map_err(|error| format!("Cannot serialize log entry: {}", error))?;
+            file.write_all(line.as_bytes())
+                .and_then(|_| file.write_all(b"\n"))
+                .map_err(|error| {
+                    format!(
+                        "Cannot write log export {}: {}",
+                        export_path.display(),
+                        error
+                    )
+                })?;
+        }
+        file.flush().map_err(|error| {
+            format!(
+                "Cannot flush log export {}: {}",
+                export_path.display(),
+                error
+            )
+        })?;
+        Ok(LogExportResult {
+            path: export_path.to_string_lossy().to_string(),
+            count: entries.len(),
+        })
+    }
+
+    pub fn clear(&self) -> Result<LogClearResult, String> {
+        let _guard = self.write_lock.lock().unwrap();
+        let mut removed_files = 0usize;
+        for path in self.all_paths() {
+            if !path.exists() {
+                continue;
+            }
+            fs::remove_file(&path)
+                .map_err(|error| format!("Cannot remove log file {}: {}", path.display(), error))?;
+            removed_files += 1;
+        }
+        Ok(LogClearResult { removed_files })
+    }
+}
+
+fn current_timestamp_string() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    let mut normalized: Vec<String> = tags
+        .into_iter()
+        .map(|tag| tag.trim().to_lowercase())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn normalize_entry(mut entry: LogEntry) -> LogEntry {
+    if entry.id.trim().is_empty() {
+        entry.id = format!("log_{}", Uuid::new_v4().simple());
+    }
+    if entry.timestamp_ms <= 0 {
+        entry.timestamp_ms = now_ms();
+    }
+    if entry.timestamp.trim().is_empty() {
+        entry.timestamp = current_timestamp_string();
+    }
+    if entry.event.trim().is_empty() {
+        entry.event = "log.event".to_string();
+    }
+    if entry.message.trim().is_empty() {
+        entry.message = entry.event.clone();
+    }
+    entry.tags = normalize_tags(entry.tags);
+    if matches!(entry.data, Some(Value::Null)) {
+        entry.data = None;
+    }
+    entry
+}
+
+fn runtime_store() -> Result<&'static Arc<LogStore>, String> {
+    LOG_STORE
+        .get()
+        .ok_or_else(|| "Structured logging is not initialized".to_string())
+}
+
+fn default_backend_message(tool: &str, event: &str, data: &Map<String, Value>) -> String {
+    match event {
+        "start" => format!("{} started", tool),
+        "ok" => format!("{} completed", tool),
+        "err" => data
+            .get("error")
+            .and_then(Value::as_str)
+            .map(|error| format!("{} failed: {}", tool, error))
+            .unwrap_or_else(|| format!("{} failed", tool)),
+        _ => format!("{} {}", tool, event),
+    }
+}
+
+fn infer_backend_tags(tool: &str) -> Vec<String> {
+    let mut tags = vec!["backend".to_string(), "tool-calls".to_string()];
+    if tool.starts_with("db_")
+        || tool.starts_with("providers_")
+        || tool.starts_with("profiles_")
+        || tool.starts_with("command_list_")
+        || tool == "load_provider_env_api_keys"
+    {
+        tags.push("db".to_string());
+    } else {
+        tags.push("system".to_string());
+    }
+    tags
+}
+
+fn infer_kind(event: &str) -> LogKind {
+    match event {
+        "start" => LogKind::Start,
+        "ok" => LogKind::End,
+        "err" => LogKind::Error,
+        _ => LogKind::Event,
+    }
+}
+
+fn infer_level(event: &str) -> LogLevel {
+    match event {
+        "err" => LogLevel::Error,
+        _ => LogLevel::Info,
+    }
+}
+
+fn duration_from_map(data: &mut Map<String, Value>) -> Option<u64> {
+    data.remove("durationMs").and_then(|value| value.as_u64())
+}
+
+fn data_from_fields(fields: Value) -> Option<Value> {
+    match fields {
+        Value::Null => None,
+        Value::Object(map) if map.is_empty() => None,
+        Value::Object(map) => Some(Value::Object(map)),
+        other => Some(json!({ "data": other })),
+    }
+}
+
+fn next_backend_entry_id(tool: &str, event: &str, context: Option<&LogContext>) -> String {
+    if let Some(correlation_id) = context.and_then(|ctx| ctx.correlation_id.as_deref()) {
+        return format!(
+            "backend:{}:{}:{}",
+            tool,
+            event,
+            correlation_id.replace(':', "_")
+        );
+    }
+    format!("backend:{}:{}:{}", tool, event, Uuid::new_v4().simple())
+}
+
+pub fn build_backend_entry(
+    tool: &str,
+    event: &str,
+    fields: Value,
+    context: Option<&LogContext>,
+) -> LogEntry {
+    let mut data = match data_from_fields(fields) {
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            let mut map = Map::new();
+            map.insert("data".to_string(), other);
+            map
+        }
+        None => Map::new(),
+    };
+    let duration_ms = duration_from_map(&mut data);
+    let message = data
+        .remove("message")
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| default_backend_message(tool, event, &data));
+    let kind = infer_kind(event);
+    let data = if data.is_empty() {
+        None
+    } else {
+        Some(Value::Object(data))
+    };
+
+    LogEntry {
+        id: next_backend_entry_id(tool, event, context),
+        timestamp: current_timestamp_string(),
+        timestamp_ms: now_ms(),
+        level: infer_level(event),
+        source: LogSource::Backend,
+        tags: infer_backend_tags(tool),
+        event: format!("backend.{}.{}", tool, event),
+        message,
+        trace_id: context.and_then(|ctx| ctx.trace_id.clone()),
+        correlation_id: context.and_then(|ctx| ctx.correlation_id.clone()),
+        parent_id: context.and_then(|ctx| ctx.parent_id.clone()),
+        depth: context.and_then(|ctx| ctx.depth).unwrap_or(0),
+        kind: kind.clone(),
+        expandable: matches!(kind, LogKind::Start) || data.is_some(),
+        duration_ms,
+        data,
+    }
+}
+
+pub fn tool_logging_enabled() -> bool {
+    true
+}
+
+pub fn write_entry(entry: LogEntry) -> Result<(), String> {
+    runtime_store()?.append_entry(entry)
+}
+
+pub fn tool_log(tool: &str, event: &str, fields: Value) {
+    tool_log_with_context(tool, event, fields, None);
+}
+
+pub fn tool_log_with_context(tool: &str, event: &str, fields: Value, context: Option<&LogContext>) {
+    if let Err(error) = write_entry(build_backend_entry(tool, event, fields, context)) {
+        tracing::error!(
+            target: "rakh::logging",
+            tool = %tool,
+            event = %event,
+            error = %error,
+            "Failed to write structured backend log entry"
+        );
+    }
+}
+
+pub fn init_runtime_logging(app_handle: AppHandle) -> Result<Arc<LogStore>, String> {
+    let logs_dir = LogStore::runtime_logs_dir()?;
+    let store = if let Some(existing) = LOG_STORE.get() {
+        existing.clone()
+    } else {
+        let created = Arc::new(LogStore::new(logs_dir)?);
+        let _ = LOG_STORE.set(created.clone());
+        created
+    };
+    store.set_app_handle(app_handle);
+
+    TRACING_INIT.get_or_init(|| {
+        let max_level = if cfg!(debug_assertions) {
+            LevelFilter::DEBUG
+        } else {
+            LevelFilter::OFF
+        };
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(max_level)
+            .json()
+            .with_ansi(false)
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_target(true)
+            .try_init();
+    });
+
+    tracing::info!(
+        target: "rakh::logging",
+        path = %store.active_path().display(),
+        "Structured logging initialized"
+    );
+
+    Ok(store)
+}
+
+#[tauri::command]
+pub fn logs_write(entry: LogEntry) -> Result<(), String> {
+    write_entry(entry)
+}
+
+#[tauri::command]
+pub fn logs_query(filter: Option<LogQueryFilter>) -> Result<Vec<LogEntry>, String> {
+    runtime_store()?.query(filter.unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn logs_export(filter: Option<LogQueryFilter>) -> Result<LogExportResult, String> {
+    runtime_store()?.export(filter.unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn logs_clear() -> Result<LogClearResult, String> {
+    runtime_store()?.clear()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_entry(
+        id: &str,
+        tags: &[&str],
+        timestamp_ms: i64,
+        level: LogLevel,
+        source: LogSource,
+    ) -> LogEntry {
+        LogEntry {
+            id: id.to_string(),
+            timestamp: current_timestamp_string(),
+            timestamp_ms,
+            level,
+            source,
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            event: "test.event".to_string(),
+            message: "hello".to_string(),
+            trace_id: Some("trace-1".to_string()),
+            correlation_id: Some("corr-1".to_string()),
+            parent_id: Some("parent-1".to_string()),
+            depth: 2,
+            kind: LogKind::Event,
+            expandable: false,
+            duration_ms: Some(10),
+            data: Some(json!({ "ok": true })),
+        }
+    }
+
+    #[test]
+    fn new_store_sets_expected_paths() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        assert_eq!(
+            store.active_path(),
+            temp.path().join("logs").join("rakh.log")
+        );
+    }
+
+    #[test]
+    fn append_entry_writes_jsonl() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        store
+            .append_entry(sample_entry(
+                "entry-1",
+                &["backend", "tool-calls"],
+                1,
+                LogLevel::Info,
+                LogSource::Backend,
+            ))
+            .expect("append entry");
+
+        let content = fs::read_to_string(store.active_path()).expect("read active log");
+        let line = content.lines().next().expect("line");
+        let parsed: LogEntry = serde_json::from_str(line).expect("parse");
+        assert_eq!(parsed.id, "entry-1");
+        assert_eq!(parsed.tags, vec!["backend", "tool-calls"]);
+    }
+
+    #[test]
+    fn rotation_keeps_archive_count() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        fs::write(
+            store.active_path(),
+            "x".repeat((LOG_ROTATE_BYTES + 1) as usize),
+        )
+        .expect("write");
+        for index in 1..=LOG_ARCHIVE_COUNT {
+            fs::write(store.archived_path(index), format!("archive-{index}")).expect("archive");
+        }
+
+        store
+            .append_entry(sample_entry(
+                "entry-2",
+                &["backend"],
+                2,
+                LogLevel::Info,
+                LogSource::Backend,
+            ))
+            .expect("append");
+
+        assert!(store.archived_path(1).exists());
+        assert!(store.archived_path(LOG_ARCHIVE_COUNT).exists());
+        let archived = fs::read_to_string(store.archived_path(1)).expect("read archive");
+        assert!(archived.contains('x'));
+    }
+
+    #[test]
+    fn clear_removes_active_and_archives() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        fs::write(store.active_path(), "active").expect("write active");
+        fs::write(store.archived_path(1), "archive").expect("write archive");
+
+        let result = store.clear().expect("clear");
+
+        assert_eq!(result.removed_files, 2);
+        assert!(!store.active_path().exists());
+        assert!(!store.archived_path(1).exists());
+    }
+
+    #[test]
+    fn query_supports_and_or_tag_filters() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        store
+            .append_entry(sample_entry(
+                "entry-1",
+                &["backend", "db"],
+                10,
+                LogLevel::Info,
+                LogSource::Backend,
+            ))
+            .expect("append 1");
+        store
+            .append_entry(sample_entry(
+                "entry-2",
+                &["frontend", "system"],
+                20,
+                LogLevel::Warn,
+                LogSource::Frontend,
+            ))
+            .expect("append 2");
+
+        let or_filtered = store
+            .query(LogQueryFilter {
+                tags: Some(vec!["db".to_string(), "system".to_string()]),
+                tag_mode: Some(TagMode::Or),
+                ..LogQueryFilter::default()
+            })
+            .expect("or query");
+        assert_eq!(or_filtered.len(), 2);
+
+        let and_filtered = store
+            .query(LogQueryFilter {
+                tags: Some(vec!["backend".to_string(), "db".to_string()]),
+                tag_mode: Some(TagMode::And),
+                ..LogQueryFilter::default()
+            })
+            .expect("and query");
+        assert_eq!(and_filtered.len(), 1);
+        assert_eq!(and_filtered[0].id, "entry-1");
+    }
+
+    #[test]
+    fn query_filters_level_source_and_ids() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        store
+            .append_entry(sample_entry(
+                "entry-1",
+                &["backend"],
+                10,
+                LogLevel::Info,
+                LogSource::Backend,
+            ))
+            .expect("append 1");
+        store
+            .append_entry(sample_entry(
+                "entry-2",
+                &["frontend"],
+                20,
+                LogLevel::Warn,
+                LogSource::Frontend,
+            ))
+            .expect("append 2");
+
+        let filtered = store
+            .query(LogQueryFilter {
+                levels: Some(vec![LogLevel::Warn]),
+                source: Some(LogSource::Frontend),
+                trace_id: Some("trace-1".to_string()),
+                correlation_id: Some("corr-1".to_string()),
+                since_ms: Some(15),
+                until_ms: Some(25),
+                ..LogQueryFilter::default()
+            })
+            .expect("filtered query");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "entry-2");
+        assert_eq!(filtered[0].depth, 2);
+        assert_eq!(filtered[0].parent_id.as_deref(), Some("parent-1"));
+    }
+
+    #[test]
+    fn export_writes_filtered_jsonl_file() {
+        let temp = tempdir().expect("tempdir");
+        let store = LogStore::new(temp.path().join("logs")).expect("store");
+        store
+            .append_entry(sample_entry(
+                "entry-1",
+                &["backend", "db"],
+                10,
+                LogLevel::Info,
+                LogSource::Backend,
+            ))
+            .expect("append");
+
+        let exported = store
+            .export(LogQueryFilter {
+                tags: Some(vec!["db".to_string()]),
+                ..LogQueryFilter::default()
+            })
+            .expect("export");
+
+        assert_eq!(exported.count, 1);
+        let exported_content = fs::read_to_string(exported.path).expect("read export");
+        assert!(exported_content.contains("\"id\":\"entry-1\""));
+    }
+
+    #[test]
+    fn build_backend_entry_carries_trace_fields() {
+        let context = LogContext {
+            trace_id: Some("trace-main".to_string()),
+            correlation_id: Some("tool-1".to_string()),
+            parent_id: Some("tool:tool-1:start".to_string()),
+            depth: Some(3),
+            ..LogContext::default()
+        };
+
+        let entry = build_backend_entry(
+            "exec_run",
+            "ok",
+            json!({
+                "durationMs": 42,
+                "exitCode": 0
+            }),
+            Some(&context),
+        );
+
+        assert_eq!(entry.trace_id.as_deref(), Some("trace-main"));
+        assert_eq!(entry.correlation_id.as_deref(), Some("tool-1"));
+        assert_eq!(entry.parent_id.as_deref(), Some("tool:tool-1:start"));
+        assert_eq!(entry.depth, 3);
+        assert_eq!(entry.duration_ms, Some(42));
+        assert_eq!(entry.kind, LogKind::End);
+    }
+}

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,5 +1,6 @@
+use crate::logging::LogContext;
 use crate::shell_env::resolved_login_shell_env;
-use crate::utils::{app_store_root, now_ms, tool_log};
+use crate::utils::{app_store_root, now_ms, tool_log, tool_log_with_context};
 use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::model::{CallToolRequestParams, CallToolResult, Tool};
 use rmcp::service::RunningService;
@@ -85,9 +86,7 @@ impl McpServerRecord {
 
     fn timeout_ms(&self) -> u64 {
         let raw = match self {
-            Self::Stdio { timeout_ms, .. } | Self::StreamableHttp { timeout_ms, .. } => {
-                *timeout_ms
-            }
+            Self::Stdio { timeout_ms, .. } | Self::StreamableHttp { timeout_ms, .. } => *timeout_ms,
         };
 
         match raw {
@@ -238,7 +237,10 @@ fn save_mcp_config_to_path(path: &Path, config: &PersistedMcpConfigRecord) -> Re
                 let _ = fs::remove_file(&tmp);
                 Ok(())
             } else {
-                Err(format!("INTERNAL: cannot rename MCP server file: {}", error))
+                Err(format!(
+                    "INTERNAL: cannot rename MCP server file: {}",
+                    error
+                ))
             }
         }
     }
@@ -257,13 +259,15 @@ fn save_mcp_settings_to_path(path: &Path, settings: &McpSettingsRecord) -> Resul
 }
 
 fn tool_annotations_record(tool: &Tool) -> Option<McpToolAnnotationsRecord> {
-    tool.annotations.as_ref().map(|annotations| McpToolAnnotationsRecord {
-        title: annotations.title.clone(),
-        read_only_hint: annotations.read_only_hint,
-        destructive_hint: annotations.destructive_hint,
-        idempotent_hint: annotations.idempotent_hint,
-        open_world_hint: annotations.open_world_hint,
-    })
+    tool.annotations
+        .as_ref()
+        .map(|annotations| McpToolAnnotationsRecord {
+            title: annotations.title.clone(),
+            read_only_hint: annotations.read_only_hint,
+            destructive_hint: annotations.destructive_hint,
+            idempotent_hint: annotations.idempotent_hint,
+            open_world_hint: annotations.open_world_hint,
+        })
 }
 
 fn discovered_tool_record(server: &McpServerRecord, tool: Tool) -> McpDiscoveredToolRecord {
@@ -313,10 +317,7 @@ async fn connect_stdio_server(
     cwd: &str,
 ) -> Result<RunningService<RoleClient, ()>, String> {
     let McpServerRecord::Stdio {
-        command,
-        args,
-        env,
-        ..
+        command, args, env, ..
     } = server
     else {
         return Err("Invalid stdio server definition".to_string());
@@ -338,10 +339,13 @@ async fn connect_stdio_server(
         .map(|(transport, _stderr)| transport)
         .map_err(|error| format!("Failed to spawn {}: {}", server.name(), error))?;
 
-    timeout(Duration::from_millis(server.timeout_ms()), ().serve(transport))
-        .await
-        .map_err(|_| format!("Timed out connecting to {}", server.name()))?
-        .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
+    timeout(
+        Duration::from_millis(server.timeout_ms()),
+        ().serve(transport),
+    )
+    .await
+    .map_err(|_| format!("Timed out connecting to {}", server.name()))?
+    .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
 }
 
 fn parse_custom_headers(
@@ -369,10 +373,13 @@ async fn connect_streamable_http_server(
         .custom_headers(parse_custom_headers(headers)?);
     let transport = StreamableHttpClientTransport::from_config(config);
 
-    timeout(Duration::from_millis(server.timeout_ms()), ().serve(transport))
-        .await
-        .map_err(|_| format!("Timed out connecting to {}", server.name()))?
-        .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
+    timeout(
+        Duration::from_millis(server.timeout_ms()),
+        ().serve(transport),
+    )
+    .await
+    .map_err(|_| format!("Timed out connecting to {}", server.name()))?
+    .map_err(|error| format!("Failed to initialize {}: {}", server.name(), error))
 }
 
 async fn connect_server(
@@ -396,10 +403,18 @@ async fn list_tools(
     server: &McpServerRecord,
 ) -> Result<Vec<McpDiscoveredToolRecord>, String> {
     let client = runtime.client.lock().await;
-    let tools = timeout(Duration::from_millis(runtime.timeout_ms), client.peer().list_all_tools())
-        .await
-        .map_err(|_| format!("Timed out listing tools for {}", runtime.server_name))?
-        .map_err(|error| format!("Failed to list tools for {}: {}", runtime.server_name, error))?;
+    let tools = timeout(
+        Duration::from_millis(runtime.timeout_ms),
+        client.peer().list_all_tools(),
+    )
+    .await
+    .map_err(|_| format!("Timed out listing tools for {}", runtime.server_name))?
+    .map_err(|error| {
+        format!(
+            "Failed to list tools for {}: {}",
+            runtime.server_name, error
+        )
+    })?;
 
     Ok(tools
         .into_iter()
@@ -425,7 +440,11 @@ fn map_call_result(result: CallToolResult) -> McpToolCallResultRecord {
         content: result
             .content
             .into_iter()
-            .map(|content| serde_json::to_value(content).unwrap_or_else(|_| json!({ "type": "text", "text": "Unable to serialize MCP content." })))
+            .map(|content| {
+                serde_json::to_value(content).unwrap_or_else(
+                    |_| json!({ "type": "text", "text": "Unable to serialize MCP content." }),
+                )
+            })
             .collect(),
         structured_content: result.structured_content,
         is_error: result.is_error,
@@ -530,11 +549,13 @@ pub async fn mcp_prepare_run(
     cwd: String,
     servers: Vec<McpServerRecord>,
     state: State<'_, McpRunState>,
+    log_context: Option<LogContext>,
 ) -> Result<McpPrepareRunResult, String> {
-    tool_log(
+    tool_log_with_context(
         "mcp_prepare_run",
         "start",
         json!({ "runId": run_id, "cwd": cwd, "serverCount": servers.len() }),
+        log_context.as_ref(),
     );
 
     let mut runtimes = HashMap::new();
@@ -577,7 +598,7 @@ pub async fn mcp_prepare_run(
         shutdown_run(previous).await;
     }
 
-    tool_log(
+    tool_log_with_context(
         "mcp_prepare_run",
         "ok",
         json!({
@@ -585,6 +606,7 @@ pub async fn mcp_prepare_run(
             "toolCount": tools.len(),
             "failureCount": failures.len(),
         }),
+        log_context.as_ref(),
     );
 
     Ok(McpPrepareRunResult { tools, failures })
@@ -597,14 +619,30 @@ pub async fn mcp_call_tool(
     tool_name: String,
     input: Value,
     state: State<'_, McpRunState>,
+    log_context: Option<LogContext>,
 ) -> Result<McpToolCallResultRecord, String> {
+    tool_log_with_context(
+        "mcp_call_tool",
+        "start",
+        json!({
+            "runId": run_id,
+            "serverId": server_id,
+            "toolName": tool_name
+        }),
+        log_context.as_ref(),
+    );
     let runtime = {
         let runs = state.runs.lock().await;
         runs.get(&run_id)
             .and_then(|run| run.servers.get(&server_id))
             .cloned()
     }
-    .ok_or_else(|| format!("MCP server '{}' is not available for run '{}'.", server_id, run_id))?;
+    .ok_or_else(|| {
+        format!(
+            "MCP server '{}' is not available for run '{}'.",
+            server_id, run_id
+        )
+    })?;
 
     let client = runtime.client.lock().await;
     let mut request = CallToolRequestParams::new(tool_name.clone());
@@ -625,13 +663,28 @@ pub async fn mcp_call_tool(
     })?
     .map_err(|error| format!("MCP tool '{}' failed: {}", tool_name, error))?;
 
-    Ok(map_call_result(result))
+    let mapped = map_call_result(result);
+    let is_error = mapped.is_error.unwrap_or(false);
+    tool_log_with_context(
+        "mcp_call_tool",
+        if is_error { "err" } else { "ok" },
+        json!({
+            "runId": run_id,
+            "serverId": server_id,
+            "toolName": tool_name,
+            "contentCount": mapped.content.len(),
+            "isError": is_error
+        }),
+        log_context.as_ref(),
+    );
+    Ok(mapped)
 }
 
 #[tauri::command]
 pub async fn mcp_shutdown_run(
     run_id: String,
     state: State<'_, McpRunState>,
+    log_context: Option<LogContext>,
 ) -> Result<(), String> {
     let removed = {
         let mut runs = state.runs.lock().await;
@@ -642,7 +695,12 @@ pub async fn mcp_shutdown_run(
         shutdown_run(run).await;
     }
 
-    tool_log("mcp_shutdown_run", "ok", json!({ "runId": run_id }));
+    tool_log_with_context(
+        "mcp_shutdown_run",
+        "ok",
+        json!({ "runId": run_id }),
+        log_context.as_ref(),
+    );
     Ok(())
 }
 
@@ -672,10 +730,7 @@ mod tests {
                 enabled: false,
                 timeout_ms: None,
                 url: "http://localhost:8123/mcp".to_string(),
-                headers: HashMap::from([(
-                    "Authorization".to_string(),
-                    "Bearer token".to_string(),
-                )]),
+                headers: HashMap::from([("Authorization".to_string(), "Bearer token".to_string())]),
             },
         ]
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,4 +1,8 @@
-use serde_json::{json, Value};
+use crate::logging::{
+    tool_log as structured_tool_log, tool_log_with_context as structured_tool_log_with_context,
+    tool_logging_enabled as structured_tool_logging_enabled, LogContext,
+};
+use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -48,39 +52,15 @@ pub fn non_empty_env_var(name: &str) -> Option<String> {
 }
 
 pub fn tool_logging_enabled() -> bool {
-    // In dev builds, default to on for easier debugging.
-    // In release builds, require opt-in via env var.
-    if cfg!(debug_assertions) {
-        return true;
-    }
-    std::env::var("RAKH_TOOL_LOG")
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v == "1" || v == "true" || v == "yes" || v == "on"
-        })
-        .unwrap_or(false)
+    structured_tool_logging_enabled()
 }
 
 pub fn tool_log(tool: &str, event: &str, fields: Value) {
-    if !tool_logging_enabled() {
-        return;
-    }
+    structured_tool_log(tool, event, fields);
+}
 
-    let mut obj = serde_json::Map::new();
-    obj.insert("tsMs".to_string(), json!(now_ms()));
-    obj.insert("tool".to_string(), json!(tool));
-    obj.insert("event".to_string(), json!(event));
-
-    if let Value::Object(map) = fields {
-        for (k, v) in map {
-            obj.insert(k, v);
-        }
-    } else {
-        obj.insert("data".to_string(), fields);
-    }
-
-    // JSONL (one object per line) for easy grepping and ingestion.
-    eprintln!("{}", Value::Object(obj).to_string());
+pub fn tool_log_with_context(tool: &str, event: &str, fields: Value, context: Option<&LogContext>) {
+    structured_tool_log_with_context(tool, event, fields, context);
 }
 
 pub fn truncate_bytes(data: &[u8], max: usize) -> (Vec<u8>, bool) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/agent/persistence";
 import type { AgentStatus } from "@/agent/types";
 import { preloadEnvProviderKeys } from "@/agent/useEnvProviderKeys";
+import { logFrontendSoon } from "@/logging/client";
 import { getThemeSubagentColorVariables } from "@/styles/themes/registry";
 import { checkForAppUpdates } from "@/updater";
 
@@ -215,7 +216,14 @@ export default function App() {
             hydratePersistedSession(s, { restoreError });
             markSessionAsPersisted(s);
           } catch (e) {
-            console.error("rakh: failed to restore session", s.id, e);
+            logFrontendSoon({
+              level: "error",
+              tags: ["frontend", "db", "system"],
+              event: "app.restoreSession.error",
+              message: "Failed to restore session",
+              kind: "error",
+              data: { sessionId: s.id, error: e },
+            });
           }
         }
         setInitialSessions(sessions);

--- a/src/agent/mcp.test.ts
+++ b/src/agent/mcp.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import {
+  callMcpTool,
+  prepareMcpRun,
+  shutdownMcpRun,
+} from "./mcp";
+
+describe("agent/mcp", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("passes logContext to MCP backend commands", async () => {
+    const logContext = {
+      sessionId: "tab-1",
+      tabId: "tab-1",
+      traceId: "trace:run_1:main",
+      correlationId: "tc-mcp",
+    };
+    invokeMock
+      .mockResolvedValueOnce({ tools: [], failures: [] })
+      .mockResolvedValueOnce({ content: [], isError: false })
+      .mockResolvedValueOnce(undefined);
+
+    await prepareMcpRun("run_1", "/workspace/app", [], logContext);
+    await callMcpTool("run_1", "filesystem", "read_file", { path: "README.md" }, logContext);
+    await shutdownMcpRun("run_1", logContext);
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "mcp_prepare_run", {
+      runId: "run_1",
+      cwd: "/workspace/app",
+      servers: [],
+      logContext,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "mcp_call_tool", {
+      runId: "run_1",
+      serverId: "filesystem",
+      toolName: "read_file",
+      input: { path: "README.md" },
+      logContext,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "mcp_shutdown_run", {
+      runId: "run_1",
+      logContext,
+    });
+  });
+});

--- a/src/agent/mcp.ts
+++ b/src/agent/mcp.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { jsonSchema, tool as aiTool } from "ai";
 import { atom } from "jotai";
+import type { LogContext } from "@/logging/types";
 
 type JsonObject = Record<string, unknown>;
 
@@ -144,8 +145,14 @@ export async function prepareMcpRun(
   runId: string,
   cwd: string,
   servers: McpServerConfig[],
+  logContext?: LogContext,
 ): Promise<McpPrepareRunResult> {
-  return invoke<McpPrepareRunResult>("mcp_prepare_run", { runId, cwd, servers });
+  return invoke<McpPrepareRunResult>("mcp_prepare_run", {
+    runId,
+    cwd,
+    servers,
+    ...(logContext ? { logContext } : {}),
+  });
 }
 
 export async function callMcpTool(
@@ -153,17 +160,25 @@ export async function callMcpTool(
   serverId: string,
   toolName: string,
   input: Record<string, unknown>,
+  logContext?: LogContext,
 ): Promise<McpToolCallResponse> {
   return invoke<McpToolCallResponse>("mcp_call_tool", {
     runId,
     serverId,
     toolName,
     input,
+    ...(logContext ? { logContext } : {}),
   });
 }
 
-export async function shutdownMcpRun(runId: string): Promise<void> {
-  await invoke("mcp_shutdown_run", { runId });
+export async function shutdownMcpRun(
+  runId: string,
+  logContext?: LogContext,
+): Promise<void> {
+  await invoke("mcp_shutdown_run", {
+    runId,
+    ...(logContext ? { logContext } : {}),
+  });
 }
 
 function slugify(value: string): string {

--- a/src/agent/persistence.test.ts
+++ b/src/agent/persistence.test.ts
@@ -6,14 +6,14 @@ const {
   patchSessionPersistenceStateMock,
   defaultModel,
   stateByTab,
-  consoleErrorSpy,
+  logFrontendSoonMock,
 } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   getAgentStateMock: vi.fn(),
   patchSessionPersistenceStateMock: vi.fn(),
   defaultModel: "openai/gpt-5.2",
   stateByTab: {} as Record<string, unknown>,
-  consoleErrorSpy: vi.spyOn(console, "error").mockImplementation(() => {}),
+  logFrontendSoonMock: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -25,6 +25,10 @@ vi.mock("./atoms", () => ({
   patchSessionPersistenceState: (...args: unknown[]) =>
     patchSessionPersistenceStateMock(...args),
   DEFAULT_MODEL: defaultModel,
+}));
+
+vi.mock("@/logging/client", () => ({
+  logFrontendSoon: (...args: unknown[]) => logFrontendSoonMock(...args),
 }));
 
 import {
@@ -56,7 +60,7 @@ describe("persistence", () => {
     invokeMock.mockReset();
     getAgentStateMock.mockReset();
     patchSessionPersistenceStateMock.mockReset();
-    consoleErrorSpy.mockClear();
+    logFrontendSoonMock.mockReset();
     for (const key of Object.keys(stateByTab)) {
       delete stateByTab[key];
     }
@@ -194,7 +198,12 @@ describe("persistence", () => {
 
     const sessions = await loadSessions();
     expect(sessions).toEqual([]);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logFrontendSoonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "error",
+        event: "persistence.load.error",
+      }),
+    );
   });
 
   it("upsertSession is no-op outside Tauri and for non-workspace tabs", async () => {

--- a/src/agent/persistence.ts
+++ b/src/agent/persistence.ts
@@ -20,6 +20,7 @@
  */
 
 import type { Tab } from "@/contexts/TabsContext";
+import { logFrontendSoon } from "@/logging/client";
 import type { AgentQueueState, AgentState } from "./types";
 import {
   DEFAULT_MODEL,
@@ -149,7 +150,14 @@ export async function loadSessions(): Promise<PersistedSession[]> {
   try {
     return await invoke<PersistedSession[]>("db_load_sessions");
   } catch (e) {
-    console.error("rakh: failed to load sessions:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.load.error",
+      message: "Failed to load sessions",
+      kind: "error",
+      data: e,
+    });
     return [];
   }
 }
@@ -229,7 +237,14 @@ export async function upsertSession(tab: Tab): Promise<void> {
     await invoke("db_upsert_session", { session });
     markSessionAsPersisted(session);
   } catch (e) {
-    console.error("rakh: failed to upsert session:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.upsert.error",
+      message: "Failed to upsert session",
+      kind: "error",
+      data: { sessionId: tab.id, error: e },
+    });
     patchSessionPersistenceState(tab.id, {
       phase: "error",
       lastSaveError: e instanceof Error ? e.message : String(e),
@@ -248,7 +263,14 @@ export async function archiveSession(id: string): Promise<void> {
   try {
     await invoke("db_archive_session", { id });
   } catch (e) {
-    console.error("rakh: failed to archive session:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.archive.error",
+      message: "Failed to archive session",
+      kind: "error",
+      data: { sessionId: id, error: e },
+    });
   }
 }
 
@@ -258,7 +280,14 @@ export async function loadArchivedSessions(): Promise<PersistedSession[]> {
   try {
     return await invoke<PersistedSession[]>("db_load_archived_sessions");
   } catch (e) {
-    console.error("rakh: failed to load archived sessions:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.loadArchived.error",
+      message: "Failed to load archived sessions",
+      kind: "error",
+      data: e,
+    });
     return [];
   }
 }
@@ -272,7 +301,14 @@ export async function restoreSession(session: PersistedSession): Promise<void> {
     });
     markSessionAsPersisted({ ...session, archived: false });
   } catch (e) {
-    console.error("rakh: failed to restore session:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.restore.error",
+      message: "Failed to restore session",
+      kind: "error",
+      data: { sessionId: session.id, error: e },
+    });
   }
 }
 
@@ -282,6 +318,13 @@ export async function deleteSession(id: string): Promise<void> {
   try {
     await invoke("db_delete_session", { id });
   } catch (e) {
-    console.error("rakh: failed to delete session:", e);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "persistence.delete.error",
+      message: "Failed to delete session",
+      kind: "error",
+      data: { sessionId: id, error: e },
+    });
   }
 }

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -70,6 +70,7 @@ const {
   shutdownMcpRunMock,
   artifactCreateMock,
   switchToGitBranchMock,
+  logFrontendSoonMock,
 } = vi.hoisted(() => ({
   states: {} as Record<string, MockAgentState>,
   providersAtomMock: { kind: "providers-atom" },
@@ -99,6 +100,7 @@ const {
   callMcpToolMock: vi.fn(),
   shutdownMcpRunMock: vi.fn(),
   artifactCreateMock: vi.fn(),
+  logFrontendSoonMock: vi.fn(),
 }));
 
 vi.mock("./atoms", () => ({
@@ -265,6 +267,16 @@ vi.mock("./tools/artifacts", async () => {
   };
 });
 
+vi.mock("@/logging/client", async () => {
+  const actual = await vi.importActual<typeof import("@/logging/client")>(
+    "@/logging/client",
+  );
+  return {
+    ...actual,
+    logFrontendSoon: (...args: unknown[]) => logFrontendSoonMock(...args),
+  };
+});
+
 import {
   buildProviderOptions,
   resumeQueue,
@@ -409,6 +421,7 @@ describe("runner", () => {
     shutdownMcpRunMock.mockReset();
     artifactCreateMock.mockReset();
     switchToGitBranchMock.mockReset();
+    logFrontendSoonMock.mockReset();
     jotaiStoreMock.get.mockReset();
 
     jotaiStoreMock.get.mockImplementation((atom: unknown) => {
@@ -671,6 +684,12 @@ describe("runner", () => {
           enabled: true,
         }),
       ],
+      expect.objectContaining({
+        sessionId: "tab-mcp-tool",
+        tabId: "tab-mcp-tool",
+        agentId: "agent_main",
+        traceId: expect.any(String),
+      }),
     );
     const firstStreamCall = streamTextMock.mock.calls[0]?.[0] as
       | Record<string, unknown>
@@ -689,6 +708,11 @@ describe("runner", () => {
       "filesystem",
       "read_file",
       { path: "README.md" },
+      expect.objectContaining({
+        correlationId: "tc-mcp-1",
+        toolName: "mcp_filesystem_read_file",
+        traceId: expect.any(String),
+      }),
     );
     expect(parseToolMessageResult(tabId, "tc-mcp-1")).toMatchObject({
       ok: true,
@@ -713,7 +737,15 @@ describe("runner", () => {
         }),
       ],
     });
-    expect(shutdownMcpRunMock).toHaveBeenCalledWith(expect.any(String));
+    expect(shutdownMcpRunMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sessionId: "tab-mcp-tool",
+        tabId: "tab-mcp-tool",
+        agentId: "agent_main",
+        traceId: expect.any(String),
+      }),
+    );
   });
 
   it("artifactizes MCP file payloads only when the global MCP setting is enabled", async () => {
@@ -812,6 +844,11 @@ describe("runner", () => {
       expect.objectContaining({
         agentId: "agent_main",
         runId: expect.stringMatching(/^run_/),
+        logContext: expect.objectContaining({
+          correlationId: "tc-mcp-image-1",
+          toolName: "mcp_playwright_browser_take_screenshot",
+          traceId: expect.any(String),
+        }),
       }),
       expect.objectContaining({
         kind: "mcp-attachment",
@@ -997,7 +1034,15 @@ describe("runner", () => {
         }),
       ]),
     );
-    expect(shutdownMcpRunMock).toHaveBeenCalledWith(expect.any(String));
+    expect(shutdownMcpRunMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sessionId: "tab-mcp-warning",
+        tabId: "tab-mcp-warning",
+        agentId: "agent_main",
+        traceId: expect.any(String),
+      }),
+    );
   });
 
   it("includes reviewer scope guidance in the main system prompt via description", async () => {
@@ -1096,30 +1141,44 @@ describe("runner", () => {
       toolCalls: [],
     });
 
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    let debugCalls: unknown[][] = [];
-    try {
-      await runAgent(tabId, "hi");
-      const debugPrefix = `[rakh:stream][${tabId}]`;
-      debugCalls = logSpy.mock.calls.filter((args) => args[0] === debugPrefix);
-    } finally {
-      logSpy.mockRestore();
-    }
-    const debugPrefix = `[rakh:stream][${tabId}]`;
+    await runAgent(tabId, "hi");
+
+    const debugCalls = logFrontendSoonMock.mock.calls
+      .map(([entry]) => entry as Record<string, unknown>)
+      .filter((entry) => entry.level === "debug");
 
     expect(debugCalls.length).toBeGreaterThan(0);
     expect(debugCalls).toEqual(
       expect.arrayContaining([
-        expect.arrayContaining([debugPrefix, "turn:start"]),
-        expect.arrayContaining([debugPrefix, "stream:part"]),
-        expect.arrayContaining([debugPrefix, "stream:reasoning-start"]),
-        expect.arrayContaining([debugPrefix, "stream:reasoning-delta"]),
-        expect.arrayContaining([debugPrefix, "stream:text-delta"]),
-        expect.arrayContaining([debugPrefix, "stream:tool-calls:raw"]),
-        expect.arrayContaining([
-          debugPrefix,
-          "stream:finish",
-          expect.objectContaining({
+        expect.objectContaining({
+          event: "runner.turn:start",
+          message: `[${tabId}] turn:start`,
+          context: expect.objectContaining({ tabId }),
+        }),
+        expect.objectContaining({
+          event: "runner.stream:part",
+          message: `[${tabId}] stream:part`,
+        }),
+        expect.objectContaining({
+          event: "runner.stream:reasoning-start",
+          message: `[${tabId}] stream:reasoning-start`,
+        }),
+        expect.objectContaining({
+          event: "runner.stream:reasoning-delta",
+          message: `[${tabId}] stream:reasoning-delta`,
+        }),
+        expect.objectContaining({
+          event: "runner.stream:text-delta",
+          message: `[${tabId}] stream:text-delta`,
+        }),
+        expect.objectContaining({
+          event: "runner.stream:tool-calls:raw",
+          message: `[${tabId}] stream:tool-calls:raw`,
+        }),
+        expect.objectContaining({
+          event: "runner.stream:finish",
+          message: `[${tabId}] stream:finish`,
+          data: expect.objectContaining({
             finishReason: "stop",
             stepCount: 1,
             steps: [
@@ -1132,8 +1191,11 @@ describe("runner", () => {
               }),
             ],
           }),
-        ]),
-        expect.arrayContaining([debugPrefix, "stream:summary"]),
+        }),
+        expect.objectContaining({
+          event: "runner.stream:summary",
+          message: `[${tabId}] stream:summary`,
+        }),
       ]),
     );
   });
@@ -1143,15 +1205,10 @@ describe("runner", () => {
     setState(tabId, { showDebug: false });
     turns.push({ deltas: ["Hello"], toolCalls: [] });
 
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    let debugCalls: unknown[][] = [];
-    try {
-      await runAgent(tabId, "hi");
-      const debugPrefix = `[rakh:stream][${tabId}]`;
-      debugCalls = logSpy.mock.calls.filter((args) => args[0] === debugPrefix);
-    } finally {
-      logSpy.mockRestore();
-    }
+    await runAgent(tabId, "hi");
+    const debugCalls = logFrontendSoonMock.mock.calls
+      .map(([entry]) => entry as Record<string, unknown>)
+      .filter((entry) => entry.level === "debug");
     expect(debugCalls).toHaveLength(0);
   });
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -109,6 +109,13 @@ import {
   type ArtifactManifest,
 } from "./tools/artifacts";
 import { buildConversationCard, type CardAddInput } from "./tools/agentControl";
+import {
+  createChildLogContext,
+  logFrontendSoon,
+  nextLogId,
+  nextTraceId,
+} from "@/logging/client";
+import type { LogContext } from "@/logging/types";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Abort controller registry — one per running agent
@@ -218,6 +225,7 @@ async function prepareMainAgentMcpRuntime(
   tabId: string,
   runId: string,
   cwd: string,
+  logContext?: LogContext,
 ): Promise<MainAgentMcpRuntime> {
   const configuredServers = jotaiStore.get(mcpServersAtom);
   if (!configuredServers.some((server) => server.enabled)) {
@@ -225,7 +233,7 @@ async function prepareMainAgentMcpRuntime(
   }
 
   try {
-    const prepared = await prepareMcpRun(runId, cwd, configuredServers);
+    const prepared = await prepareMcpRun(runId, cwd, configuredServers, logContext);
     if (prepared.failures.length > 0) {
       appendChatMessage(tabId, {
         id: msgId(),
@@ -392,6 +400,7 @@ async function createMcpPayloadArtifact(
   runId: string,
   mcpTool: McpToolRegistration,
   candidate: McpArtifactPayloadCandidate,
+  logContext?: LogContext,
 ): Promise<McpArtifactReference | null> {
   const summaryParts = [
     mcpTool.serverName,
@@ -424,14 +433,29 @@ async function createMcpPayloadArtifact(
   };
   const artifactResult = await artifactCreate(
     tabId,
-    { runId, agentId: "agent_main" },
+    { runId, agentId: "agent_main", logContext },
     artifactInput,
   );
   if (!artifactResult.ok) {
-    console.warn("Failed to artifactize MCP payload", {
-      serverId: mcpTool.serverId,
-      toolName: mcpTool.toolName,
-      error: artifactResult.error,
+    writeRunnerLog({
+      level: "warn",
+      tags: ["frontend", "tool-calls", "system"],
+      event: "runner.mcp.artifactize.warn",
+      message: "Failed to artifactize MCP payload",
+      data: {
+        serverId: mcpTool.serverId,
+        toolName: mcpTool.toolName,
+        error: artifactResult.error,
+      },
+      context:
+        logContext ??
+        {
+          sessionId: tabId,
+          tabId,
+          traceId: nextTraceId("trace", runId, "main"),
+          depth: 1,
+          agentId: "agent_main",
+        },
     });
     return null;
   }
@@ -451,10 +475,17 @@ async function sanitizeMcpStructuredValue(
   runId: string,
   mcpTool: McpToolRegistration,
   artifactRefs: McpArtifactReference[],
+  logContext?: LogContext,
 ): Promise<unknown> {
   const candidate = getMcpArtifactPayloadCandidate(value);
   if (candidate) {
-    const artifactRef = await createMcpPayloadArtifact(tabId, runId, mcpTool, candidate);
+    const artifactRef = await createMcpPayloadArtifact(
+      tabId,
+      runId,
+      mcpTool,
+      candidate,
+      logContext,
+    );
     if (!artifactRef) return value;
     artifactRefs.push(artifactRef);
     return buildMcpArtifactReferenceRecord(artifactRef);
@@ -463,7 +494,14 @@ async function sanitizeMcpStructuredValue(
   if (Array.isArray(value)) {
     return Promise.all(
       value.map((entry) =>
-        sanitizeMcpStructuredValue(entry, tabId, runId, mcpTool, artifactRefs),
+        sanitizeMcpStructuredValue(
+          entry,
+          tabId,
+          runId,
+          mcpTool,
+          artifactRefs,
+          logContext,
+        ),
       ),
     );
   }
@@ -475,7 +513,14 @@ async function sanitizeMcpStructuredValue(
   const entries = await Promise.all(
     Object.entries(value).map(async ([key, entry]) => [
       key,
-      await sanitizeMcpStructuredValue(entry, tabId, runId, mcpTool, artifactRefs),
+      await sanitizeMcpStructuredValue(
+        entry,
+        tabId,
+        runId,
+        mcpTool,
+        artifactRefs,
+        logContext,
+      ),
     ]),
   );
   return Object.fromEntries(entries);
@@ -487,6 +532,7 @@ async function maybeArtifactizeMcpToolResult(
   mcpTool: McpToolRegistration,
   result: McpToolCallResponse,
   artifactizeReturnedFiles: boolean,
+  logContext?: LogContext,
 ): Promise<McpToolCallResponse> {
   if (!artifactizeReturnedFiles) {
     return result;
@@ -498,7 +544,13 @@ async function maybeArtifactizeMcpToolResult(
       const candidate = getMcpArtifactPayloadCandidate(item);
       if (!candidate) return item;
 
-      const artifactRef = await createMcpPayloadArtifact(tabId, runId, mcpTool, candidate);
+      const artifactRef = await createMcpPayloadArtifact(
+        tabId,
+        runId,
+        mcpTool,
+        candidate,
+        logContext,
+      );
       if (!artifactRef) return item;
       artifactRefs.push(artifactRef);
       return {
@@ -516,11 +568,19 @@ async function maybeArtifactizeMcpToolResult(
           runId,
           mcpTool,
           artifactRefs,
+          logContext,
         );
   const nextMeta =
     result.meta === undefined
       ? undefined
-      : await sanitizeMcpStructuredValue(result.meta, tabId, runId, mcpTool, artifactRefs);
+      : await sanitizeMcpStructuredValue(
+          result.meta,
+          tabId,
+          runId,
+          mcpTool,
+          artifactRefs,
+          logContext,
+        );
 
   if (artifactRefs.length === 0) {
     return result;
@@ -1203,7 +1263,17 @@ export function queueMessage(tabId: string, userMessage: string): void {
     queueState: prev.queueState === "paused" ? "paused" : "draining",
   }));
 
-  void maybeStartQueuedRun(tabId).catch(console.error);
+  void maybeStartQueuedRun(tabId).catch((error) => {
+    writeRunnerLog({
+      level: "error",
+      tags: ["frontend", "agent-loop", "system"],
+      event: "runner.queue.start.error",
+      message: "Failed to start queued run",
+      kind: "error",
+      data: error,
+      context: { sessionId: tabId, tabId, depth: 0 },
+    });
+  });
 }
 
 export async function steerMessage(
@@ -1226,7 +1296,17 @@ export function resumeQueue(tabId: string): void {
     ...prev,
     queueState: prev.queuedMessages.length > 0 ? "draining" : "idle",
   }));
-  void maybeStartQueuedRun(tabId).catch(console.error);
+  void maybeStartQueuedRun(tabId).catch((error) => {
+    writeRunnerLog({
+      level: "error",
+      tags: ["frontend", "agent-loop", "system"],
+      event: "runner.queue.resume.error",
+      message: "Failed to resume queued run",
+      kind: "error",
+      data: error,
+      context: { sessionId: tabId, tabId, depth: 0 },
+    });
+  });
 }
 
 export function removeQueuedMessage(tabId: string, messageId: string): void {
@@ -1515,19 +1595,92 @@ function toLoggable(value: unknown): unknown {
   return value instanceof Error ? serializeError(value) : value;
 }
 
+function writeRunnerLog(input: {
+  id?: string;
+  level?: "trace" | "debug" | "info" | "warn" | "error";
+  tags: string[];
+  event: string;
+  message: string;
+  kind?: "start" | "end" | "event" | "error";
+  expandable?: boolean;
+  durationMs?: number;
+  data?: unknown;
+  context?: LogContext;
+}): void {
+  logFrontendSoon({
+    id: input.id,
+    level: input.level,
+    tags: input.tags,
+    event: input.event,
+    message: input.message,
+    kind: input.kind,
+    expandable: input.expandable,
+    durationMs: input.durationMs,
+    data: input.data,
+    context: input.context,
+  });
+}
+
+function createMainRunLogContext(tabId: string, runId: string): {
+  runStartId: string;
+  rootContext: LogContext;
+  childContext: LogContext;
+} {
+  const traceId = nextTraceId("trace", runId, "main");
+  const runStartId = nextLogId(`run:${runId}`);
+  const rootContext: LogContext = {
+    sessionId: tabId,
+    tabId,
+    traceId,
+    depth: 0,
+    agentId: "agent_main",
+  };
+  return {
+    runStartId,
+    rootContext,
+    childContext: {
+      ...rootContext,
+      parentId: runStartId,
+      depth: 1,
+    },
+  };
+}
+
+function createToolLogContext(
+  baseContext: LogContext,
+  toolCallId: string,
+  toolName: string,
+): { startId: string; context: LogContext } {
+  const startId = nextLogId(`tool:${toolCallId}`);
+  return {
+    startId,
+    context: createChildLogContext(baseContext, {
+      correlationId: toolCallId,
+      parentId: startId,
+      toolName,
+    }),
+  };
+}
+
 function logStreamDebug(
   tabId: string,
   debugEnabled: boolean,
   event: string,
+  logContext: LogContext,
   payload?: unknown,
 ): void {
   if (!debugEnabled) return;
-  const prefix = `[rakh:stream][${tabId}]`;
-  if (payload === undefined) {
-    console.log(prefix, event);
-    return;
-  }
-  console.log(prefix, event, toLoggable(payload));
+  const tags = ["frontend", "agent-loop", "streaming"];
+  if (event.includes("delta")) tags.push("tokens");
+  if (event.includes("tool-calls")) tags.push("tool-calls");
+  writeRunnerLog({
+    level: "debug",
+    tags,
+    event: `runner.${event}`,
+    message: `[${tabId}] ${event}`,
+    data: payload === undefined ? undefined : toLoggable(payload),
+    context: logContext,
+  });
 }
 
 interface DebuggableStreamStep {
@@ -1589,6 +1742,7 @@ async function logStreamFinishDebug(
   tabId: string,
   debugEnabled: boolean,
   result: DebuggableStreamResult,
+  logContext: LogContext,
 ): Promise<void> {
   if (!debugEnabled) return;
 
@@ -1600,7 +1754,7 @@ async function logStreamFinishDebug(
     ]);
     const steps = Array.isArray(stepsValue) ? stepsValue : [];
 
-    logStreamDebug(tabId, debugEnabled, "stream:finish", {
+    logStreamDebug(tabId, debugEnabled, "stream:finish", logContext, {
       ...(typeof finishReason === "string" ? { finishReason } : {}),
       ...(typeof rawFinishReason === "string" ? { rawFinishReason } : {}),
       stepCount: steps.length,
@@ -1609,7 +1763,7 @@ async function logStreamFinishDebug(
       ),
     });
   } catch (error) {
-    logStreamDebug(tabId, debugEnabled, "stream:finish:error", error);
+    logStreamDebug(tabId, debugEnabled, "stream:finish:error", logContext, error);
   }
 }
 
@@ -1838,6 +1992,7 @@ interface SubagentLoopOptions {
   parentModelId: string;
   providers: ProviderInstance[];
   debugEnabled: boolean;
+  logContext: LogContext;
 }
 
 /**
@@ -1865,9 +2020,35 @@ async function runSubagentLoop(
     parentModelId,
     providers,
     debugEnabled,
+    logContext,
   } = opts;
 
   const startedAtMs = Date.now();
+  const subagentStartId = nextLogId(`subagent:${subagentDef.id}`);
+  const subagentRootContext: LogContext = {
+    ...logContext,
+    agentId: `agent_${subagentDef.id}`,
+  };
+  const subagentContext: LogContext = {
+    ...subagentRootContext,
+    traceId: nextTraceId(logContext.traceId ?? nextTraceId("trace", runId), subagentDef.id),
+    parentId: subagentStartId,
+    depth: (logContext.depth ?? 0) + 1,
+  };
+  writeRunnerLog({
+    id: subagentStartId,
+    level: "info",
+    tags: ["frontend", "agent-loop", "messages"],
+    event: "runner.subagent.start",
+    message: `${subagentDef.name} started`,
+    kind: "start",
+    expandable: true,
+    data: {
+      subagentId: subagentDef.id,
+      modelId: parentModelId,
+    },
+    context: subagentRootContext,
+  });
   const modelId = resolveSubagentModelId(subagentDef, parentModelId, providers);
 
   let languageModel;
@@ -2376,6 +2557,30 @@ async function runSubagentLoop(
     const toolResults = await Promise.all(
       parsedToolCalls.map(async (tc) => {
         const tcId = tc.id;
+        const toolLog = createToolLogContext(
+          subagentContext,
+          tcId,
+          tc.function.name,
+        );
+        writeRunnerLog({
+          id: toolLog.startId,
+          level: "info",
+          tags: ["frontend", "agent-loop", "tool-calls"],
+          event: "runner.subagent.tool.start",
+          message: `${subagentDef.name} queued ${tc.function.name}`,
+          kind: "start",
+          expandable: true,
+          data: {
+            toolName: tc.function.name,
+            args: parseArgs(tc.function.arguments),
+            subagentId: subagentDef.id,
+          },
+          context: {
+            ...subagentContext,
+            correlationId: tcId,
+            depth: subagentContext.depth,
+          },
+        });
 
         function updateToolCallById(patch: Partial<ToolCallDisplay>): void {
           if (signal.aborted || !isCurrentRunId(tabId, runId)) return;
@@ -2578,11 +2783,28 @@ async function runSubagentLoop(
           args,
           tcId,
           callbacks,
-          { runId, agentId: `agent_${subagentDef.id}` },
+          {
+            runId,
+            agentId: `agent_${subagentDef.id}`,
+            logContext: toolLog.context,
+          },
         );
         updateToolCallById({
           status: toolResult.ok ? "done" : "error",
           result: toolResult.ok ? toolResult.data : toolResult.error,
+        });
+        writeRunnerLog({
+          level: toolResult.ok ? "info" : "error",
+          tags: ["frontend", "agent-loop", "tool-calls"],
+          event: toolResult.ok
+            ? "runner.subagent.tool.end"
+            : "runner.subagent.tool.error",
+          message: toolResult.ok
+            ? `${subagentDef.name} completed ${tc.function.name}`
+            : `${subagentDef.name} failed ${tc.function.name}`,
+          kind: toolResult.ok ? "end" : "error",
+          data: toolResult.ok ? toolResult.data : toolResult.error,
+          context: toolLog.context,
         });
 
         if (
@@ -2636,15 +2858,28 @@ async function runSubagentLoop(
     }
 
     if (debugEnabled) {
-      console.log(
-        `[rakh:subagent][${tabId}][${subagentDef.id}]`,
-        `iteration=${iteration} toolCalls=${parsedToolCalls.length}`,
-      );
+      writeRunnerLog({
+        level: "debug",
+        tags: ["frontend", "agent-loop", "messages"],
+        event: "runner.subagent.iteration",
+        message: `${subagentDef.name} iteration ${iteration}`,
+        data: { iteration, toolCallCount: parsedToolCalls.length },
+        context: subagentContext,
+      });
     }
   }
 
   const contractResult = finalizeSubagentArtifacts();
   if (!contractResult.ok) {
+    writeRunnerLog({
+      level: "error",
+      tags: ["frontend", "agent-loop", "messages"],
+      event: "runner.subagent.error",
+      message: `${subagentDef.name} failed artifact validation`,
+      kind: "error",
+      data: contractResult.result.error,
+      context: subagentContext,
+    });
     return {
       ok: false,
       error: contractResult.result.error,
@@ -2652,6 +2887,21 @@ async function runSubagentLoop(
   }
 
   const note = subagentDef.output?.parentNote;
+  writeRunnerLog({
+    level: "info",
+    tags: ["frontend", "agent-loop", "messages"],
+    event: "runner.subagent.end",
+    message: `${subagentDef.name} completed`,
+    kind: "end",
+    durationMs: Math.max(0, Date.now() - startedAtMs),
+    data: {
+      subagentId: subagentDef.id,
+      turns,
+      artifactCount: collectedArtifacts.length,
+      cardCount: collectedCards.length,
+    },
+    context: subagentContext,
+  });
 
   return {
     ok: true,
@@ -2780,12 +3030,28 @@ async function runAgentTurn(
 ): Promise<void> {
   const controller = new AbortController();
   const runId = nextRunId(tabId);
+  const { runStartId, rootContext: runRootLogContext, childContext: runLogContext } =
+    createMainRunLogContext(tabId, runId);
   const activeRun: ActiveRun = {
     runId,
     controller,
     abortReason: null,
   };
   activeRuns.set(tabId, activeRun);
+  writeRunnerLog({
+    id: runStartId,
+    level: "info",
+    tags: ["frontend", "agent-loop", "messages"],
+    event: "runner.run.start",
+    message: "Agent run started",
+    kind: "start",
+    expandable: true,
+    data: {
+      userMessageLength: userMessage.length,
+      hasAttachments: Boolean(attachments && attachments.length > 0),
+    },
+    context: runRootLogContext,
+  });
 
   let completedCleanly = false;
 
@@ -2829,8 +3095,18 @@ async function runAgentTurn(
         parentModelId: triggerState.config.model,
         providers: triggerProviders,
         debugEnabled: triggerDebug,
+        logContext: runLogContext,
       });
       if (!triggerResult.ok) {
+        writeRunnerLog({
+          level: "error",
+          tags: ["frontend", "agent-loop", "messages"],
+          event: "runner.run.error",
+          message: "Trigger subagent run failed",
+          kind: "error",
+          data: triggerResult.error,
+          context: runLogContext,
+        });
         setAgentErrorState(
           tabId,
           triggerResult.error.message,
@@ -2846,6 +3122,15 @@ async function runAgentTurn(
         return;
       }
       const msg = err instanceof Error ? err.message : String(err);
+      writeRunnerLog({
+        level: "error",
+        tags: ["frontend", "agent-loop", "messages"],
+        event: "runner.run.error",
+        message: "Trigger subagent run threw",
+        kind: "error",
+        data: err,
+        context: runLogContext,
+      });
       setAgentErrorState(tabId, msg, serializeError(err));
       updateLastChatMessage(tabId, (m) =>
         m.role === "assistant" ? { ...m, streaming: false } : m,
@@ -2855,13 +3140,31 @@ async function runAgentTurn(
       clearActiveRun(tabId, activeRun);
       if (activeRun.abortReason !== null) return;
       if (completedCleanly) {
+        writeRunnerLog({
+          level: "info",
+          tags: ["frontend", "agent-loop", "messages"],
+          event: "runner.run.end",
+          message: "Agent run completed",
+          kind: "end",
+          context: runLogContext,
+        });
         patchAgentState(tabId, (prev) => ({
           ...prev,
           status: "idle",
           streamingContent: null,
           queueState: normalizeQueueState(prev.queuedMessages, prev.queueState),
         }));
-        void maybeStartQueuedRun(tabId).catch(console.error);
+        void maybeStartQueuedRun(tabId).catch((error) => {
+          writeRunnerLog({
+            level: "error",
+            tags: ["frontend", "agent-loop", "system"],
+            event: "runner.queue.drain.error",
+            message: "Failed to drain queued messages",
+            kind: "error",
+            data: error,
+            context: runLogContext,
+          });
+        });
       }
     }
     return;
@@ -2874,9 +3177,14 @@ async function runAgentTurn(
   const provider = modelEntry?.owned_by ?? null;
   const providers = jotaiStore.get(providersAtom);
 
-  console.log(
-    `Starting agent with model ${model} (provider: ${provider}) in workspace ${cwd}`,
-  );
+  writeRunnerLog({
+    level: "info",
+    tags: ["frontend", "agent-loop", "system"],
+    event: "runner.model.resolve",
+    message: `Starting agent with model ${model}`,
+    data: { model, provider, cwd },
+    context: runLogContext,
+  });
 
   if (!modelEntry || !provider) {
     setAgentErrorState(
@@ -3031,6 +3339,7 @@ async function runAgentTurn(
       providers,
       debugEnabled,
       runId,
+      runLogContext,
     );
     completedCleanly = !controller.signal.aborted;
   } catch (err) {
@@ -3040,6 +3349,15 @@ async function runAgentTurn(
       return;
     }
     const msg = err instanceof Error ? err.message : String(err);
+    writeRunnerLog({
+      level: "error",
+      tags: ["frontend", "agent-loop", "messages"],
+      event: "runner.run.error",
+      message: "Agent loop failed",
+      kind: "error",
+      data: err,
+      context: runLogContext,
+    });
     setAgentErrorState(tabId, msg, serializeError(err));
     updateLastChatMessage(tabId, (m) =>
       m.role === "assistant" ? { ...m, streaming: false } : m,
@@ -3060,7 +3378,25 @@ async function runAgentTurn(
             queueState: normalizeQueueState(prev.queuedMessages, prev.queueState),
           },
     );
-    void maybeStartQueuedRun(tabId).catch(console.error);
+    writeRunnerLog({
+      level: "info",
+      tags: ["frontend", "agent-loop", "messages"],
+      event: "runner.run.end",
+      message: "Agent run completed",
+      kind: "end",
+      context: runLogContext,
+    });
+    void maybeStartQueuedRun(tabId).catch((error) => {
+      writeRunnerLog({
+        level: "error",
+        tags: ["frontend", "agent-loop", "system"],
+        event: "runner.queue.drain.error",
+        message: "Failed to drain queued messages",
+        kind: "error",
+        data: error,
+        context: runLogContext,
+      });
+    });
   }
 }
 
@@ -3075,6 +3411,7 @@ async function agentLoop(
   providers: ProviderInstance[],
   debugEnabled: boolean,
   runId: string,
+  runLogContext: LogContext,
 ): Promise<void> {
   const languageModel = resolveLanguageModel(modelId, providers);
   const modelEntry = getModelCatalogEntry(modelId);
@@ -3089,6 +3426,7 @@ async function agentLoop(
     tabId,
     runId,
     getAgentState(tabId).config.cwd,
+    runLogContext,
   );
   const toolDefinitions = {
     ...TOOL_DEFINITIONS,
@@ -3102,7 +3440,28 @@ async function agentLoop(
 
       const turnStartedAtMs = Date.now();
       const currentApiMessages = getAgentState(tabId).apiMessages;
-      logStreamDebug(tabId, debugEnabled, "turn:start", {
+      const turnStartId = nextLogId(`turn:${runId}:${iteration}`);
+      const turnContext: LogContext = {
+        ...runLogContext,
+        parentId: turnStartId,
+        depth: (runLogContext.depth ?? 1) + 1,
+      };
+      writeRunnerLog({
+        id: turnStartId,
+        level: "info",
+        tags: ["frontend", "agent-loop", "messages"],
+        event: "runner.turn.start",
+        message: `Turn ${iteration} started`,
+        kind: "start",
+        expandable: true,
+        data: {
+          iteration,
+          apiMessageCount: currentApiMessages.length,
+          modelId,
+        },
+        context: runLogContext,
+      });
+      logStreamDebug(tabId, debugEnabled, "turn:start", turnContext, {
         iteration,
         apiMessageCount: currentApiMessages.length,
         modelId,
@@ -3183,7 +3542,7 @@ async function agentLoop(
         for await (const part of fullStream) {
           if (signal.aborted) return;
           streamPartCount += 1;
-          logStreamDebug(tabId, debugEnabled, "stream:part", part);
+          logStreamDebug(tabId, debugEnabled, "stream:part", turnContext, part);
 
           const streamError = streamPartError(part);
           if (streamError !== null) {
@@ -3192,6 +3551,7 @@ async function agentLoop(
               tabId,
               debugEnabled,
               "stream:error-part",
+              turnContext,
               streamError,
             );
             streamErrors.push(streamError);
@@ -3202,7 +3562,12 @@ async function agentLoop(
             reasoningStartCount += 1;
             ensureReasoningStart();
             reasoningActive = true;
-            logStreamDebug(tabId, debugEnabled, "stream:reasoning-start");
+            logStreamDebug(
+              tabId,
+              debugEnabled,
+              "stream:reasoning-start",
+              turnContext,
+            );
             updateStreamingMessage();
             continue;
           }
@@ -3211,7 +3576,7 @@ async function agentLoop(
             reasoningEndCount += 1;
             reasoningActive = false;
             finalizeReasoningDuration();
-            logStreamDebug(tabId, debugEnabled, "stream:reasoning-end", {
+            logStreamDebug(tabId, debugEnabled, "stream:reasoning-end", turnContext, {
               reasoningDurationMs,
             });
             updateStreamingMessage();
@@ -3223,7 +3588,7 @@ async function agentLoop(
             accText += textDelta;
             textDeltaCount += 1;
             textDeltaChars += textDelta.length;
-            logStreamDebug(tabId, debugEnabled, "stream:text-delta", {
+            logStreamDebug(tabId, debugEnabled, "stream:text-delta", turnContext, {
               delta: textDelta,
               deltaLength: textDelta.length,
               accumulatedLength: accText.length,
@@ -3240,7 +3605,7 @@ async function agentLoop(
             accReasoning += reasoningDelta;
             reasoningDeltaCount += 1;
             reasoningDeltaChars += reasoningDelta.length;
-            logStreamDebug(tabId, debugEnabled, "stream:reasoning-delta", {
+            logStreamDebug(tabId, debugEnabled, "stream:reasoning-delta", turnContext, {
               delta: reasoningDelta,
               deltaLength: reasoningDelta.length,
               accumulatedLength: accReasoning.length,
@@ -3255,7 +3620,7 @@ async function agentLoop(
           accText += delta;
           textDeltaCount += 1;
           textDeltaChars += delta.length;
-          logStreamDebug(tabId, debugEnabled, "stream:text-delta:textStream", {
+          logStreamDebug(tabId, debugEnabled, "stream:text-delta:textStream", turnContext, {
             delta,
             deltaLength: delta.length,
             accumulatedLength: accText.length,
@@ -3266,7 +3631,7 @@ async function agentLoop(
         }
       }
       } catch (err) {
-        logStreamDebug(tabId, debugEnabled, "stream:throw", err);
+        logStreamDebug(tabId, debugEnabled, "stream:throw", turnContext, err);
         // Re-throw if it's not a generic abort
         if (!signal.aborted) throw attachStreamErrors(err, streamErrors);
         return;
@@ -3279,13 +3644,14 @@ async function agentLoop(
           tabId,
           debugEnabled,
           "stream:tool-calls:raw",
+          turnContext,
           sdkToolCalls,
         );
       } catch (err) {
-        logStreamDebug(tabId, debugEnabled, "stream:tool-calls:error", err);
+        logStreamDebug(tabId, debugEnabled, "stream:tool-calls:error", turnContext, err);
         throw attachStreamErrors(err, streamErrors);
       }
-      await logStreamFinishDebug(tabId, debugEnabled, result);
+      await logStreamFinishDebug(tabId, debugEnabled, result, turnContext);
 
       // --- Turn complete ---
       if (reasoningStartedAtMs !== null && reasoningDurationMs === null) {
@@ -3299,14 +3665,15 @@ async function agentLoop(
       )
         .map((tc) => toApiToolCall(tc))
         .filter((tc): tc is ApiToolCall => tc !== null);
-      logStreamDebug(tabId, debugEnabled, "stream:tool-calls:parsed", {
+      logStreamDebug(tabId, debugEnabled, "stream:tool-calls:parsed", turnContext, {
         count: parsedToolCalls.length,
         toolCallIds: parsedToolCalls.map((tc) => tc.id),
         toolNames: parsedToolCalls.map((tc) => tc.function.name),
       });
-      logStreamDebug(tabId, debugEnabled, "stream:summary", {
+      const turnDurationMs = Math.max(0, Date.now() - turnStartedAtMs);
+      logStreamDebug(tabId, debugEnabled, "stream:summary", turnContext, {
         iteration,
-        turnDurationMs: Math.max(0, Date.now() - turnStartedAtMs),
+        turnDurationMs,
         usedFullStream,
         streamPartCount,
         streamErrorPartCount,
@@ -3320,6 +3687,22 @@ async function agentLoop(
         assistantReasoningChars: accReasoning.length,
         toolCallCount: parsedToolCalls.length,
         reasoningDurationMs: reasoningDurationMs ?? undefined,
+      });
+      writeRunnerLog({
+        level: "info",
+        tags: ["frontend", "agent-loop", "messages"],
+        event: "runner.turn.end",
+        message: `Turn ${iteration} completed`,
+        kind: "end",
+        durationMs: turnDurationMs,
+        data: {
+          iteration,
+          toolCallCount: parsedToolCalls.length,
+          assistantTextChars: accText.length,
+          assistantReasoningChars: accReasoning.length,
+          reasoningDurationMs: reasoningDurationMs ?? undefined,
+        },
+        context: turnContext,
       });
 
       const assistantApiMsg: AssistantApiMessage = {
@@ -3374,6 +3757,25 @@ async function agentLoop(
       const toolResults = await Promise.all(
         parsedToolCalls.map(async (tc) => {
         const tcId = tc.id;
+        const toolLog = createToolLogContext(turnContext, tcId, tc.function.name);
+        writeRunnerLog({
+          id: toolLog.startId,
+          level: "info",
+          tags: ["frontend", "agent-loop", "tool-calls"],
+          event: "runner.tool.start",
+          message: `${tc.function.name} queued`,
+          kind: "start",
+          expandable: true,
+          data: {
+            toolName: tc.function.name,
+            args: parseArgs(tc.function.arguments),
+          },
+          context: {
+            ...turnContext,
+            correlationId: tcId,
+            depth: turnContext.depth ?? 2,
+          },
+        });
 
         /** Update this specific tool call (by id) regardless of which message hosts it. */
         function updateToolCallById(patch: Partial<ToolCallDisplay>): void {
@@ -3457,6 +3859,7 @@ async function agentLoop(
             parentModelId: modelId,
             providers,
             debugEnabled,
+            logContext: toolLog.context,
           });
 
           updateToolCallById({
@@ -3552,6 +3955,7 @@ async function agentLoop(
               mcpTool.serverId,
               mcpTool.toolName,
               preArgs,
+              toolLog.context,
             );
             const mcpResult = await maybeArtifactizeMcpToolResult(
               tabId,
@@ -3559,6 +3963,7 @@ async function agentLoop(
               mcpTool,
               rawMcpResult,
               artifactizeReturnedFiles,
+              toolLog.context,
             );
 
             if (mcpResult.isError) {
@@ -3738,13 +4143,28 @@ async function agentLoop(
           args,
           tcId,
           callbacks,
-          { runId, agentId: "agent_main" },
+          {
+            runId,
+            agentId: "agent_main",
+            logContext: toolLog.context,
+          },
         );
 
         // Mark tool call as done/error
         updateToolCallById({
           status: result.ok ? "done" : "error",
           result: result.ok ? result.data : result.error,
+        });
+        writeRunnerLog({
+          level: result.ok ? "info" : "error",
+          tags: ["frontend", "agent-loop", "tool-calls"],
+          event: result.ok ? "runner.tool.end" : "runner.tool.error",
+          message: result.ok
+            ? `${tc.function.name} completed`
+            : `${tc.function.name} failed`,
+          kind: result.ok ? "end" : "error",
+          data: result.ok ? result.data : result.error,
+          context: toolLog.context,
         });
 
         return { tool_call_id: tcId, result };
@@ -3780,9 +4200,17 @@ async function agentLoop(
     setAgentErrorState(tabId, "Reached maximum iteration limit (50 turns)");
   } finally {
     try {
-      await shutdownMcpRun(runId);
+      await shutdownMcpRun(runId, runLogContext);
     } catch (error) {
-      console.error("Failed to shut down MCP run", error);
+      writeRunnerLog({
+        level: "error",
+        tags: ["frontend", "agent-loop", "system"],
+        event: "runner.mcp.shutdown.error",
+        message: "Failed to shut down MCP run",
+        kind: "error",
+        data: error,
+        context: runLogContext,
+      });
     }
   }
 }

--- a/src/agent/sessionRestore.ts
+++ b/src/agent/sessionRestore.ts
@@ -1,4 +1,5 @@
 import type { Tab } from "@/contexts/TabsContext";
+import { logFrontendSoon } from "@/logging/client";
 import { patchAgentState } from "./atoms";
 import {
   loadArchivedSessions,
@@ -121,7 +122,14 @@ export async function restoreArchivedTab(
   try {
     hydratePersistedSession(session);
   } catch (error) {
-    console.error("rakh: failed to hydrate restored session", error);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "db", "system"],
+      event: "sessionRestore.hydrate.error",
+      message: "Failed to hydrate restored session",
+      kind: "error",
+      data: { sessionId: session.id, error },
+    });
   }
 
   addTabWithId(buildTabFromSession(session));

--- a/src/agent/tools/artifacts.test.ts
+++ b/src/agent/tools/artifacts.test.ts
@@ -112,6 +112,64 @@ describe("artifact tools", () => {
     });
   });
 
+  it("forwards logContext to artifact commands", async () => {
+    const logContext = {
+      sessionId: "tab-1",
+      tabId: "tab-1",
+      traceId: "trace:run_1:main",
+      correlationId: "tc-artifact",
+    };
+    invokeMock
+      .mockResolvedValueOnce({
+        artifactId: "report_deadbeef",
+        version: 1,
+      })
+      .mockResolvedValueOnce({
+        artifactId: "report_deadbeef",
+        version: 1,
+      })
+      .mockResolvedValueOnce([{ artifactId: "report_deadbeef", version: 1 }]);
+
+    await artifactCreate(
+      "tab-1",
+      { runId: "run_1", agentId: "agent_main", logContext },
+      {
+        kind: "report",
+        contentFormat: "markdown",
+        content: "# Report",
+      },
+    );
+    await artifactGet(
+      "tab-1",
+      { artifactId: "report_deadbeef" },
+      logContext,
+    );
+    await artifactList("tab-1", {}, logContext);
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "db_artifact_create", {
+      sessionId: "tab-1",
+      runId: "run_1",
+      agentId: "agent_main",
+      input: expect.objectContaining({ kind: "report" }),
+      logContext,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "db_artifact_get", {
+      sessionId: "tab-1",
+      artifactId: "report_deadbeef",
+      version: null,
+      includeContent: true,
+      logContext,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "db_artifact_list", {
+      sessionId: "tab-1",
+      input: {
+        latestOnly: true,
+        limit: 200,
+      },
+      logContext,
+    });
+  });
+
   it("persists artifactType in framework metadata on create", async () => {
     invokeMock.mockResolvedValueOnce({
       artifactId: "review_1",

--- a/src/agent/tools/artifacts.ts
+++ b/src/agent/tools/artifacts.ts
@@ -15,6 +15,7 @@ import {
   ARTIFACT_CONTENT_FORMAT,
   type ArtifactContentFormat,
 } from "./artifactTypes";
+import type { LogContext } from "@/logging/types";
 
 export interface ArtifactRef {
   artifactId: string;
@@ -55,6 +56,7 @@ export interface ArtifactManifest {
 export interface ArtifactRuntimeContext {
   runId: string;
   agentId: string;
+  logContext?: LogContext;
 }
 
 export type ArtifactChangeType = "created" | "versioned";
@@ -226,12 +228,14 @@ export function withArtifactFrameworkMetadata(
 async function getLatestArtifactForFrameworkMetadata(
   sessionId: string,
   artifactId: string,
+  logContext?: LogContext,
 ): Promise<ArtifactManifest> {
   return invoke<ArtifactManifest>("db_artifact_get", {
     sessionId,
     artifactId,
     version: null,
     includeContent: false,
+    ...(logContext ? { logContext } : {}),
   });
 }
 
@@ -258,6 +262,7 @@ function toArtifactCreateInvokeInput(
 async function toArtifactVersionInvokeInput(
   sessionId: string,
   input: ArtifactVersionInput,
+  logContext?: LogContext,
 ): Promise<Omit<ArtifactVersionInput, "artifactType">> {
   let metadata = input.metadata;
 
@@ -265,6 +270,7 @@ async function toArtifactVersionInvokeInput(
     const latest = await getLatestArtifactForFrameworkMetadata(
       sessionId,
       input.artifactId,
+      logContext,
     );
     metadata = latest.metadata;
   }
@@ -328,6 +334,7 @@ export async function artifactCreate(
       runId: runtimeCtx.runId,
       agentId: runtimeCtx.agentId,
       input: toArtifactCreateInvokeInput(input),
+      ...(runtimeCtx.logContext ? { logContext: runtimeCtx.logContext } : {}),
     });
     return { ok: true, data: { artifact } };
   } catch (err) {
@@ -359,12 +366,17 @@ export async function artifactVersion(
 
   try {
     const runtimeCtx = ensureRuntimeContext(runtime);
-    const invokeInput = await toArtifactVersionInvokeInput(sessionId, input);
+    const invokeInput = await toArtifactVersionInvokeInput(
+      sessionId,
+      input,
+      runtimeCtx.logContext,
+    );
     const artifact = await invoke<ArtifactManifest>("db_artifact_version", {
       sessionId,
       runId: runtimeCtx.runId,
       agentId: runtimeCtx.agentId,
       input: invokeInput,
+      ...(runtimeCtx.logContext ? { logContext: runtimeCtx.logContext } : {}),
     });
     return { ok: true, data: { artifact } };
   } catch (err) {
@@ -376,6 +388,7 @@ export async function artifactVersion(
 export async function artifactGet(
   sessionId: string,
   input: ArtifactGetInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<{ artifact: ArtifactManifest }>> {
   if (!input.artifactId?.trim()) {
     return makeError("INVALID_ARGUMENT", "artifactId must not be empty");
@@ -386,6 +399,7 @@ export async function artifactGet(
       artifactId: input.artifactId,
       version: input.version ?? null,
       includeContent: input.includeContent ?? true,
+      ...(logContext ? { logContext } : {}),
     });
     return { ok: true, data: { artifact: withArtifactValidation(artifact) } };
   } catch (err) {
@@ -397,6 +411,7 @@ export async function artifactGet(
 export async function artifactList(
   sessionId: string,
   input: ArtifactListInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<{ artifacts: ArtifactManifest[] }>> {
   const normalizedInput: ArtifactListInput = {
     ...input,
@@ -410,6 +425,7 @@ export async function artifactList(
     const artifacts = await invoke<ArtifactManifest[]>("db_artifact_list", {
       sessionId,
       input: normalizedInput,
+      ...(logContext ? { logContext } : {}),
     });
     return { ok: true, data: { artifacts } };
   } catch (err) {

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -5,6 +5,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { ToolResult } from "../types";
+import type { LogContext } from "@/logging/types";
 
 function normalizeSlashes(path: string): string {
   return path.replace(/\\/g, "/");
@@ -76,6 +77,7 @@ export async function execRun(
   agentCwd: string,
   input: ExecRunInput,
   onOutput?: (stream: "stdout" | "stderr", data: string) => void,
+  logContext?: LogContext,
 ): Promise<ToolResult<ExecRunOutput>> {
   if (!input.command || input.command.trim() === "") {
     return {
@@ -123,6 +125,7 @@ export async function execRun(
       maxStderrBytes: input.maxStderrBytes ?? 200_000,
       stdin: input.stdin ?? null,
       runId: input.runId ?? null,
+      ...(logContext ? { logContext } : {}),
     });
     return { ok: true, data };
   } catch (e) {

--- a/src/agent/tools/git.test.ts
+++ b/src/agent/tools/git.test.ts
@@ -461,6 +461,7 @@ describe("gitWorktreeInit", () => {
         runId: "tc-1",
       },
       undefined,
+      undefined,
     );
     expect(result).toEqual({
       ok: true,

--- a/src/agent/tools/git.ts
+++ b/src/agent/tools/git.ts
@@ -15,6 +15,7 @@ import {
 } from "../approvals";
 import { execRun, type ExecRunOutput } from "./exec";
 import type { ToolResult } from "../types";
+import type { LogContext } from "@/logging/types";
 
 export interface GitWorktreeInitInput {
   suggestedBranch: string;
@@ -72,6 +73,14 @@ export interface GitWorktreeInitOutput {
 type OutputStream = "stdout" | "stderr";
 type OutputCallback = (stream: OutputStream, data: string) => void;
 
+function invokeWithLogContext<T>(
+  cmd: string,
+  args: Record<string, unknown>,
+  logContext?: LogContext,
+): Promise<T> {
+  return invoke<T>(cmd, logContext ? { ...args, logContext } : args);
+}
+
 async function runGitCommand(
   cwd: string,
   args: string[],
@@ -80,9 +89,10 @@ async function runGitCommand(
     maxStdoutBytes?: number;
     maxStderrBytes?: number;
   } = {},
+  logContext?: LogContext,
 ): Promise<ToolResult<GitExecOutput>> {
   try {
-    const result = await invoke<GitExecOutput>("exec_run", {
+    const result = await invokeWithLogContext<GitExecOutput>("exec_run", {
       command: "git",
       args,
       cwd,
@@ -91,7 +101,7 @@ async function runGitCommand(
       maxStdoutBytes: options.maxStdoutBytes ?? 32_000,
       maxStderrBytes: options.maxStderrBytes ?? 32_000,
       stdin: null,
-    });
+    }, logContext);
     return { ok: true, data: result };
   } catch (error) {
     return {
@@ -147,8 +157,14 @@ export function getBranchReleaseInstructions(
 
 export async function readGitHeadState(
   cwd: string,
+  logContext?: LogContext,
 ): Promise<ToolResult<GitHeadState>> {
-  const result = await runGitCommand(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  const result = await runGitCommand(
+    cwd,
+    ["symbolic-ref", "--quiet", "--short", "HEAD"],
+    {},
+    logContext,
+  );
   if (!result.ok) return result;
   if (result.data.exitCode === 0) {
     const branch = result.data.stdout.trim();
@@ -169,13 +185,14 @@ export async function readGitHeadState(
 export async function switchToGitBranch(
   cwd: string,
   branch: string,
+  logContext?: LogContext,
 ): Promise<
   ToolResult<{
     branch: string;
     guidance?: BranchReleaseGuidance;
   }>
 > {
-  const result = await runGitCommand(cwd, ["switch", branch]);
+  const result = await runGitCommand(cwd, ["switch", branch], {}, logContext);
   if (!result.ok) return result;
   if (result.data.exitCode === 0) {
     return { ok: true, data: { branch } };
@@ -202,8 +219,11 @@ export async function switchToGitBranch(
   };
 }
 
-export async function detachGitHead(cwd: string): Promise<ToolResult<{ detached: true }>> {
-  const result = await runGitCommand(cwd, ["switch", "--detach"]);
+export async function detachGitHead(
+  cwd: string,
+  logContext?: LogContext,
+): Promise<ToolResult<{ detached: true }>> {
+  const result = await runGitCommand(cwd, ["switch", "--detach"], {}, logContext);
   if (!result.ok) return result;
   if (result.data.exitCode === 0) {
     return { ok: true, data: { detached: true } };
@@ -219,12 +239,13 @@ export async function detachGitHead(cwd: string): Promise<ToolResult<{ detached:
 
 export async function stageAllGitChanges(
   cwd: string,
+  logContext?: LogContext,
 ): Promise<ToolResult<{ staged: true }>> {
   const result = await runGitCommand(cwd, ["add", "-A"], {
     timeoutMs: 30_000,
     maxStdoutBytes: 8_000,
     maxStderrBytes: 16_000,
-  });
+  }, logContext);
   if (!result.ok) return result;
   if (result.data.exitCode === 0) {
     return { ok: true, data: { staged: true } };
@@ -382,6 +403,7 @@ async function runSetupAttempt(
   setupCommand: string,
   attemptCount: number,
   onSetupOutput?: OutputCallback,
+  logContext?: LogContext,
 ): Promise<GitWorktreeSetupState> {
   if (attemptCount > 1) {
     onSetupOutput?.(
@@ -399,6 +421,7 @@ async function runSetupAttempt(
       runId: toolCallId,
     },
     onSetupOutput,
+    logContext,
   );
 
   if (!result.ok) {
@@ -427,6 +450,7 @@ export async function gitWorktreeInit(
   agentCwd: string,
   input: GitWorktreeInitInput,
   onSetupOutput?: OutputCallback,
+  logContext?: LogContext,
 ): Promise<ToolResult<GitWorktreeInitOutput>> {
   const state = getAgentState(tabId);
   const config = state.config;
@@ -448,7 +472,7 @@ export async function gitWorktreeInit(
 
   let repoRoot: string;
   try {
-    const result = await invoke<{
+    const result = await invokeWithLogContext<{
       exitCode: number;
       stdout: string;
       stderr: string;
@@ -461,7 +485,7 @@ export async function gitWorktreeInit(
       maxStdoutBytes: 4096,
       maxStderrBytes: 4096,
       stdin: null,
-    });
+    }, logContext);
     if (result.exitCode !== 0) {
       return {
         ok: false,
@@ -482,7 +506,7 @@ export async function gitWorktreeInit(
   const repoName = repoRoot.split("/").filter(Boolean).pop() ?? "repo";
   let slug = repoName;
   try {
-    const result = await invoke<{ exitCode: number; stdout: string }>(
+    const result = await invokeWithLogContext<{ exitCode: number; stdout: string }>(
       "exec_run",
       {
         command: "git",
@@ -494,6 +518,7 @@ export async function gitWorktreeInit(
         maxStderrBytes: 4096,
         stdin: null,
       },
+      logContext,
     );
     if (result.exitCode === 0 && result.stdout.trim()) {
       slug = parseRemoteSlug(result.stdout, repoName);
@@ -532,13 +557,14 @@ export async function gitWorktreeInit(
     finalBranch = sanitiseBranch(branchName || sanitised);
 
     try {
-      const created = await invoke<{ path: string; branch: string }>(
+      const created = await invokeWithLogContext<{ path: string; branch: string }>(
         "git_worktree_add",
         {
           repoPath: repoRoot,
           repoSlug,
           branch: finalBranch,
         },
+        logContext,
       );
       finalPath = created.path;
       break;
@@ -616,6 +642,7 @@ export async function gitWorktreeInit(
       setupCommand,
       attemptCount,
       onSetupOutput,
+      logContext,
     );
 
     if (setupAttempt.status === "success") {

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -201,8 +201,52 @@ describe("tools/index dispatchTool", () => {
       "tc-1",
     );
 
-    expect(listDirMock).toHaveBeenCalledWith("/cwd", { path: "src" });
+    expect(listDirMock).toHaveBeenCalledWith("/cwd", { path: "src" }, undefined);
     expect(result).toMatchObject({ ok: true });
+  });
+
+  it("passes runtime logContext through workspace and exec dispatch", async () => {
+    const logContext = {
+      sessionId: "tab",
+      tabId: "tab",
+      traceId: "trace:run-1:main",
+      correlationId: "tc-log",
+    };
+    listDirMock.mockResolvedValue({
+      ok: true,
+      data: { path: "/cwd/src", entries: [], truncated: false },
+    });
+    execRunMock.mockResolvedValue({ ok: true, data: { exitCode: 0 } });
+
+    await dispatchTool(
+      "tab",
+      "/cwd",
+      "workspace_listDir",
+      { path: "src" },
+      "tc-log",
+      undefined,
+      { runId: "run_1", agentId: "agent_main", logContext },
+    );
+    await dispatchTool(
+      "tab",
+      "/cwd",
+      "exec_run",
+      { command: "pwd" },
+      "tc-log",
+      undefined,
+      { runId: "run_1", agentId: "agent_main", logContext },
+    );
+
+    expect(listDirMock).toHaveBeenCalledWith("/cwd", { path: "src" }, logContext);
+    expect(execRunMock).toHaveBeenCalledWith(
+      "/cwd",
+      expect.objectContaining({
+        command: "pwd",
+        runId: "tc-log",
+      }),
+      undefined,
+      logContext,
+    );
   });
 
   it("routes agent_card_add calls to cardAdd", async () => {
@@ -264,7 +308,7 @@ describe("tools/index dispatchTool", () => {
     expect(editFileMock).toHaveBeenCalledWith("/cwd", {
       path: "file.txt",
       changes: [{ oldString: "original", newString: "edited" }],
-    });
+    }, undefined);
     expect(computeDiffFileMock).toHaveBeenCalledWith(
       "file.txt",
       "original content",
@@ -341,7 +385,7 @@ describe("tools/index dispatchTool", () => {
       content: "export const x = 1;",
       mode: "create",
       createDirs: true,
-    });
+    }, undefined);
     expect(computeDiffFileMock).toHaveBeenCalledWith(
       "new.ts",
       "",
@@ -375,6 +419,7 @@ describe("tools/index dispatchTool", () => {
       "/cwd",
       { suggestedBranch: "feature branch" },
       undefined,
+      undefined,
     );
     expect(result).toMatchObject({ ok: true });
   });
@@ -405,6 +450,7 @@ describe("tools/index dispatchTool", () => {
       "/cwd",
       { suggestedBranch: "feature branch" },
       onExecOutput,
+      undefined,
     );
   });
 
@@ -426,6 +472,7 @@ describe("tools/index dispatchTool", () => {
       "/cwd",
       { command: "pwd", runId: "tool-call-exec" },
       undefined, // no onExecOutput when no callbacks provided
+      undefined,
     );
     expect(result).toMatchObject({ ok: true });
   });
@@ -450,6 +497,7 @@ describe("tools/index dispatchTool", () => {
       "/cwd",
       { command: "pwd", runId: "tc-cb" },
       onExecOutput,
+      undefined,
     );
   });
 
@@ -522,7 +570,7 @@ describe("tools/index dispatchTool", () => {
     );
 
     expect(artifactVersionMock).toHaveBeenCalledTimes(1);
-    expect(artifactGetMock).toHaveBeenCalledWith("tab", { artifactId: "a1" });
-    expect(artifactListMock).toHaveBeenCalledWith("tab", { latestOnly: true });
+    expect(artifactGetMock).toHaveBeenCalledWith("tab", { artifactId: "a1" }, undefined);
+    expect(artifactListMock).toHaveBeenCalledWith("tab", { latestOnly: true }, undefined);
   });
 });

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -36,6 +36,7 @@ import type { ToolResult } from "../types";
 import { computeDiffFile } from "../patchToDiff";
 import { serializeDiff } from "@/components/diffSerialization";
 import { patchAgentState, getAgentState } from "../atoms";
+import type { LogContext } from "@/logging/types";
 
 export { TOOL_DEFINITIONS, getToolDefinitionsByNames } from "./definitions";
 
@@ -109,6 +110,10 @@ export interface DispatchCallbacks {
   onExecOutput?: (stream: "stdout" | "stderr", data: string) => void;
 }
 
+export interface DispatchRuntimeContext extends ArtifactRuntimeContext {
+  logContext?: LogContext;
+}
+
 export async function dispatchTool(
   tabId: string,
   cwd: string,
@@ -117,7 +122,7 @@ export async function dispatchTool(
   args: Record<string, any>,
   toolCallId: string = "",
   callbacks?: DispatchCallbacks,
-  runtime?: ArtifactRuntimeContext,
+  runtime?: DispatchRuntimeContext,
 ): Promise<ToolResult<unknown>> {
   // ⚠️  args are LLM-generated and may be missing fields; each tool validates internally.
   // The casts below are intentional — runtime errors surface as ToolResult errors.
@@ -126,13 +131,13 @@ export async function dispatchTool(
   switch (name) {
     /* ── workspace ──────────────────────────────────────────────────────────── */
     case "workspace_listDir":
-      return listDir(cwd, a);
+      return listDir(cwd, a, runtime?.logContext);
 
     case "workspace_stat":
-      return statFile(cwd, a);
+      return statFile(cwd, a, runtime?.logContext);
 
     case "workspace_readFile":
-      return readFile(cwd, a);
+      return readFile(cwd, a, runtime?.logContext);
 
     case "workspace_writeFile": {
       const wfPath = typeof a.path === "string" ? a.path : "";
@@ -147,7 +152,7 @@ export async function dispatchTool(
         content: typeof a.content === "string" ? a.content : "",
         mode: wfOverwrite ? "create_or_overwrite" : "create",
         createDirs: true,
-      });
+      }, runtime?.logContext);
 
       if (wfResult.ok) {
         const currentContent = typeof a.content === "string" ? a.content : "";
@@ -162,11 +167,15 @@ export async function dispatchTool(
       // Snapshot original before editing
       const efOriginal = await snapshotOriginal(tabId, cwd, efInput.path);
 
-      const efResult = await editFile(cwd, efInput);
+      const efResult = await editFile(cwd, efInput, runtime?.logContext);
 
       if (efResult.ok) {
         // Read the new content from disk
-        const readResult = await readFile(cwd, { path: efInput.path });
+        const readResult = await readFile(
+          cwd,
+          { path: efInput.path },
+          runtime?.logContext,
+        );
         const currentContent = readResult.ok ? readResult.data.content : "";
         upsertReviewEdit(tabId, efInput.path, efOriginal ?? "", currentContent);
       }
@@ -175,14 +184,21 @@ export async function dispatchTool(
     }
 
     case "workspace_glob":
-      return glob(cwd, a);
+      return glob(cwd, a, runtime?.logContext);
 
     case "workspace_search":
-      return searchFiles(cwd, a);
+      return searchFiles(cwd, a, runtime?.logContext);
 
     /* ── git ─────────────────────────────────────────────────────────────────────────── */
     case "git_worktree_init":
-      return gitWorktreeInit(tabId, toolCallId, cwd, a, callbacks?.onExecOutput);
+      return gitWorktreeInit(
+        tabId,
+        toolCallId,
+        cwd,
+        a,
+        callbacks?.onExecOutput,
+        runtime?.logContext,
+      );
 
     /* ── exec ──────────────────────────────────────────────────────────────────────── */
     case "exec_run":
@@ -196,6 +212,7 @@ export async function dispatchTool(
               : undefined,
         },
         callbacks?.onExecOutput,
+        runtime?.logContext,
       );
 
     /* ── agent.todo ─────────────────────────────────────────────────────────── */
@@ -222,10 +239,10 @@ export async function dispatchTool(
       return artifactVersion(tabId, runtime, a);
 
     case "agent_artifact_get":
-      return artifactGet(tabId, a);
+      return artifactGet(tabId, a, runtime?.logContext);
 
     case "agent_artifact_list":
-      return artifactList(tabId, a);
+      return artifactList(tabId, a, runtime?.logContext);
 
     /* ── agent.title ─────────────────────────────────────────────────────────────── */
     case "agent_title_set":

--- a/src/agent/tools/workspace.ts
+++ b/src/agent/tools/workspace.ts
@@ -5,6 +5,7 @@
  */
 import { invoke } from "@tauri-apps/api/core";
 import type { ToolResult } from "../types";
+import type { LogContext } from "@/logging/types";
 
 /* ── helpers ────────────────────────────────────────────────────────────────── */
 
@@ -63,11 +64,12 @@ function validatePath(
 async function tauriInvoke<T>(
   cmd: string,
   args: Record<string, unknown>,
+  logContext?: LogContext,
 ): Promise<T> {
   if (!isTauri()) {
     throw new Error("Tauri is not available — run inside the Tauri app");
   }
-  return invoke<T>(cmd, args);
+  return invoke<T>(cmd, logContext ? { ...args, logContext } : args);
 }
 
 /* ── 1.1 workspace.listDir ──────────────────────────────────────────────────── */
@@ -95,6 +97,7 @@ export interface ListDirOutput {
 export async function listDir(
   cwd: string,
   input: ListDirInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<ListDirOutput>> {
   const pathErr = validatePath(input.path, { allowEmpty: true });
   if (pathErr)
@@ -107,7 +110,7 @@ export async function listDir(
       path: absPath,
       includeHidden: input.includeHidden ?? false,
       maxEntries: input.maxEntries ?? 200,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     return { ok: false, error: { code: "INTERNAL", message: String(e) } };
@@ -131,6 +134,7 @@ export interface StatFileOutput {
 export async function statFile(
   cwd: string,
   input: StatFileInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<StatFileOutput>> {
   const pathErr = validatePath(input.path);
   if (pathErr)
@@ -140,7 +144,7 @@ export async function statFile(
   try {
     const data = await tauriInvoke<StatFileOutput>("stat_file", {
       path: absPath,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     return { ok: false, error: { code: "INTERNAL", message: String(e) } };
@@ -168,6 +172,7 @@ export interface ReadFileOutput {
 export async function readFile(
   cwd: string,
   input: ReadFileInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<ReadFileOutput>> {
   const pathErr = validatePath(input.path);
   if (pathErr)
@@ -181,7 +186,7 @@ export async function readFile(
       startLine: input.range?.startLine ?? null,
       endLine: input.range?.endLine ?? null,
       maxBytes: input.maxBytes ?? 200_000,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     const msg = String(e);
@@ -213,6 +218,7 @@ export interface WriteFileOutput {
 export async function writeFile(
   cwd: string,
   input: WriteFileInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<WriteFileOutput>> {
   const pathErr = validatePath(input.path);
   if (pathErr)
@@ -237,7 +243,7 @@ export async function writeFile(
       content: input.content,
       mode: input.mode ?? "create_or_overwrite",
       createDirs: input.createDirs ?? true,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     const msg = String(e);
@@ -316,6 +322,7 @@ export function applyEditChanges(
 export async function validateEditFile(
   cwd: string,
   input: EditFileInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<null> | null> {
   const pathErr = validatePath(input.path);
   if (pathErr)
@@ -332,7 +339,7 @@ export async function validateEditFile(
   }
 
   // Read current content
-  const readResult = await readFile(cwd, { path: input.path });
+  const readResult = await readFile(cwd, { path: input.path }, logContext);
   if (!readResult.ok) {
     return {
       ok: false,
@@ -356,13 +363,14 @@ export async function validateEditFile(
 export async function editFile(
   cwd: string,
   input: EditFileInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<EditFileOutput>> {
-  const validationErr = await validateEditFile(cwd, input);
+  const validationErr = await validateEditFile(cwd, input, logContext);
   if (validationErr) {
     return validationErr as unknown as ToolResult<EditFileOutput>;
   }
 
-  const readResult = await readFile(cwd, { path: input.path });
+  const readResult = await readFile(cwd, { path: input.path }, logContext);
   if (!readResult.ok) {
     return {
       ok: false,
@@ -386,7 +394,7 @@ export async function editFile(
     path: input.path,
     content: newContent,
     mode: "overwrite",
-  });
+  }, logContext);
   if (!writeResult.ok) return writeResult as ToolResult<EditFileOutput>;
 
   return {
@@ -417,6 +425,7 @@ export interface GlobOutput {
 export async function glob(
   agentCwd: string,
   input: GlobInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<GlobOutput>> {
   const pathErr = validatePath(input.cwd, { allowEmpty: true });
   if (pathErr)
@@ -434,7 +443,7 @@ export async function glob(
       maxMatches: input.maxMatches ?? 2000,
       includeDirs: input.includeDirs ?? false,
       includeHidden: input.includeHidden ?? false,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     return { ok: false, error: { code: "INTERNAL", message: String(e) } };
@@ -473,6 +482,7 @@ export interface SearchFilesOutput {
 export async function searchFiles(
   agentCwd: string,
   input: SearchFilesInput,
+  logContext?: LogContext,
 ): Promise<ToolResult<SearchFilesOutput>> {
   const pathErr = validatePath(input.rootDir, { allowEmpty: true });
   if (pathErr)
@@ -494,7 +504,7 @@ export async function searchFiles(
       includeHidden: input.includeHidden ?? false,
       contextLines: input.contextLines ?? 0,
       followSymlinks: input.followSymlinks ?? false,
-    });
+    }, logContext);
     return { ok: true, data };
   } catch (e) {
     return { ok: false, error: { code: "INTERNAL", message: String(e) } };

--- a/src/agent/useAgents.ts
+++ b/src/agent/useAgents.ts
@@ -11,6 +11,7 @@
 
 import { useAtom, useAtomValue } from "jotai";
 import { useCallback } from "react";
+import { logFrontendSoon } from "@/logging/client";
 
 import {
   agentAtomFamily,
@@ -180,7 +181,16 @@ export function useSendMessage() {
   return useCallback(
     (tabId: string, message: string, attachments?: AttachedImage[]) => {
       // fire-and-forget; the runner updates atoms reactively
-      runAgent(tabId, message, attachments).catch(console.error);
+      runAgent(tabId, message, attachments).catch((error) => {
+        logFrontendSoon({
+          level: "error",
+          tags: ["frontend", "agent-loop"],
+          event: "agent.send-message.error",
+          message: "Failed to start an agent run from the send-message hook.",
+          data: { error, tabId },
+          context: { tabId },
+        });
+      });
     },
     [],
   );
@@ -194,7 +204,16 @@ export function useStopAgent() {
 /** retryAgent — re-run the last user message after an error */
 export function useRetryAgent() {
   return useCallback((tabId: string) => {
-    _retryAgent(tabId).catch(console.error);
+    _retryAgent(tabId).catch((error) => {
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "agent-loop"],
+        event: "agent.retry.error",
+        message: "Failed to retry the agent run.",
+        data: { error, tabId },
+        context: { tabId },
+      });
+    });
   }, []);
 }
 
@@ -206,7 +225,16 @@ export function useQueueMessage() {
 
 export function useSteerMessage() {
   return useCallback((tabId: string, message: string, queuedMessageId?: string) => {
-    _steerMessage(tabId, message, queuedMessageId).catch(console.error);
+    _steerMessage(tabId, message, queuedMessageId).catch((error) => {
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "agent-loop"],
+        event: "agent.steer.error",
+        message: "Failed to steer the active agent run.",
+        data: { error, tabId, queuedMessageId },
+        context: { tabId, correlationId: queuedMessageId },
+      });
+    });
   }, []);
 }
 

--- a/src/components/DesktopTrayManager.tsx
+++ b/src/components/DesktopTrayManager.tsx
@@ -8,6 +8,7 @@ import {
   type WorkspaceAggregateStatus,
 } from "@/agent/desktopStatus";
 import { useTabs } from "@/contexts/TabsContext";
+import { logFrontendSoon } from "@/logging/client";
 import { focusAppWindow } from "@/notifications";
 import trayDarkIconUrl from "../../src-tauri/icons/tray-dark.png";
 import trayLightIconUrl from "../../src-tauri/icons/tray-light.png";
@@ -242,7 +243,13 @@ export default function DesktopTrayManager() {
       return tray;
     })().catch((error) => {
       trayInitPromiseRef.current = null;
-      console.error("Failed to initialize desktop tray:", error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "desktop-tray.init.error",
+        message: "Failed to initialize the desktop tray.",
+        data: { error },
+      });
       return null;
     });
 
@@ -301,7 +308,13 @@ export default function DesktopTrayManager() {
 
       appliedStateRef.current = nextState;
     } catch (error) {
-      console.error("Failed to sync desktop tray state:", error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "desktop-tray.sync.error",
+        message: "Failed to sync desktop tray state.",
+        data: { error },
+      });
     }
   }, [ensureTrayReady]);
 

--- a/src/components/MentionTextarea.tsx
+++ b/src/components/MentionTextarea.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, TauriEvent } from "@tauri-apps/api/event";
+import { logFrontendSoon } from "@/logging/client";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -652,7 +653,15 @@ export const MentionTextarea = forwardRef<
       .then((result) => {
         setFiles(result.matches);
       })
-      .catch(console.error);
+      .catch((error) => {
+        logFrontendSoon({
+          level: "error",
+          tags: ["frontend", "system"],
+          event: "mention-textarea.search-files.error",
+          message: "Failed to refresh mention autocomplete files.",
+          data: { error, cwd },
+        });
+      });
   }, [cwd]);
 
   useEffect(() => {

--- a/src/components/NewSession.tsx
+++ b/src/components/NewSession.tsx
@@ -35,6 +35,7 @@ import {
   type SavedProject,
 } from "@/projects";
 import { writeProjectScriptsConfig } from "@/projectScripts";
+import { logFrontendSoon } from "@/logging/client";
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Advanced options — localStorage helpers
@@ -315,7 +316,13 @@ export default function NewSession({ onSubmit }: NewSessionProps) {
         addProject(result);
       }
     } catch (error) {
-      console.error("Failed to select folder:", error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "new-session.select-folder.error",
+        message: "Failed to select a folder.",
+        data: { error },
+      });
     }
   };
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { logFrontendSoon } from "@/logging/client";
 
 import "@xterm/xterm/css/xterm.css";
 
@@ -99,7 +100,13 @@ export default function Terminal({
             data: `${command}\r`,
           });
         } catch (error) {
-          console.error("Failed to run queued PTY command", error);
+          logFrontendSoon({
+            level: "error",
+            tags: ["frontend", "system"],
+            event: "terminal.pty.queue.error",
+            message: "Failed to run a queued PTY command.",
+            data: { error, tabId, command },
+          });
           queueCommand(tabId, command);
           break;
         }
@@ -189,7 +196,17 @@ export default function Terminal({
           invoke("write_pty", { sessionId: session.sessionId, data }).catch(
             (err) => {
               if (!session.exited) {
-                console.error("Failed to write to PTY", err);
+                logFrontendSoon({
+                  level: "error",
+                  tags: ["frontend", "system"],
+                  event: "terminal.pty.write.error",
+                  message: "Failed to write to the PTY.",
+                  data: {
+                    error: err,
+                    sessionId: session.sessionId,
+                    tabId: session.tabId,
+                  },
+                });
               }
             },
           );
@@ -203,7 +220,19 @@ export default function Terminal({
             cols: size.cols,
           }).catch((err) => {
             if (!session.exited) {
-              console.error("Failed to resize PTY", err);
+              logFrontendSoon({
+                level: "error",
+                tags: ["frontend", "system"],
+                event: "terminal.pty.resize.error",
+                message: "Failed to resize the PTY.",
+                data: {
+                  error: err,
+                  sessionId: session.sessionId,
+                  tabId: session.tabId,
+                  rows: size.rows,
+                  cols: size.cols,
+                },
+              });
             }
           });
         });
@@ -214,7 +243,13 @@ export default function Terminal({
           setTimeout(() => session.fitAddon.fit(), 0);
         }
       } catch (e) {
-        console.error("Failed to spawn PTY", e);
+        logFrontendSoon({
+          level: "error",
+          tags: ["frontend", "system"],
+          event: "terminal.pty.spawn.error",
+          message: "Failed to spawn a PTY session.",
+          data: { error: e, tabId: session.tabId, cwd: spawnCwd ?? cwd ?? "" },
+        });
         session.exited = true;
         session.exitCode = -1;
         session.sessionId = "";
@@ -358,7 +393,15 @@ export default function Terminal({
     invoke("write_pty", {
       sessionId: session.sessionId,
       data: `cd ${JSON.stringify(cwd)}\r`,
-    }).catch(console.error);
+    }).catch((error) => {
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "terminal.cwd-sync.error",
+        message: "Failed to sync the terminal working directory.",
+        data: { error, sessionId: session.sessionId, tabId: activeTabId, cwd },
+      });
+    });
   }, [cwd, activeTabId]);
 
   useEffect(() => {
@@ -374,7 +417,18 @@ export default function Terminal({
         sessionId: session.sessionId,
         data: `${commandRequest.command}\r`,
       }).catch((error) => {
-        console.error("Failed to run PTY command", error);
+        logFrontendSoon({
+          level: "error",
+          tags: ["frontend", "system"],
+          event: "terminal.pty.command.error",
+          message: "Failed to run a PTY command.",
+          data: {
+            error,
+            sessionId: session.sessionId,
+            tabId: activeTabId,
+            command: commandRequest.command,
+          },
+        });
       });
       return;
     }

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -42,6 +42,7 @@ import {
   type McpServerConfig,
   type McpServerProbeResult,
 } from "@/agent/mcp";
+import { logFrontendSoon } from "@/logging/client";
 import { cn } from "@/utils/cn";
 import {
   THEME_NAMES,
@@ -1294,10 +1295,13 @@ function ProvidersSection({
       setProviderRefreshStatus((prev) => ({ ...prev, [provider.id]: "ok" }));
       scheduleRefreshStatusReset(provider.id);
     } catch (error) {
-      console.error(
-        `Failed to refresh OpenAI-compatible models for "${provider.name}"`,
-        error,
-      );
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "settings.providers.refresh-models.error",
+        message: `Failed to refresh OpenAI-compatible models for "${provider.name}".`,
+        data: { error, providerId: provider.id, providerName: provider.name },
+      });
       setProviderRefreshStatus((prev) => ({
         ...prev,
         [provider.id]: "error",
@@ -1580,7 +1584,13 @@ function McpServersSection({
       setProbeStatusById((prev) => ({ ...prev, [server.id]: "ok" }));
       scheduleProbeStatusReset(server.id);
     } catch (error) {
-      console.error(`Failed to probe MCP server "${server.name}"`, error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "settings.mcp.probe.error",
+        message: `Failed to probe MCP server "${server.name}".`,
+        data: { error, serverId: server.id, serverName: server.name },
+      });
       setProbeStatusById((prev) => ({ ...prev, [server.id]: "error" }));
       scheduleProbeStatusReset(server.id);
     }

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -35,6 +35,7 @@ import {
   isTauriRuntime,
   type EnvKeyEntry,
 } from "@/agent/useEnvProviderKeys";
+import { logFrontendSoon } from "@/logging/client";
 import type { ThemeName } from "@/styles/themes/registry";
 import { checkForAppUpdates, installAppUpdate } from "@/updater";
 import { useTabs } from "@/contexts/TabsContext";
@@ -220,7 +221,12 @@ export function useSettingsController(): SettingsControllerValue {
     if (nextValue) {
       const granted = await ensureNotificationPermission();
       if (!granted) {
-        console.warn("Notification permission denied by user");
+        logFrontendSoon({
+          level: "warn",
+          tags: ["frontend", "system"],
+          event: "settings.notifications.denied",
+          message: "Notification permission was denied by the user.",
+        });
         return;
       }
     }

--- a/src/logging/client.test.ts
+++ b/src/logging/client.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, listenMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+import {
+  buildFrontendLogEntry,
+  listenForLogEntries,
+  writeLogEntry,
+} from "./client";
+
+describe("logging/client", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    listenMock.mockReset();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("falls back to structured console output outside Tauri", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      const entry = buildFrontendLogEntry({
+        tags: ["frontend", "system"],
+        event: "logging.test",
+        message: "console fallback",
+      });
+      await writeLogEntry(entry);
+
+      expect(invokeMock).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith(
+        "[rakh][logging.test]",
+        "console fallback",
+        expect.objectContaining({
+          event: "logging.test",
+          message: "console fallback",
+          source: "frontend",
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("persists log entries through the Tauri backend when available", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    invokeMock.mockResolvedValueOnce(undefined);
+
+    const entry = buildFrontendLogEntry({
+      tags: ["frontend", "messages"],
+      event: "logging.persist",
+      message: "persist me",
+      context: { traceId: "trace:run_1:main", correlationId: "tc-1", depth: 2 },
+    });
+    await writeLogEntry(entry);
+
+    expect(invokeMock).toHaveBeenCalledWith("logs_write", { entry });
+  });
+
+  it("subscribes to live log_entry events in Tauri", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    const unlisten = vi.fn();
+    listenMock.mockResolvedValueOnce(unlisten);
+    const handler = vi.fn();
+
+    const result = await listenForLogEntries(handler);
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "log_entry",
+      expect.any(Function),
+    );
+    expect(result).toBe(unlisten);
+  });
+});

--- a/src/logging/client.ts
+++ b/src/logging/client.ts
@@ -1,0 +1,197 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import type {
+  FrontendLogInput,
+  LogClearResult,
+  LogContext,
+  LogEntry,
+  LogExportResult,
+  LogQueryFilter,
+} from "./types";
+
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function nextRandomId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function normalizeTags(tags: string[]): string[] {
+  return Array.from(
+    new Set(
+      tags
+        .map((tag) => tag.trim().toLowerCase())
+        .filter((tag) => tag.length > 0),
+    ),
+  ).sort();
+}
+
+function jsonSafe(value: unknown): unknown {
+  const seen = new WeakSet<object>();
+
+  const replacer = (_key: string, current: unknown): unknown => {
+    if (typeof current === "bigint") return current.toString();
+    if (typeof current === "function") {
+      return `[Function${current.name ? `: ${current.name}` : ""}]`;
+    }
+    if (current instanceof Error) {
+      const error = current as Error & Record<string, unknown>;
+      return {
+        name: current.name,
+        message: current.message,
+        stack: current.stack,
+        ...Object.fromEntries(Object.entries(error)),
+      };
+    }
+    if (current && typeof current === "object") {
+      if (seen.has(current as object)) return "[Circular]";
+      seen.add(current as object);
+      if (current instanceof Map) {
+        return {
+          __type: "Map",
+          entries: Array.from(current.entries()),
+        };
+      }
+      if (current instanceof Set) {
+        return {
+          __type: "Set",
+          values: Array.from(current.values()),
+        };
+      }
+    }
+    return current;
+  };
+
+  try {
+    return JSON.parse(JSON.stringify(value, replacer));
+  } catch {
+    return String(value);
+  }
+}
+
+function consoleMethod(level: LogEntry["level"]): "debug" | "info" | "warn" | "error" {
+  switch (level) {
+    case "trace":
+    case "debug":
+      return "debug";
+    case "warn":
+      return "warn";
+    case "error":
+      return "error";
+    default:
+      return "info";
+  }
+}
+
+export function nextLogId(prefix = "log"): string {
+  return `${prefix}:${Date.now()}:${nextRandomId()}`;
+}
+
+export function nextTraceId(...parts: string[]): string {
+  const normalized = parts
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => part.replace(/[^a-zA-Z0-9:_-]+/g, "-"));
+  return normalized.join(":") || `trace:${nextRandomId()}`;
+}
+
+export function createChildLogContext(
+  parent: LogContext | undefined,
+  overrides: Partial<LogContext> = {},
+  depthStep = 1,
+): LogContext {
+  const depth = overrides.depth ?? (parent?.depth ?? 0) + depthStep;
+  return {
+    ...parent,
+    ...overrides,
+    depth,
+  };
+}
+
+export function buildFrontendLogEntry(input: FrontendLogInput): LogEntry {
+  const timestampMs = Date.now();
+  const context = input.context ?? {};
+  return {
+    id: input.id ?? nextLogId("frontend"),
+    timestamp: new Date(timestampMs).toISOString(),
+    timestampMs,
+    level: input.level ?? "info",
+    source: "frontend",
+    tags: normalizeTags(input.tags),
+    event: input.event,
+    message: input.message,
+    ...(context.traceId ? { traceId: context.traceId } : {}),
+    ...(context.correlationId ? { correlationId: context.correlationId } : {}),
+    ...(context.parentId ? { parentId: context.parentId } : {}),
+    depth: context.depth ?? 0,
+    kind: input.kind ?? "event",
+    expandable: input.expandable ?? false,
+    ...(typeof input.durationMs === "number" ? { durationMs: input.durationMs } : {}),
+    ...(input.data !== undefined ? { data: jsonSafe(input.data) } : {}),
+  };
+}
+
+function writeToConsole(entry: LogEntry): void {
+  const method = consoleMethod(entry.level);
+  console[method](`[rakh][${entry.event}]`, entry.message, entry);
+}
+
+export async function writeLogEntry(entry: LogEntry): Promise<void> {
+  if (!isTauriRuntime()) {
+    writeToConsole(entry);
+    return;
+  }
+
+  try {
+    await invoke("logs_write", { entry });
+  } catch (error) {
+    console.error("rakh: failed to persist structured log entry", {
+      error,
+      entry,
+    });
+  }
+}
+
+export async function logFrontend(input: FrontendLogInput): Promise<LogEntry> {
+  const entry = buildFrontendLogEntry(input);
+  await writeLogEntry(entry);
+  return entry;
+}
+
+export function logFrontendSoon(input: FrontendLogInput): void {
+  void logFrontend(input);
+}
+
+export async function queryLogs(
+  filter: LogQueryFilter = {},
+): Promise<LogEntry[]> {
+  if (!isTauriRuntime()) return [];
+  return invoke<LogEntry[]>("logs_query", { filter });
+}
+
+export async function exportLogs(
+  filter: LogQueryFilter = {},
+): Promise<LogExportResult | null> {
+  if (!isTauriRuntime()) return null;
+  return invoke<LogExportResult>("logs_export", { filter });
+}
+
+export async function clearLogs(): Promise<LogClearResult> {
+  if (!isTauriRuntime()) {
+    return { removedFiles: 0 };
+  }
+  return invoke<LogClearResult>("logs_clear");
+}
+
+export async function listenForLogEntries(
+  handler: (entry: LogEntry) => void,
+): Promise<UnlistenFn | null> {
+  if (!isTauriRuntime()) return null;
+  return listen<LogEntry>("log_entry", (event) => {
+    handler(event.payload);
+  });
+}

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -1,0 +1,68 @@
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error";
+export type LogSource = "backend" | "frontend";
+export type LogKind = "start" | "end" | "event" | "error";
+export type TagMode = "and" | "or";
+
+export interface LogContext {
+  sessionId?: string;
+  tabId?: string;
+  traceId?: string;
+  correlationId?: string;
+  parentId?: string;
+  depth?: number;
+  agentId?: string;
+  toolName?: string;
+}
+
+export interface LogEntry {
+  id: string;
+  timestamp: string;
+  timestampMs: number;
+  level: LogLevel;
+  source: LogSource;
+  tags: string[];
+  event: string;
+  message: string;
+  traceId?: string;
+  correlationId?: string;
+  parentId?: string;
+  depth: number;
+  kind: LogKind;
+  expandable: boolean;
+  durationMs?: number;
+  data?: unknown;
+}
+
+export interface LogQueryFilter {
+  tags?: string[];
+  tagMode?: TagMode;
+  levels?: LogLevel[];
+  traceId?: string;
+  correlationId?: string;
+  source?: LogSource;
+  sinceMs?: number;
+  untilMs?: number;
+  limit?: number;
+}
+
+export interface LogExportResult {
+  path: string;
+  count: number;
+}
+
+export interface LogClearResult {
+  removedFiles: number;
+}
+
+export interface FrontendLogInput {
+  id?: string;
+  level?: LogLevel;
+  tags: string[];
+  event: string;
+  message: string;
+  kind?: LogKind;
+  expandable?: boolean;
+  durationMs?: number;
+  data?: unknown;
+  context?: LogContext;
+}

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,3 +1,5 @@
+import { logFrontendSoon } from "@/logging/client";
+
 export interface NotificationPayload {
   title: string;
   options?: NotificationOptions;
@@ -30,7 +32,13 @@ export async function ensureNotificationPermission(): Promise<boolean> {
       }
       return granted;
     } catch (err) {
-      console.error("Tauri notification permission error:", err);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "notifications.permission.error",
+        message: "Failed to query Tauri notification permission.",
+        data: { error: err },
+      });
       return false;
     }
   }
@@ -122,7 +130,13 @@ export async function setAppBadgeCount(count: number | null): Promise<void> {
     }
     await win.setBadgeCount(Math.max(1, Math.trunc(count)));
   } catch (err) {
-    console.error("Failed to update app badge count:", err);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "system"],
+      event: "notifications.badge.error",
+      message: "Failed to update the app badge count.",
+      data: { error: err, count },
+    });
   }
 }
 

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -4,6 +4,7 @@ import {
   type ProjectCommandConfig,
   type ProjectScriptsConfigState,
 } from "@/projectScripts";
+import { logFrontendSoon } from "@/logging/client";
 
 export interface SavedProject {
   path: string;
@@ -125,7 +126,13 @@ export function saveSavedProjects(projects: SavedProject[]): void {
       JSON.stringify(normalized),
     );
   } catch (error) {
-    console.error("Failed to save projects:", error);
+    logFrontendSoon({
+      level: "error",
+      tags: ["frontend", "system"],
+      event: "projects.save.error",
+      message: "Failed to save projects to local storage.",
+      data: { error },
+    });
   }
 }
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -7,6 +7,7 @@ import {
   jotaiStore,
   type AppUpdaterState,
 } from "@/agent/atoms";
+import { logFrontendSoon } from "@/logging/client";
 
 interface CheckForAppUpdatesOptions {
   silent?: boolean;
@@ -138,7 +139,13 @@ export async function checkForAppUpdates(
       return null;
     } catch (error) {
       const message = toErrorMessage(error);
-      console.error("rakh: failed to check for updates", error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "updater.check.error",
+        message: "Failed to check for updates.",
+        data: { error },
+      });
 
       patchUpdaterState((prev) => {
         if (previousState.availableVersion) {
@@ -212,7 +219,13 @@ export async function installAppUpdate(
       await relaunch();
     } catch (error) {
       const message = toErrorMessage(error);
-      console.error("rakh: failed to install update", error);
+      logFrontendSoon({
+        level: "error",
+        tags: ["frontend", "system"],
+        event: "updater.install.error",
+        message: "Failed to install the downloaded update.",
+        data: { error },
+      });
 
       patchUpdaterState((prev) =>
         prev.availableVersion


### PR DESCRIPTION
## Summary

This implements issue #133 by replacing the split frontend/backend logging paths with a single structured logging pipeline owned by the Tauri backend.

Highlights:

- add a backend JSONL log store with rotation, retention, query, export, clear, and live `log_entry` events
- add shared frontend logging types and a logger client that persists through Tauri and falls back to structured console output in plain web mode
- thread `logContext` through the runner, tool dispatch, MCP, exec, git, workspace, and artifact calls so runs, turns, tool calls, and subagents share trace/correlation ids
- replace app-owned `console.*` logging in the runner, persistence, terminal, updater, notifications, settings, and related frontend flows
- add backend and frontend tests plus docs for log schema, storage paths, and CLI usage

This stays infrastructure-only. It does not add a log viewer UI.

## Testing

- `npm run typecheck`
- `npm run test`
- `cd src-tauri && cargo test`

## Links

Fixes #133
Follow-up UI issue: #135
