### PR TITLE
fix: group inline tool calls across assistant messages

### DIFF
--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -875,6 +875,63 @@ describe("WorkspacePage chat input", () => {
     });
   });
 
+  it("groups inline tool calls across assistant messages in the same bubble when no visible block separates them", async () => {
+    workspaceMocks.agentState = {
+      ...workspaceMocks.agentState,
+      showDebug: false,
+    };
+    workspaceMocks.chatBubbleGroups = [
+      {
+        kind: "assistant",
+        key: "assistant:msg-grouped-inline",
+        messages: [
+          {
+            id: "msg-1",
+            role: "assistant",
+            content: "",
+            timestamp: 1,
+            toolCalls: [
+              {
+                id: "tc-1",
+                tool: "workspace_listDir",
+                args: { path: "src" },
+                status: "done",
+              },
+            ],
+          },
+          {
+            id: "msg-2",
+            role: "assistant",
+            content: "",
+            timestamp: 2,
+            toolCalls: [
+              {
+                id: "tc-2",
+                tool: "workspace_readFile",
+                args: { path: "README.md" },
+                status: "done",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    render(<WorkspacePage />);
+
+    const openLogsButtons = screen.getAllByRole("button", { name: "Open logs" });
+    expect(openLogsButtons).toHaveLength(1);
+
+    fireEvent.click(openLogsButtons[0]);
+
+    await waitFor(() => {
+      expect(workspaceMocks.openLogViewerWindowMock).toHaveBeenCalledWith({
+        origin: "tool-call",
+        filter: { correlationId: "tc-2" },
+      });
+    });
+  });
+
   it("keeps the send button available while busy when text is queued", async () => {
     workspaceMocks.agentState.status = "working";
 

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -61,7 +61,7 @@ import { getAllSubagents, getSubagentThemeColorToken } from "@/agent/subagents";
 import { groupChatMessagesForBubbles } from "@/agent/chatBubbleGroups";
 import { useArtifactContentCache } from "@/components/artifact-pane/useSessionArtifacts";
 import {
-  buildToolCallRenderItems,
+  buildToolCallRenderItemsByMessage,
   type ToolCallRenderKind,
   type ToolCallRenderItem,
 } from "@/components/toolCallRenderItems";
@@ -1294,6 +1294,11 @@ export default function WorkspacePage() {
               const subagentMeta = group.agentName
                 ? subagentMetaByName.get(group.agentName)
                 : undefined;
+              const toolCallRenderItemsByMessage =
+                buildToolCallRenderItemsByMessage(
+                  groupMessages,
+                  agent.groupInlineToolCalls,
+                );
 
               return (
                 <div key={group.key} className="conversation-group">
@@ -1309,14 +1314,30 @@ export default function WorkspacePage() {
                 >
                   {groupMessages.map((msg) => {
                       const visibleToolCalls = msg.toolCalls ?? [];
-                      const toolCallRenderItems = buildToolCallRenderItems(
-                        visibleToolCalls,
-                        agent.groupInlineToolCalls,
-                      );
+                      const toolCallRenderItems =
+                        toolCallRenderItemsByMessage[msg.id] ?? [];
                       const showReasoning =
                         !!msg.reasoning || !!msg.reasoningStreaming;
                       const reasoningExpanded =
                         reasoningExpandedById[msg.id] ?? false;
+                      const showThinkingDots =
+                        !!msg.streaming &&
+                        !msg.content &&
+                        !showReasoning &&
+                        visibleToolCalls.length === 0;
+                      const showStreamingCursor =
+                        !!msg.streaming && !showThinkingDots;
+                      const hasRenderableSegmentContent =
+                        showReasoning ||
+                        !!msg.content ||
+                        showThinkingDots ||
+                        showStreamingCursor ||
+                        toolCallRenderItems.length > 0 ||
+                        !!msg.traceId;
+
+                      if (!hasRenderableSegmentContent) {
+                        return null;
+                      }
 
                       return (
                         <div key={msg.id} className="agent-message-segment">
@@ -1337,21 +1358,18 @@ export default function WorkspacePage() {
                           {msg.content && <Markdown>{msg.content}</Markdown>}
 
                           {/* Streaming cursor or thinking animation */}
-                          {msg.streaming &&
-                            (!msg.content &&
-                            !showReasoning &&
-                            visibleToolCalls.length === 0 ? (
-                              <div className="thinking-dots mt-0.5 mb-0.5">
-                                <span />
-                                <span />
-                                <span />
-                              </div>
-                            ) : (
-                              <span className="animate-blink ml-0.5">◍</span>
-                            ))}
+                          {showThinkingDots ? (
+                            <div className="thinking-dots mt-0.5 mb-0.5">
+                              <span />
+                              <span />
+                              <span />
+                            </div>
+                          ) : showStreamingCursor ? (
+                            <span className="animate-blink ml-0.5">◍</span>
+                          ) : null}
 
                           {/* Tool calls */}
-                          {visibleToolCalls.length > 0 && (
+                          {toolCallRenderItems.length > 0 && (
                             <div className="mt-2 flex flex-col gap-1">
                               {toolCallRenderItems.map((item, index) =>
                                 item.kind === "group" ? (

--- a/src/components/CompactToolCall.tsx
+++ b/src/components/CompactToolCall.tsx
@@ -139,7 +139,7 @@ function ExpandedListDir({ tc }: { tc: ToolCallDisplay }) {
   const symlinkCount = entries.filter((e) => e.kind === "symlink").length;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Listing directory:{" "}
         <span className="font-mono text-[#6a9fb5]">&lt;{outputPath}&gt;</span>
@@ -219,7 +219,7 @@ function ExpandedStatFile({ tc }: { tc: ToolCallDisplay }) {
       : null;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Stat for:{" "}
         <span className="font-mono text-[#6a9fb5]">&lt;{outputPath}&gt;</span>
@@ -294,7 +294,7 @@ function ExpandedReadFile({ tc }: { tc: ToolCallDisplay }) {
       : null;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Reading file:{" "}
         <span className="font-mono text-[#6a9fb5]">&lt;{outputPath}&gt;</span>
@@ -376,7 +376,7 @@ function ExpandedGlob({ tc }: { tc: ToolCallDisplay }) {
       : null;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Matching glob patterns in{" "}
         <span className="font-mono text-[#6a9fb5]">&lt;{rootDir}&gt;</span>
@@ -445,12 +445,14 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
       : resultRecord?.details &&
           typeof resultRecord.details === "object" &&
           (resultRecord.details as Record<string, unknown>).setup &&
-          typeof (resultRecord.details as Record<string, unknown>).setup === "object"
-        ? ((resultRecord.details as Record<string, unknown>)
-            .setup as Record<string, unknown>)
+          typeof (resultRecord.details as Record<string, unknown>).setup ===
+            "object"
+        ? ((resultRecord.details as Record<string, unknown>).setup as Record<
+            string,
+            unknown
+          >)
         : null;
-  const setupStatus =
-    typeof setup?.status === "string" ? setup.status : null;
+  const setupStatus = typeof setup?.status === "string" ? setup.status : null;
   const setupStdout =
     typeof setup?.stdout === "string" ? setup.stdout.trimEnd() : "";
   const setupStderr =
@@ -468,7 +470,7 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
       : null;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Initializing git worktree
       </div>
@@ -510,16 +512,24 @@ function ExpandedGitWorktree({ tc }: { tc: ToolCallDisplay }) {
           {setupStatus === "failed_continued" && (
             <div>Setup: failed, continued anyway</div>
           )}
-          {setupAttemptCount ? <div>Setup attempts: {setupAttemptCount}</div> : null}
-          {setupExitCode !== null ? <div>Setup exit code: {setupExitCode}</div> : null}
-          {setupErrorMessage ? <div>Setup note: {setupErrorMessage}</div> : null}
+          {setupAttemptCount ? (
+            <div>Setup attempts: {setupAttemptCount}</div>
+          ) : null}
+          {setupExitCode !== null ? (
+            <div>Setup exit code: {setupExitCode}</div>
+          ) : null}
+          {setupErrorMessage ? (
+            <div>Setup note: {setupErrorMessage}</div>
+          ) : null}
           {!declined && !path && !branch && !alreadyExists && (
             <div>No worktree data returned.</div>
           )}
         </div>
       )}
 
-      {setupStdout ? <pre className="cmd-output mt-1">{setupStdout}</pre> : null}
+      {setupStdout ? (
+        <pre className="cmd-output mt-1">{setupStdout}</pre>
+      ) : null}
       {setupStderr ? (
         <pre className="cmd-output cmd-output--error mt-1">{setupStderr}</pre>
       ) : null}
@@ -645,7 +655,7 @@ function ExpandedSearch({ tc }: { tc: ToolCallDisplay }) {
       : null;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       <div className="text-xs text-text leading-[1.55]">
         Searching for pattern:{" "}
         <span className="font-mono bg-surface border border-border-subtle rounded px-1">
@@ -807,7 +817,7 @@ function ExpandedUserInput({ tc }: { tc: ToolCallDisplay }) {
   const isCustomAnswer = answer !== null && !isOptionAnswer;
 
   return (
-    <div className="cmd-block mt-1 border border-border-subtle rounded-[6px] bg-inset">
+    <div className="cmd-block mt-1 bg-inset">
       {/* Question */}
       <div className="text-xs text-text leading-[1.6] mb-2">{question}</div>
 

--- a/src/components/toolCallRenderItems.test.ts
+++ b/src/components/toolCallRenderItems.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ToolCallDisplay } from "@/agent/types";
 import {
+  buildToolCallRenderItemsByMessage,
   buildToolCallRenderItems,
   getToolCallRenderKind,
 } from "./toolCallRenderItems";
@@ -15,6 +16,23 @@ function makeToolCall(
     tool,
     args: {},
     status,
+  };
+}
+
+function makeMessage(
+  id: string,
+  overrides: Partial<{
+    content: string;
+    reasoning: string;
+    reasoningStreaming: boolean;
+    streaming: boolean;
+    traceId: string;
+    toolCalls: ToolCallDisplay[];
+  }> = {},
+) {
+  return {
+    id,
+    ...overrides,
   };
 }
 
@@ -126,5 +144,87 @@ describe("toolCallRenderItems", () => {
     expect(getToolCallRenderKind(makeToolCall("tc-3", "workspace_listDir"))).toBe(
       "compact",
     );
+  });
+
+  it("groups inline compact tool calls across assistant messages when nothing visible separates them", () => {
+    const itemsByMessage = buildToolCallRenderItemsByMessage(
+      [
+        makeMessage("msg-1", {
+          toolCalls: [makeToolCall("tc-1", "workspace_listDir")],
+        }),
+        makeMessage("msg-2", {
+          toolCalls: [makeToolCall("tc-2", "workspace_readFile")],
+        }),
+      ],
+      true,
+    );
+
+    expect(itemsByMessage["msg-1"]).toBeUndefined();
+    expect(itemsByMessage["msg-2"]).toEqual([
+      {
+        kind: "group",
+        toolCalls: [
+          expect.objectContaining({ id: "tc-1" }),
+          expect.objectContaining({ id: "tc-2" }),
+        ],
+      },
+    ]);
+  });
+
+  it("treats reasoning blocks between assistant messages as hard boundaries", () => {
+    const itemsByMessage = buildToolCallRenderItemsByMessage(
+      [
+        makeMessage("msg-1", {
+          toolCalls: [makeToolCall("tc-1", "workspace_listDir")],
+        }),
+        makeMessage("msg-2", {
+          reasoning: "Checking constraints first.",
+        }),
+        makeMessage("msg-3", {
+          toolCalls: [makeToolCall("tc-2", "workspace_readFile")],
+        }),
+      ],
+      true,
+    );
+
+    expect(itemsByMessage["msg-1"]).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-1" }),
+      }),
+    ]);
+    expect(itemsByMessage["msg-3"]).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-2" }),
+      }),
+    ]);
+  });
+
+  it("keeps tool calls on their original messages when cross-message grouping is disabled", () => {
+    const itemsByMessage = buildToolCallRenderItemsByMessage(
+      [
+        makeMessage("msg-1", {
+          toolCalls: [makeToolCall("tc-1", "workspace_listDir")],
+        }),
+        makeMessage("msg-2", {
+          toolCalls: [makeToolCall("tc-2", "workspace_readFile")],
+        }),
+      ],
+      false,
+    );
+
+    expect(itemsByMessage["msg-1"]).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-1" }),
+      }),
+    ]);
+    expect(itemsByMessage["msg-2"]).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        toolCall: expect.objectContaining({ id: "tc-2" }),
+      }),
+    ]);
   });
 });

--- a/src/components/toolCallRenderItems.ts
+++ b/src/components/toolCallRenderItems.ts
@@ -14,6 +14,16 @@ export type ToolCallRenderItem =
       toolCalls: ToolCallDisplay[];
     };
 
+export interface ToolCallRenderMessage {
+  id: string;
+  content?: string;
+  reasoning?: string;
+  reasoningStreaming?: boolean;
+  streaming?: boolean;
+  traceId?: string;
+  toolCalls?: ToolCallDisplay[];
+}
+
 export function getToolCallRenderKind(tc: ToolCallDisplay): ToolCallRenderKind {
   if (tc.tool === "user_input" && tc.status === "awaiting_approval") {
     return "user_input";
@@ -89,4 +99,72 @@ export function buildToolCallRenderItems(
 
   flushGroup(items, pendingGroup);
   return items;
+}
+
+function hasVisibleContentBeforeToolCalls(message: ToolCallRenderMessage): boolean {
+  return Boolean(
+    message.content ||
+      message.reasoning ||
+      message.reasoningStreaming ||
+      message.streaming,
+  );
+}
+
+function hasVisibleContentAfterToolCalls(message: ToolCallRenderMessage): boolean {
+  return Boolean(message.traceId);
+}
+
+export function buildToolCallRenderItemsByMessage(
+  messages: ToolCallRenderMessage[],
+  groupInlineToolCalls: boolean,
+): Partial<Record<string, ToolCallRenderItem[]>> {
+  const itemsByMessageId: Partial<Record<string, ToolCallRenderItem[]>> = {};
+
+  if (!groupInlineToolCalls) {
+    for (const message of messages) {
+      const toolCalls = message.toolCalls ?? [];
+      if (toolCalls.length === 0) continue;
+      itemsByMessageId[message.id] = buildToolCallRenderItems(
+        toolCalls,
+        false,
+      );
+    }
+    return itemsByMessageId;
+  }
+
+  let pendingToolCalls: ToolCallDisplay[] = [];
+  let pendingMessageIds: string[] = [];
+
+  const flushPending = () => {
+    if (pendingToolCalls.length === 0 || pendingMessageIds.length === 0) {
+      return;
+    }
+
+    const anchorMessageId = pendingMessageIds[pendingMessageIds.length - 1];
+    itemsByMessageId[anchorMessageId] = buildToolCallRenderItems(
+      pendingToolCalls,
+      true,
+    );
+    pendingToolCalls = [];
+    pendingMessageIds = [];
+  };
+
+  for (const message of messages) {
+    if (hasVisibleContentBeforeToolCalls(message)) {
+      flushPending();
+    }
+
+    const toolCalls = message.toolCalls ?? [];
+    if (toolCalls.length > 0) {
+      pendingToolCalls = [...pendingToolCalls, ...toolCalls];
+      pendingMessageIds.push(message.id);
+    }
+
+    if (hasVisibleContentAfterToolCalls(message)) {
+      flushPending();
+    }
+  }
+
+  flushPending();
+  return itemsByMessageId;
 }


### PR DESCRIPTION
## Summary
- group inline tool calls across assistant messages in the same bubble when nothing visible separates them
- keep reasoning/thinking and trace actions as hard boundaries and skip empty message segments
- add regression tests for cross-message grouping and include the CompactToolCall cleanup in this branch

## Testing
- npx vitest run src/components/toolCallRenderItems.test.ts src/WorkspacePage.test.tsx
- npm run typecheck
- npm run lint

Fixes #129