### PR TITLE
fix(agent): align static catalog with models.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "start": "vite preview",
     "preview": "vite preview",
+    "model-search": "node scripts/model-search.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "tauri": "tauri",

--- a/scripts/model-search.mjs
+++ b/scripts/model-search.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+const MODELS_DEV_URL = "https://models.dev/api.json";
+
+function writeStderr(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function usage() {
+  writeStderr(
+    "Usage: npm run model-search [--provider <provider>|-p <provider>] [id]",
+  );
+}
+
+function parseArgs(argv, env) {
+  const tokens = argv.slice(2);
+  const queryTokens = [];
+  let provider = null;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+
+    if (token === "--provider" || token === "-p") {
+      provider = tokens[i + 1] ?? null;
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith("--provider=")) {
+      provider = token.slice("--provider=".length);
+      continue;
+    }
+
+    if (token.startsWith("-p=")) {
+      provider = token.slice("-p=".length);
+      continue;
+    }
+
+    queryTokens.push(token);
+  }
+
+  const npmProvider = typeof env.npm_config_provider === "string"
+    ? env.npm_config_provider.trim()
+    : "";
+  const npmShortProvider = typeof env.npm_config_p === "string"
+    ? env.npm_config_p.trim()
+    : "";
+
+  if (!provider) {
+    if (npmProvider && npmProvider !== "true") {
+      provider = npmProvider;
+    } else if (npmShortProvider && npmShortProvider !== "true") {
+      provider = npmShortProvider;
+    } else if (
+      (npmProvider === "true" || npmShortProvider === "true") &&
+      queryTokens.length >= 2
+    ) {
+      provider = queryTokens.shift() ?? null;
+    }
+  }
+
+  return {
+    provider: provider?.trim().toLowerCase() || null,
+    query: queryTokens.join(" ").trim().toLowerCase(),
+    queryTokens,
+  };
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
+function flattenModels(payload) {
+  const matches = [];
+
+  for (const [providerKey, providerValue] of Object.entries(payload)) {
+    if (!isRecord(providerValue)) continue;
+    const providerId =
+      typeof providerValue.id === "string" ? providerValue.id : providerKey;
+    const providerName =
+      typeof providerValue.name === "string" ? providerValue.name : providerId;
+    const models = isRecord(providerValue.models) ? providerValue.models : null;
+
+    if (!models) continue;
+
+    for (const modelValue of Object.values(models)) {
+      if (!isRecord(modelValue) || typeof modelValue.id !== "string") continue;
+      matches.push({
+        provider: {
+          id: providerId,
+          name: providerName,
+        },
+        model: modelValue,
+      });
+    }
+  }
+
+  return matches;
+}
+
+async function main() {
+  const parsedArgs = parseArgs(process.argv, process.env);
+  const response = await fetch(MODELS_DEV_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${MODELS_DEV_URL}: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  if (!isRecord(payload)) {
+    throw new Error("Unexpected response shape from models.dev");
+  }
+
+  const flattenedModels = flattenModels(payload);
+  const providerAliases = new Map();
+  for (const entry of flattenedModels) {
+    providerAliases.set(entry.provider.id.toLowerCase(), entry.provider.id);
+    providerAliases.set(entry.provider.name.toLowerCase(), entry.provider.id);
+  }
+
+  let provider = parsedArgs.provider;
+  let effectiveQuery = parsedArgs.query;
+
+  if (
+    !provider &&
+    parsedArgs.queryTokens.length >= 1 &&
+    providerAliases.has(parsedArgs.queryTokens[0].toLowerCase())
+  ) {
+    provider = parsedArgs.queryTokens[0].toLowerCase();
+    effectiveQuery = parsedArgs.queryTokens.slice(1).join(" ").trim().toLowerCase();
+  }
+
+  if (!provider && !effectiveQuery) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const providerId = provider ? providerAliases.get(provider) ?? provider : null;
+  if (providerId && effectiveQuery.startsWith(`${providerId.toLowerCase()}/`)) {
+    effectiveQuery = effectiveQuery.slice(providerId.length + 1);
+  }
+
+  const allModels = flattenedModels.filter((entry) => {
+    if (!providerId) return true;
+    return (
+      entry.provider.id.toLowerCase() === providerId.toLowerCase() ||
+      entry.provider.name.toLowerCase() === providerId.toLowerCase()
+    );
+  });
+
+  if (!effectiveQuery) {
+    process.stdout.write(`${JSON.stringify(allModels, null, 2)}\n`);
+    return;
+  }
+
+  const exactMatches = allModels.filter(
+    ({ model }) => model.id.toLowerCase() === effectiveQuery,
+  );
+  const matches =
+    exactMatches.length > 0
+      ? exactMatches
+      : allModels.filter(({ model }) =>
+          model.id.toLowerCase().includes(effectiveQuery),
+        );
+
+  process.stdout.write(`${JSON.stringify(matches, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  writeStderr(message);
+  process.exitCode = 1;
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import {
 import type { AgentStatus } from "@/agent/types";
 import { preloadEnvProviderKeys } from "@/agent/useEnvProviderKeys";
 import { logFrontendSoon } from "@/logging/client";
+import { STATIC_MODEL_CATALOG } from "@/agent/modelCatalog";
 import { getThemeSubagentColorVariables } from "@/styles/themes/registry";
 import { checkForAppUpdates } from "@/updater";
 
@@ -205,11 +206,24 @@ export default function App() {
             if (s.model) {
               // Find provider by prefix since model is "{providerName}/{rawId}"
               const [providerName] = s.model.split("/");
-              if (
-                providerName &&
-                !providers.some((p) => p.name === providerName)
-              ) {
+              const provider = providerName
+                ? providers.find((p) => p.name === providerName)
+                : undefined;
+              if (providerName && !provider) {
                 restoreError = `The provider previously driving this session ("${providerName}") was deleted or renamed. Please choose another model.`;
+              } else if (
+                provider &&
+                (provider.type === "openai" || provider.type === "anthropic")
+              ) {
+                const staticModelId = s.model.slice(provider.name.length + 1);
+                const modelStillExists = STATIC_MODEL_CATALOG.some(
+                  (entry) =>
+                    entry.id === staticModelId &&
+                    entry.owned_by === provider.type,
+                );
+                if (!modelStillExists) {
+                  restoreError = `The model previously selected for this session ("${staticModelId}") is no longer in src/agent/models.catalog.json. Please choose another model.`;
+                }
               }
             }
 

--- a/src/agent/modelCatalog.ts
+++ b/src/agent/modelCatalog.ts
@@ -3,32 +3,102 @@ import rawCatalog from "./models.catalog.json";
 export type SupportedProvider = "openai" | "anthropic" | "openai-compatible";
 
 export interface ModelCatalogEntry {
-  id: string; // E.g. "MyOpenAI/gpt-4o"
+  id: string; // E.g. "MyOpenAI/openai/gpt-5.3-codex"
   name: string; // The display name
   providerId: string; // Maps to ProviderInstance.id
   owned_by: SupportedProvider; // UI Badge indicator
   tags: string[];
   context_length?: number;
   pricing?: {
-    prompt: string;
-    completion: string;
+    prompt: number;
+    completion: number;
   };
   /**
    * Provider-native model identifier used when constructing the SDK model.
-   * E.g. "gpt-4o" or raw compatible model id.
+   * E.g. "gpt-5.3-codex" or a raw compatible model id.
    */
   sdk_id: string;
 }
 
-interface ModelCatalogFile {
-  version: number;
-  generatedAt: string;
-  source: string;
-  filters?: {
-    providers?: string[];
-    requiredTag?: string;
+interface ModelCatalogSourceProvider {
+  id?: unknown;
+  name?: unknown;
+}
+
+interface ModelCatalogSourceCost {
+  input?: unknown;
+  output?: unknown;
+}
+
+interface ModelCatalogSourceLimit {
+  context?: unknown;
+}
+
+interface ModelCatalogSourceModalities {
+  input?: unknown;
+}
+
+interface ModelCatalogSourceModel {
+  id?: unknown;
+  name?: unknown;
+  reasoning?: unknown;
+  tool_call?: unknown;
+  structured_output?: unknown;
+  modalities?: unknown;
+  cost?: unknown;
+  limit?: unknown;
+}
+
+interface ModelCatalogSourceEntry {
+  provider?: unknown;
+  model?: unknown;
+}
+
+function getFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function inferTags(model: ModelCatalogSourceModel): string[] {
+  const tags: string[] = [];
+
+  if (model.reasoning === true) tags.push("reasoning");
+  if (model.tool_call === true) tags.push("tool-use");
+  if (model.structured_output === true) tags.push("structured-output");
+
+  if (isRecord(model.modalities)) {
+    const modalities = model.modalities as ModelCatalogSourceModalities;
+    const inputModalities = isStringArray(modalities.input)
+      ? modalities.input
+      : [];
+
+    if (inputModalities.includes("image")) tags.push("vision");
+    if (inputModalities.includes("pdf")) tags.push("file-input");
+  }
+
+  return tags;
+}
+
+function normalizePrice(
+  pricing: unknown,
+): ModelCatalogEntry["pricing"] | undefined {
+  if (!isRecord(pricing)) return undefined;
+
+  const cost = pricing as ModelCatalogSourceCost;
+  const prompt = getFiniteNumber(cost.input);
+  const completion = getFiniteNumber(cost.output);
+
+  if (prompt === undefined && completion === undefined) {
+    return undefined;
+  }
+
+  return {
+    prompt: prompt ?? 0,
+    completion: completion ?? 0,
   };
-  models: ModelCatalogEntry[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -41,72 +111,55 @@ function isSupportedProvider(value: unknown): value is SupportedProvider {
   );
 }
 
-function normalizeCatalog(input: unknown): ModelCatalogFile {
-  if (!isRecord(input)) {
-    throw new Error("Invalid model catalog: expected object");
+function normalizeCatalog(input: unknown): ModelCatalogEntry[] {
+  if (!Array.isArray(input)) {
+    throw new Error("Invalid model catalog: expected array");
   }
 
-  const modelsRaw = Array.isArray(input.models) ? input.models : [];
   const models: ModelCatalogEntry[] = [];
 
-  for (const item of modelsRaw) {
+  for (const item of input) {
     if (!isRecord(item)) continue;
 
-    const id = typeof item.id === "string" ? item.id.trim() : "";
-    const name = typeof item.name === "string" ? item.name.trim() : "";
-    const ownedBy = item.owned_by;
-    const sdkId = typeof item.sdk_id === "string" ? item.sdk_id.trim() : "";
+    const provider = isRecord((item as ModelCatalogSourceEntry).provider)
+      ? ((item as ModelCatalogSourceEntry).provider as ModelCatalogSourceProvider)
+      : null;
+    const model = isRecord((item as ModelCatalogSourceEntry).model)
+      ? ((item as ModelCatalogSourceEntry).model as ModelCatalogSourceModel)
+      : null;
 
-    if (!id || !name || !isSupportedProvider(ownedBy)) continue;
+    if (!provider || !model) continue;
 
-    const tags = Array.isArray(item.tags)
-      ? item.tags.filter((t): t is string => typeof t === "string")
-      : [];
+    const providerKey = typeof provider.id === "string" ? provider.id.trim() : "";
+    const modelId = typeof model.id === "string" ? model.id.trim() : "";
+    const name = typeof model.name === "string" ? model.name.trim() : "";
 
-    const context_length =
-      typeof item.context_length === "number" &&
-      Number.isFinite(item.context_length)
-        ? item.context_length
-        : undefined;
-
-    let pricing: ModelCatalogEntry["pricing"];
-    if (isRecord(item.pricing)) {
-      const prompt =
-        typeof item.pricing.prompt === "string" ? item.pricing.prompt : "";
-      const completion =
-        typeof item.pricing.completion === "string"
-          ? item.pricing.completion
-          : "";
-      if (prompt || completion) {
-        pricing = { prompt, completion };
-      }
+    if (!providerKey || !modelId || !name || !isSupportedProvider(providerKey)) {
+      continue;
     }
 
+    const limit = isRecord(model.limit)
+      ? (model.limit as ModelCatalogSourceLimit)
+      : null;
+    const context_length = limit ? getFiniteNumber(limit.context) : undefined;
+
     models.push({
-      id,
+      id: `${providerKey}/${modelId}`,
       name,
       providerId: "", // Filled at runtime
-      owned_by: ownedBy,
-      tags,
+      owned_by: providerKey,
+      tags: inferTags(model),
       context_length,
-      pricing,
-      sdk_id: sdkId,
+      pricing: normalizePrice(model.cost),
+      sdk_id: modelId,
     });
   }
 
-  return {
-    version: typeof input.version === "number" ? input.version : 1,
-    generatedAt:
-      typeof input.generatedAt === "string" ? input.generatedAt : "unknown",
-    source: typeof input.source === "string" ? input.source : "unknown",
-    models,
-  };
+  return models;
 }
 
-const catalog = normalizeCatalog(rawCatalog);
-
 export const STATIC_MODEL_CATALOG: ModelCatalogEntry[] = [
-  ...catalog.models,
+  ...normalizeCatalog(rawCatalog),
 ].sort((a, b) => a.id.localeCompare(b.id));
 
 // Fallback for missing configurations

--- a/src/agent/models.catalog.json
+++ b/src/agent/models.catalog.json
@@ -1,437 +1,380 @@
-{
-  "version": 1,
-  "generatedAt": "2026-02-24",
-  "source": "https://ai-gateway.vercel.sh/v1/models",
-  "filters": {
-    "providers": ["openai", "anthropic"],
-    "requiredTag": "tool-use"
-  },
-  "models": [
-    {
-      "id": "anthropic/claude-3-haiku",
-      "name": "Claude 3 Haiku",
-      "owned_by": "anthropic",
-      "tags": ["tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.00000125"
-      },
-      "sdk_id": "claude-3-haiku-20240307"
+[
+  {
+    "provider": {
+      "id": "anthropic",
+      "name": "Anthropic"
     },
-    {
-      "id": "anthropic/claude-haiku-4.5",
-      "name": "Claude Haiku 4.5",
-      "owned_by": "anthropic",
-      "tags": ["tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000001",
-        "completion": "0.000005"
+    "model": {
+      "id": "claude-haiku-4-5",
+      "name": "Claude Haiku 4.5 (latest)",
+      "family": "claude-haiku",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": true,
+      "knowledge": "2025-02-28",
+      "release_date": "2025-10-15",
+      "last_updated": "2025-10-15",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
       },
-      "sdk_id": "claude-haiku-4-5-20251001"
-    },
-    {
-      "id": "anthropic/claude-opus-4",
-      "name": "Claude Opus 4",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.000075"
+      "open_weights": false,
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
       },
-      "sdk_id": "claude-opus-4-20250514"
-    },
-    {
-      "id": "anthropic/claude-opus-4.1",
-      "name": "Claude Opus 4.1",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.000075"
-      },
-      "sdk_id": "claude-opus-4-1-20250805"
-    },
-    {
-      "id": "anthropic/claude-opus-4.5",
-      "name": "Claude Opus 4.5",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.000075"
-      },
-      "sdk_id": "claude-opus-4-5-20251101"
-    },
-    {
-      "id": "anthropic/claude-opus-4.6",
-      "name": "Claude Opus 4.6",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.000075"
-      },
-      "sdk_id": "claude-opus-4-6"
-    },
-    {
-      "id": "anthropic/claude-sonnet-4",
-      "name": "Claude Sonnet 4",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000003",
-        "completion": "0.000015"
-      },
-      "sdk_id": "claude-sonnet-4-20250514"
-    },
-    {
-      "id": "anthropic/claude-sonnet-4.5",
-      "name": "Claude Sonnet 4.5",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000003",
-        "completion": "0.000015"
-      },
-      "sdk_id": "claude-sonnet-4-5-20250929"
-    },
-    {
-      "id": "anthropic/claude-sonnet-4.6",
-      "name": "Claude Sonnet 4.6",
-      "owned_by": "anthropic",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000003",
-        "completion": "0.000015"
-      },
-      "sdk_id": "claude-sonnet-4-6"
-    },
-    {
-      "id": "openai/codex-mini",
-      "name": "Codex Mini",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.0000015",
-        "completion": "0.000006"
-      },
-      "sdk_id": "codex-mini-latest"
-    },
-    {
-      "id": "openai/gpt-4-turbo",
-      "name": "GPT-4 Turbo",
-      "owned_by": "openai",
-      "tags": ["tool-use"],
-      "context_length": 128000,
-      "pricing": {
-        "prompt": "0.00001",
-        "completion": "0.00003"
-      },
-      "sdk_id": "gpt-4-turbo"
-    },
-    {
-      "id": "openai/gpt-4.1",
-      "name": "GPT-4.1",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision"],
-      "context_length": 1047576,
-      "pricing": {
-        "prompt": "0.000002",
-        "completion": "0.000008"
-      },
-      "sdk_id": "gpt-4.1"
-    },
-    {
-      "id": "openai/gpt-4.1-mini",
-      "name": "GPT-4.1 mini",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision"],
-      "context_length": 1047576,
-      "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000016"
-      },
-      "sdk_id": "gpt-4.1-mini"
-    },
-    {
-      "id": "openai/gpt-4.1-nano",
-      "name": "GPT-4.1 nano",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision"],
-      "context_length": 1047576,
-      "pricing": {
-        "prompt": "0.0000001",
-        "completion": "0.0000004"
-      },
-      "sdk_id": "gpt-4.1-nano"
-    },
-    {
-      "id": "openai/gpt-4o",
-      "name": "GPT-4o",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision"],
-      "context_length": 128000,
-      "pricing": {
-        "prompt": "0.0000025",
-        "completion": "0.00001"
-      },
-      "sdk_id": "gpt-4o"
-    },
-    {
-      "id": "openai/gpt-4o-mini",
-      "name": "GPT-4o mini",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision"],
-      "context_length": 128000,
-      "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.0000006"
-      },
-      "sdk_id": "gpt-4o-mini"
-    },
-    {
-      "id": "openai/gpt-5",
-      "name": "GPT-5",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001"
-      },
-      "sdk_id": "gpt-5"
-    },
-    {
-      "id": "openai/gpt-5-chat",
-      "name": "GPT-5 Chat",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001"
-      },
-      "sdk_id": "gpt-5-chat-latest"
-    },
-    {
-      "id": "openai/gpt-5-codex",
-      "name": "GPT-5 Codex",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.0000015",
-        "completion": "0.000006"
-      },
-      "sdk_id": "gpt-5-codex"
-    },
-    {
-      "id": "openai/gpt-5-mini",
-      "name": "GPT-5 mini",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.000002"
-      },
-      "sdk_id": "gpt-5-mini"
-    },
-    {
-      "id": "openai/gpt-5-nano",
-      "name": "GPT-5 nano",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.0000004"
-      },
-      "sdk_id": "gpt-5-nano"
-    },
-    {
-      "id": "openai/gpt-5-pro",
-      "name": "GPT-5 Pro",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.00012"
-      },
-      "sdk_id": "gpt-5-pro"
-    },
-    {
-      "id": "openai/gpt-5.1-codex",
-      "name": "GPT-5.1 Codex",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.0000015",
-        "completion": "0.000006"
-      },
-      "sdk_id": "gpt-5.1-codex"
-    },
-    {
-      "id": "openai/gpt-5.1-codex-max",
-      "name": "GPT-5.1 Codex Max",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.000006",
-        "completion": "0.000024"
-      },
-      "sdk_id": "gpt-5.1-codex-max"
-    },
-    {
-      "id": "openai/gpt-5.1-codex-mini",
-      "name": "GPT-5.1 Codex Mini",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.000000375",
-        "completion": "0.0000015"
-      },
-      "sdk_id": "gpt-5.1-codex-mini"
-    },
-    {
-      "id": "openai/gpt-5.2",
-      "name": "GPT-5.2",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001"
-      },
-      "sdk_id": "gpt-5.2"
-    },
-    {
-      "id": "openai/gpt-5.2-chat",
-      "name": "GPT-5.2 Chat",
-      "owned_by": "openai",
-      "tags": ["tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001"
-      },
-      "sdk_id": "gpt-5.2-chat-latest"
-    },
-    {
-      "id": "openai/gpt-5.2-codex",
-      "name": "GPT-5.2 Codex",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.0000015",
-        "completion": "0.000006"
-      },
-      "sdk_id": "gpt-5.2-codex"
-    },
-    {
-      "id": "openai/gpt-5.2-pro",
-      "name": "GPT-5.2 Pro",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 400000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.00012"
-      },
-      "sdk_id": "gpt-5.2-pro"
-    },
-    {
-      "id": "openai/o1",
-      "name": "o1",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000015",
-        "completion": "0.00006"
-      },
-      "sdk_id": "o1"
-    },
-    {
-      "id": "openai/o3",
-      "name": "o3",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.000002",
-        "completion": "0.000008"
-      },
-      "sdk_id": "o3"
-    },
-    {
-      "id": "openai/o3-deep-research",
-      "name": "o3 Deep Research",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.00001",
-        "completion": "0.00004"
-      },
-      "sdk_id": "o3-deep-research"
-    },
-    {
-      "id": "openai/o3-mini",
-      "name": "o3-mini",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.0000011",
-        "completion": "0.0000044"
-      },
-      "sdk_id": "o3-mini"
-    },
-    {
-      "id": "openai/o3-pro",
-      "name": "o3-pro",
-      "owned_by": "openai",
-      "tags": ["reasoning", "tool-use", "vision", "implicit-caching"],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.00002",
-        "completion": "0.00008"
-      },
-      "sdk_id": "o3-pro"
-    },
-    {
-      "id": "openai/o4-mini",
-      "name": "o4-mini",
-      "owned_by": "openai",
-      "tags": [
-        "file-input",
-        "reasoning",
-        "tool-use",
-        "vision",
-        "implicit-caching"
-      ],
-      "context_length": 200000,
-      "pricing": {
-        "prompt": "0.0000011",
-        "completion": "0.0000044"
-      },
-      "sdk_id": "o4-mini"
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      }
     }
-  ]
-}
+  },
+  {
+    "provider": {
+      "id": "anthropic",
+      "name": "Anthropic"
+    },
+    "model": {
+      "id": "claude-opus-4-5",
+      "name": "Claude Opus 4.5 (latest)",
+      "family": "claude-opus",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": true,
+      "knowledge": "2025-03-31",
+      "release_date": "2025-11-24",
+      "last_updated": "2025-11-24",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "anthropic",
+      "name": "Anthropic"
+    },
+    "model": {
+      "id": "claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5 (latest)",
+      "family": "claude-sonnet",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": true,
+      "knowledge": "2025-07-31",
+      "release_date": "2025-09-29",
+      "last_updated": "2025-09-29",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "anthropic",
+      "name": "Anthropic"
+    },
+    "model": {
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "family": "claude-opus",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": true,
+      "knowledge": "2025-05",
+      "release_date": "2026-02-05",
+      "last_updated": "2026-02-05",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25,
+        "context_over_200k": {
+          "input": 10,
+          "output": 37.5,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "limit": {
+        "context": 200000,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "anthropic",
+      "name": "Anthropic"
+    },
+    "model": {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "family": "claude-sonnet",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": true,
+      "knowledge": "2025-08",
+      "release_date": "2026-02-17",
+      "last_updated": "2026-02-17",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75,
+        "context_over_200k": {
+          "input": 6,
+          "output": 22.5,
+          "cache_read": 0.6,
+          "cache_write": 7.5
+        }
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "gpt-5.3-codex",
+      "name": "GPT-5.3 Codex",
+      "family": "gpt-codex",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": false,
+      "knowledge": "2025-08-31",
+      "release_date": "2026-02-05",
+      "last_updated": "2026-02-05",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "gpt-5.2-codex",
+      "name": "GPT-5.2 Codex",
+      "family": "gpt-codex",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": false,
+      "knowledge": "2025-08-31",
+      "release_date": "2025-12-11",
+      "last_updated": "2025-12-11",
+      "modalities": {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "gpt-5-codex",
+      "name": "GPT-5-Codex",
+      "family": "gpt-codex",
+      "attachment": false,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": false,
+      "knowledge": "2024-09-30",
+      "release_date": "2025-09-15",
+      "last_updated": "2025-09-15",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "gpt-4o-mini",
+      "name": "GPT-4o mini",
+      "family": "gpt-mini",
+      "attachment": true,
+      "reasoning": false,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "knowledge": "2023-09",
+      "release_date": "2024-07-18",
+      "last_updated": "2024-07-18",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.08
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "codex-mini-latest",
+      "name": "Codex Mini",
+      "family": "gpt-codex-mini",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "temperature": false,
+      "knowledge": "2024-04",
+      "release_date": "2025-05-16",
+      "last_updated": "2025-05-16",
+      "modalities": {
+        "input": ["text"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 1.5,
+        "output": 6,
+        "cache_read": 0.375
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      }
+    }
+  },
+  {
+    "provider": {
+      "id": "openai",
+      "name": "OpenAI"
+    },
+    "model": {
+      "id": "gpt-5-nano",
+      "name": "GPT-5 Nano",
+      "family": "gpt-nano",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": false,
+      "knowledge": "2024-05-30",
+      "release_date": "2025-08-07",
+      "last_updated": "2025-08-07",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_read": 0.005
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      }
+    }
+  }
+]

--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -1946,9 +1946,7 @@ describe("runner", () => {
       const result = buildProviderOptions("anthropic");
       expect(result).toBeDefined();
       expect(result!.anthropic.thinking).toEqual({ type: "adaptive" });
-      expect(result!.anthropic.effort).toBe(
-        DEFAULT_ADVANCED_OPTIONS.reasoningEffort,
-      );
+      expect(result!.anthropic).not.toHaveProperty("effort");
       expect(result!.anthropic).not.toHaveProperty("speed");
     });
 
@@ -2054,12 +2052,27 @@ describe("runner", () => {
       });
 
       it.each(["low", "medium", "high"] as const)(
-        "reasoning effort: %s",
+        "reasoning effort on unsupported models is omitted: %s",
         (effort) => {
           const r = buildProviderOptions("anthropic", {
             ...base,
             reasoningEffort: effort,
           });
+          expect(r!.anthropic).not.toHaveProperty("effort");
+        },
+      );
+
+      it.each(["low", "medium", "high"] as const)(
+        "reasoning effort on opus 4.5 is included: %s",
+        (effort) => {
+          const r = buildProviderOptions(
+            "anthropic",
+            {
+              ...base,
+              reasoningEffort: effort,
+            },
+            "claude-opus-4-5",
+          );
           expect(r!.anthropic.effort).toBe(effort);
         },
       );
@@ -2147,7 +2160,7 @@ describe("runner", () => {
     expect(po!.anthropic.speed).toBe("fast");
   });
 
-  it("omits unsupported Anthropic fast mode from streamText", async () => {
+  it("omits unsupported Anthropic effort and fast mode from streamText", async () => {
     const tabId = "tab-provider-options-no-fast-mode";
     registerDynamicModels([
       {
@@ -2186,7 +2199,7 @@ describe("runner", () => {
       type: "enabled",
       budgetTokens: 4096,
     });
-    expect(po!.anthropic.effort).toBe("high");
+    expect(po!.anthropic).not.toHaveProperty("effort");
     expect(po!.anthropic).not.toHaveProperty("speed");
   });
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -715,6 +715,14 @@ function supportsAnthropicFastMode(modelSdkId?: string): boolean {
   return typeof modelSdkId === "string" && modelSdkId.startsWith("claude-opus-4-6");
 }
 
+function supportsAnthropicEffort(modelSdkId?: string): boolean {
+  return (
+    typeof modelSdkId === "string" &&
+    (modelSdkId.startsWith("claude-opus-4-5") ||
+      modelSdkId.startsWith("claude-opus-4-6"))
+  );
+}
+
 export function buildProviderOptions(
   provider: string | null,
   opts?: AdvancedModelOptions,
@@ -763,8 +771,11 @@ export function buildProviderOptions(
     anthropic.thinking = { type: "adaptive" };
   }
 
-  // Reasoning effort
-  anthropic.effort = reasoningEffort;
+  // Effort is model-specific for Anthropic. Omit it for unsupported models
+  // so requests for Haiku/Sonnet do not fail at the API layer.
+  if (supportsAnthropicEffort(modelSdkId)) {
+    anthropic.effort = reasoningEffort;
+  }
 
   // Fast mode is Anthropic model-specific. Omit the default "standard" mode
   // entirely so unsupported models do not receive an invalid request field.
@@ -797,7 +808,7 @@ function resolveLanguageModel(modelKey: string, providers: ProviderInstance[]) {
 
   if (!providerModelId) {
     throw new Error(
-      `Model "${modelEntry.id}" is missing sdk_id. Update src/agent/models.catalog.json and set sdk_id for this model.`,
+      `Model "${modelEntry.id}" is missing a provider model ID. Update src/agent/models.catalog.json for this model.`,
     );
   }
 
@@ -3198,7 +3209,7 @@ async function runAgentTurn(
   if (!modelEntry.sdk_id.trim()) {
     setAgentErrorState(
       tabId,
-      `Selected model is missing sdk_id. Please update src/agent/models.catalog.json for ${modelEntry.id}.`,
+      `Selected model is missing a provider model ID. Please update src/agent/models.catalog.json for ${modelEntry.id}.`,
     );
     clearActiveRun(tabId, activeRun);
     return;

--- a/src/agent/useModels.test.ts
+++ b/src/agent/useModels.test.ts
@@ -3,23 +3,23 @@ import { filterModelsForQuery, type GatewayModel } from "./useModels";
 
 const MODELS: GatewayModel[] = [
   {
-    id: "team-openai/openai/gpt-4o-mini",
-    name: "GPT-4o mini",
+    id: "team-openai/openai/codex-mini",
+    name: "Codex Mini",
     providerId: "provider-openai",
     owned_by: "openai",
-    tags: ["tool-use", "vision"],
-    sdk_id: "gpt-4o-mini",
+    tags: ["tool-use", "reasoning"],
+    sdk_id: "codex-mini-latest",
   },
   {
-    id: "team-openai/openai/gpt-4.1",
-    name: "GPT-4.1",
+    id: "team-openai/openai/gpt-5.3-codex",
+    name: "GPT-5.3 Codex",
     providerId: "provider-openai",
     owned_by: "openai",
-    tags: ["tool-use"],
-    sdk_id: "gpt-4.1",
+    tags: ["tool-use", "reasoning"],
+    sdk_id: "gpt-5.3-codex",
   },
   {
-    id: "team-anthropic/anthropic/claude-sonnet-4.5",
+    id: "team-anthropic/anthropic/claude-sonnet-4-5",
     name: "Claude Sonnet 4.5",
     providerId: "provider-anthropic",
     owned_by: "anthropic",
@@ -27,12 +27,12 @@ const MODELS: GatewayModel[] = [
     sdk_id: "claude-sonnet-4-5",
   },
   {
-    id: "team-anthropic/anthropic/claude-opus-4.1",
-    name: "Claude Opus 4.1",
+    id: "team-anthropic/anthropic/claude-opus-4-6",
+    name: "Claude Opus 4.6",
     providerId: "provider-anthropic",
     owned_by: "anthropic",
     tags: ["tool-use", "reasoning"],
-    sdk_id: "claude-opus-4-1",
+    sdk_id: "claude-opus-4-6",
   },
   {
     id: "my-gateway/meta/llama-3.3-70b",
@@ -48,19 +48,19 @@ describe("filterModelsForQuery", () => {
   it("matches provider names", () => {
     const ids = filterModelsForQuery(MODELS, "anthropic").map((m) => m.id);
     expect(ids).toEqual([
-      "team-anthropic/anthropic/claude-sonnet-4.5",
-      "team-anthropic/anthropic/claude-opus-4.1",
+      "team-anthropic/anthropic/claude-sonnet-4-5",
+      "team-anthropic/anthropic/claude-opus-4-6",
     ]);
   });
 
-  it("matches fuzzy ids like gpt4o", () => {
-    const results = filterModelsForQuery(MODELS, "gpt4o");
-    expect(results[0]?.id).toBe("team-openai/openai/gpt-4o-mini");
+  it("matches fuzzy ids like gpt53codex", () => {
+    const results = filterModelsForQuery(MODELS, "gpt53codex");
+    expect(results[0]?.id).toBe("team-openai/openai/gpt-5.3-codex");
   });
 
   it("supports multi-token matching across fields", () => {
     const results = filterModelsForQuery(MODELS, "openai mini");
-    expect(results[0]?.id).toBe("team-openai/openai/gpt-4o-mini");
+    expect(results[0]?.id).toBe("team-openai/openai/codex-mini");
   });
 
   it("supports searching openai-compatible models via custom alias", () => {

--- a/src/agent/useModels.ts
+++ b/src/agent/useModels.ts
@@ -22,12 +22,12 @@ export function fmtCtx(n?: number): string {
 }
 
 /** Format prompt price per 1M tokens. Returns "free" or "$0.15/M". */
-export function fmtPrice(pricing?: { prompt: string }): string {
-  if (!pricing?.prompt) return "";
-  const perToken = parseFloat(pricing.prompt);
-  if (isNaN(perToken) || perToken === 0) return "free";
-  const perM = perToken * 1_000_000;
-  return `$${perM < 1 ? perM.toFixed(3) : perM.toFixed(2)}/M`;
+export function fmtPrice(pricing?: { prompt: number }): string {
+  if (typeof pricing?.prompt !== "number" || !Number.isFinite(pricing.prompt)) {
+    return "";
+  }
+  if (pricing.prompt === 0) return "free";
+  return `$${pricing.prompt < 1 ? pricing.prompt.toFixed(3) : pricing.prompt.toFixed(2)}/M`;
 }
 
 function getModelSearchFields(model: GatewayModel): string[] {


### PR DESCRIPTION
## Summary
- reset the static model catalog to the selected models.dev entries and normalize the loader around the raw API shape
- add the model-search CLI for fetching and filtering models.dev data, including provider filtering
- preserve session restore validation and gate Anthropic effort/speed provider options to supported models

## Testing
- npm run typecheck
- npm run test -- --run src/agent/useModels.test.ts src/agent/runner.test.ts src/logging/client.test.ts
- npm run model-search -- --provider openai gpt-5.3-codex