### PR TITLE
Revamp logs window controls

### DIFF
--- a/src/agent/runner.test.ts
+++ b/src/agent/runner.test.ts
@@ -1091,32 +1091,32 @@ describe("runner", () => {
       expect.arrayContaining([
         expect.objectContaining({
           event: "runner.turn:start",
-          message: `[${tabId}] turn:start`,
+          message: "turn:start",
           context: expect.objectContaining({ tabId }),
         }),
         expect.objectContaining({
           event: "runner.stream:part",
-          message: `[${tabId}] stream:part`,
+          message: "stream:part",
         }),
         expect.objectContaining({
           event: "runner.stream:reasoning-start",
-          message: `[${tabId}] stream:reasoning-start`,
+          message: "stream:reasoning-start",
         }),
         expect.objectContaining({
           event: "runner.stream:reasoning-delta",
-          message: `[${tabId}] stream:reasoning-delta`,
+          message: "stream:reasoning-delta",
         }),
         expect.objectContaining({
           event: "runner.stream:text-delta",
-          message: `[${tabId}] stream:text-delta`,
+          message: "stream:text-delta",
         }),
         expect.objectContaining({
           event: "runner.stream:tool-calls:raw",
-          message: `[${tabId}] stream:tool-calls:raw`,
+          message: "stream:tool-calls:raw",
         }),
         expect.objectContaining({
           event: "runner.stream:finish",
-          message: `[${tabId}] stream:finish`,
+          message: "stream:finish",
           data: expect.objectContaining({
             finishReason: "stop",
             stepCount: 1,
@@ -1133,7 +1133,7 @@ describe("runner", () => {
         }),
         expect.objectContaining({
           event: "runner.stream:summary",
-          message: `[${tabId}] stream:summary`,
+          message: "stream:summary",
         }),
       ]),
     );

--- a/src/agent/runner/agentLoop.ts
+++ b/src/agent/runner/agentLoop.ts
@@ -157,7 +157,7 @@ export async function agentLoop(
         },
         context: runLogContext,
       });
-      logStreamDebug(tabId, debugEnabled, "turn:start", turnContext, {
+      logStreamDebug(debugEnabled, "turn:start", turnContext, {
         iteration,
         apiMessageCount: currentApiMessages.length,
         modelId,

--- a/src/agent/runner/logging.ts
+++ b/src/agent/runner/logging.ts
@@ -80,7 +80,6 @@ export function createToolLogContext(
 }
 
 export function logStreamDebug(
-  tabId: string,
   debugEnabled: boolean,
   event: string,
   logContext: LogContext,
@@ -94,7 +93,7 @@ export function logStreamDebug(
     level: "debug",
     tags,
     event: `runner.${event}`,
-    message: `[${tabId}] ${event}`,
+    message: event,
     data: payload === undefined ? undefined : toLoggable(payload),
     context: logContext,
   });
@@ -158,7 +157,6 @@ function summarizeStreamStepForDebug(
 }
 
 export async function logStreamFinishDebug(
-  tabId: string,
   debugEnabled: boolean,
   result: DebuggableStreamResult,
   logContext: LogContext,
@@ -173,7 +171,7 @@ export async function logStreamFinishDebug(
     ]);
     const steps = Array.isArray(stepsValue) ? stepsValue : [];
 
-    logStreamDebug(tabId, debugEnabled, "stream:finish", logContext, {
+    logStreamDebug(debugEnabled, "stream:finish", logContext, {
       ...(typeof finishReason === "string" ? { finishReason } : {}),
       ...(typeof rawFinishReason === "string" ? { rawFinishReason } : {}),
       stepCount: steps.length,
@@ -182,7 +180,7 @@ export async function logStreamFinishDebug(
       ),
     });
   } catch (error) {
-    logStreamDebug(tabId, debugEnabled, "stream:finish:error", logContext, error);
+    logStreamDebug(debugEnabled, "stream:finish:error", logContext, error);
   }
 }
 

--- a/src/agent/runner/streamTurn.ts
+++ b/src/agent/runner/streamTurn.ts
@@ -150,18 +150,12 @@ export async function streamTurn(
           throw new DOMException("Aborted", "AbortError");
         }
         streamPartCount += 1;
-        logStreamDebug(tabId, debugEnabled, "stream:part", logContext, part);
+        logStreamDebug(debugEnabled, "stream:part", logContext, part);
 
         const streamError = streamPartError(part);
         if (streamError !== null) {
           streamErrorPartCount += 1;
-          logStreamDebug(
-            tabId,
-            debugEnabled,
-            "stream:error-part",
-            logContext,
-            streamError,
-          );
+          logStreamDebug(debugEnabled, "stream:error-part", logContext, streamError);
           streamErrors.push(streamError);
           continue;
         }
@@ -170,12 +164,7 @@ export async function streamTurn(
           reasoningStartCount += 1;
           ensureReasoningStart();
           reasoningActive = true;
-          logStreamDebug(
-            tabId,
-            debugEnabled,
-            "stream:reasoning-start",
-            logContext,
-          );
+          logStreamDebug(debugEnabled, "stream:reasoning-start", logContext);
           updateStreamingMessage();
           continue;
         }
@@ -184,7 +173,7 @@ export async function streamTurn(
           reasoningEndCount += 1;
           reasoningActive = false;
           finalizeReasoningDuration();
-          logStreamDebug(tabId, debugEnabled, "stream:reasoning-end", logContext, {
+          logStreamDebug(debugEnabled, "stream:reasoning-end", logContext, {
             reasoningDurationMs,
           });
           updateStreamingMessage();
@@ -196,7 +185,7 @@ export async function streamTurn(
           accText += textDelta;
           textDeltaCount += 1;
           textDeltaChars += textDelta.length;
-          logStreamDebug(tabId, debugEnabled, "stream:text-delta", logContext, {
+          logStreamDebug(debugEnabled, "stream:text-delta", logContext, {
             delta: textDelta,
             deltaLength: textDelta.length,
             accumulatedLength: accText.length,
@@ -213,7 +202,7 @@ export async function streamTurn(
           accReasoning += reasoningDelta;
           reasoningDeltaCount += 1;
           reasoningDeltaChars += reasoningDelta.length;
-          logStreamDebug(tabId, debugEnabled, "stream:reasoning-delta", logContext, {
+          logStreamDebug(debugEnabled, "stream:reasoning-delta", logContext, {
             delta: reasoningDelta,
             deltaLength: reasoningDelta.length,
             accumulatedLength: accReasoning.length,
@@ -229,7 +218,7 @@ export async function streamTurn(
         accText += delta;
         textDeltaCount += 1;
         textDeltaChars += delta.length;
-        logStreamDebug(tabId, debugEnabled, "stream:text-delta:textStream", logContext, {
+        logStreamDebug(debugEnabled, "stream:text-delta:textStream", logContext, {
           delta,
           deltaLength: delta.length,
           accumulatedLength: accText.length,
@@ -240,7 +229,7 @@ export async function streamTurn(
       }
     }
   } catch (err) {
-    logStreamDebug(tabId, debugEnabled, "stream:throw", logContext, err);
+    logStreamDebug(debugEnabled, "stream:throw", logContext, err);
     if (!signal.aborted && (err as Error).name !== "AbortError") {
       throw attachStreamErrors(err, streamErrors);
     }
@@ -250,18 +239,12 @@ export async function streamTurn(
   let sdkToolCalls: unknown;
   try {
     sdkToolCalls = await result.toolCalls;
-    logStreamDebug(
-      tabId,
-      debugEnabled,
-      "stream:tool-calls:raw",
-      logContext,
-      sdkToolCalls,
-    );
+    logStreamDebug(debugEnabled, "stream:tool-calls:raw", logContext, sdkToolCalls);
   } catch (err) {
-    logStreamDebug(tabId, debugEnabled, "stream:tool-calls:error", logContext, err);
+    logStreamDebug(debugEnabled, "stream:tool-calls:error", logContext, err);
     throw attachStreamErrors(err, streamErrors);
   }
-  await logStreamFinishDebug(tabId, debugEnabled, result, logContext);
+  await logStreamFinishDebug(debugEnabled, result, logContext);
 
   if (reasoningStartedAtMs !== null && reasoningDurationMs === null) {
     reasoningDurationMs = Math.max(0, Date.now() - reasoningStartedAtMs);
@@ -273,12 +256,12 @@ export async function streamTurn(
   )
     .map((tc) => toApiToolCall(tc))
     .filter((tc): tc is ApiToolCall => tc !== null);
-  logStreamDebug(tabId, debugEnabled, "stream:tool-calls:parsed", logContext, {
+  logStreamDebug(debugEnabled, "stream:tool-calls:parsed", logContext, {
     count: parsedToolCalls.length,
     toolCallIds: parsedToolCalls.map((tc) => tc.id),
     toolNames: parsedToolCalls.map((tc) => tc.function.name),
   });
-  logStreamDebug(tabId, debugEnabled, "stream:summary", logContext, {
+  logStreamDebug(debugEnabled, "stream:summary", logContext, {
     usedFullStream,
     streamPartCount,
     streamErrorPartCount,

--- a/src/logging/LogsWindowApp.test.tsx
+++ b/src/logging/LogsWindowApp.test.tsx
@@ -82,6 +82,7 @@ describe("LogsWindowApp", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -127,7 +128,7 @@ describe("LogsWindowApp", () => {
     expect(screen.queryByText("Initial query message")).toBeNull();
   });
 
-  it("starts compact, expands filters on demand, and ignores time filters", async () => {
+  it("renders inline filters and ignores time filters", async () => {
     logsMocks.queryLogsMock.mockResolvedValue([]);
 
     const { container } = render(
@@ -148,22 +149,29 @@ describe("LogsWindowApp", () => {
     });
 
     expect(screen.queryByPlaceholderText("trace id")).toBeNull();
-    expect(screen.queryByRole("dialog", { name: "Log filters" })).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "SHOW FILTERS" }));
-
-    expect(screen.getByRole("dialog", { name: "Log filters" })).not.toBeNull();
-    expect(screen.getByPlaceholderText("trace id")).not.toBeNull();
     expect(
       screen.getByRole("button", { name: "Tag filter frontend: ignored" }),
     ).not.toBeNull();
-    expect(screen.getByText("Verbosity")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Cycle verbosity/ })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Add trace id filter" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Add tool correlation id filter" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Row limit 100" })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Source filter backend" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen.getByRole("button", { name: "Source filter frontend" }).getAttribute("aria-pressed"),
+    ).toBe("false");
     expect(
       container.querySelector('input[type="datetime-local"]'),
     ).toBeNull();
   });
 
-  it("toggles the filter popover with backquote", async () => {
+  it("adds and removes a trace id filter inline", async () => {
     logsMocks.queryLogsMock.mockResolvedValue([]);
 
     render(
@@ -175,15 +183,155 @@ describe("LogsWindowApp", () => {
       />,
     );
 
-    expect(screen.queryByRole("dialog", { name: "Log filters" })).toBeNull();
-
-    fireEvent.keyDown(window, { key: "`", code: "Backquote" });
-    expect(screen.getByRole("dialog", { name: "Log filters" })).not.toBeNull();
-
-    fireEvent.keyDown(window, { key: "`", code: "Backquote" });
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "Log filters" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Add trace id filter" }));
+    expect(screen.getByRole("dialog", { name: "Trace ID filter input" })).not.toBeNull();
+    fireEvent.change(screen.getByRole("textbox", { name: "Trace ID" }), {
+      target: { value: "trace-1" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "ADD" }));
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        traceId: "trace-1",
+        limit: 100,
+      });
+    });
+
+    expect(screen.getByText("trace: trace-1")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove trace id filter" }));
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        limit: 100,
+      });
+    });
+    expect(screen.getByRole("button", { name: "Add trace id filter" })).not.toBeNull();
+  });
+
+  it("adds and removes a tool correlation id filter inline", async () => {
+    logsMocks.queryLogsMock.mockResolvedValue([]);
+
+    render(
+      <LogsWindowApp
+        initialPayload={{
+          origin: "manual",
+          filter: { limit: 100 },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add tool correlation id filter" }));
+    expect(
+      screen.getByRole("dialog", { name: "Tool Correlation ID filter input" }),
+    ).not.toBeNull();
+    fireEvent.change(screen.getByRole("textbox", { name: "Tool Correlation ID" }), {
+      target: { value: "tool-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "ADD" }));
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        correlationId: "tool-1",
+        limit: 100,
+      });
+    });
+
+    expect(screen.getByText("tool: tool-1")).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove tool correlation id filter" }),
+    );
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        limit: 100,
+      });
+    });
+    expect(
+      screen.getByRole("button", { name: "Add tool correlation id filter" }),
+    ).not.toBeNull();
+  });
+
+  it("updates the row limit from the inline picker", async () => {
+    logsMocks.queryLogsMock.mockResolvedValue([]);
+
+    render(
+      <LogsWindowApp
+        initialPayload={{
+          origin: "manual",
+          filter: { limit: 100 },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Row limit 100" }));
+    expect(screen.getByRole("dialog", { name: "Row limit options" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Set row limit 500" }));
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        limit: 500,
+      });
+    });
+    expect(screen.getByRole("button", { name: "Row limit 500" })).not.toBeNull();
+  });
+
+  it("auto closes regular toasts, keeps export toasts until dismissed, and replaces older notices", async () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <LogsWindowApp
+          initialPayload={{
+            origin: "manual",
+            filter: { limit: 100 },
+          }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "CLEAR" }));
+      expect(
+        screen.getByText("Cleared current view. Only new logs will appear."),
+      ).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3600);
+      });
+      expect(
+        screen.queryByText("Cleared current view. Only new logs will appear."),
+      ).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "EXPORT" }));
+        await Promise.resolve();
+      });
+
+      expect(
+        screen.getByText("Exported 2 log entries to /tmp/rakh-logs.json"),
+      ).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(
+        screen.getByText("Exported 2 log entries to /tmp/rakh-logs.json"),
+      ).not.toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "CLEAR" }));
+      expect(
+        screen.queryByText("Exported 2 log entries to /tmp/rakh-logs.json"),
+      ).toBeNull();
+      expect(
+        screen.getByText("Cleared current view. Only new logs will appear."),
+      ).not.toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+      expect(
+        screen.queryByText("Cleared current view. Only new logs will appear."),
+      ).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes excluded tags through to history queries", async () => {
@@ -223,7 +371,6 @@ describe("LogsWindowApp", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "SHOW FILTERS" }));
     fireEvent.click(screen.getByRole("button", { name: "Tag filter agent-loop: ignored" }));
 
     await waitFor(() => {
@@ -263,7 +410,6 @@ describe("LogsWindowApp", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "SHOW FILTERS" }));
     fireEvent.click(screen.getByRole("button", { name: /Cycle verbosity/ }));
 
     await waitFor(() => {
@@ -300,6 +446,54 @@ describe("LogsWindowApp", () => {
         limit: 100,
       });
     });
+  });
+
+  it("toggles source pills between backend, frontend, and both", async () => {
+    logsMocks.queryLogsMock.mockResolvedValue([]);
+
+    render(
+      <LogsWindowApp
+        initialPayload={{
+          origin: "manual",
+          filter: { limit: 100 },
+        }}
+      />,
+    );
+
+    const backendButton = screen.getByRole("button", { name: "Source filter backend" });
+    const frontendButton = screen.getByRole("button", { name: "Source filter frontend" });
+
+    fireEvent.click(backendButton);
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        source: "backend",
+        limit: 100,
+      });
+    });
+    expect(backendButton.getAttribute("aria-pressed")).toBe("true");
+    expect(frontendButton.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(frontendButton);
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        source: "frontend",
+        limit: 100,
+      });
+    });
+    expect(backendButton.getAttribute("aria-pressed")).toBe("false");
+    expect(frontendButton.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(frontendButton);
+
+    await waitFor(() => {
+      expect(logsMocks.queryLogsMock).toHaveBeenLastCalledWith({
+        limit: 100,
+      });
+    });
+    expect(backendButton.getAttribute("aria-pressed")).toBe("false");
+    expect(frontendButton.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("lets tag chips add include and exclude filters", async () => {
@@ -369,7 +563,12 @@ describe("LogsWindowApp", () => {
     );
 
     await screen.findByText("Expandable log row");
+    expect(screen.getByLabelText("event").textContent).toBe("•");
     expect(screen.getByLabelText("Level warn").textContent).toBe("W");
+    expect(screen.getByLabelText("event").className.includes("h-7")).toBe(true);
+    expect(screen.getByLabelText("event").className.includes("w-7")).toBe(true);
+    expect(screen.getByLabelText("Level warn").className.includes("h-7")).toBe(true);
+    expect(screen.getByLabelText("Level warn").className.includes("w-7")).toBe(true);
     expect(screen.queryByText("Metadata")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Expand log row expandable-row" }));
@@ -381,6 +580,34 @@ describe("LogsWindowApp", () => {
     await waitFor(() => {
       expect(screen.queryByText("Metadata")).toBeNull();
     });
+  });
+
+  it("renders an icon for error kind entries", async () => {
+    logsMocks.queryLogsMock.mockResolvedValue([
+      makeEntry({
+        id: "error-row",
+        kind: "error",
+        level: "error",
+        message: "Error log row",
+      }),
+    ]);
+
+    render(
+      <LogsWindowApp
+        initialPayload={{
+          origin: "manual",
+          filter: { limit: 100 },
+        }}
+      />,
+    );
+
+    await screen.findByText("Error log row");
+    expect(screen.getByLabelText("error").textContent).toBe("!");
+    expect(screen.getByLabelText("Level error").textContent).toBe("E");
+    expect(screen.getByLabelText("error").className.includes("h-7")).toBe(true);
+    expect(screen.getByLabelText("error").className.includes("w-7")).toBe(true);
+    expect(screen.getByLabelText("Level error").className.includes("h-7")).toBe(true);
+    expect(screen.getByLabelText("Level error").className.includes("w-7")).toBe(true);
   });
 
   it("switches to tree mode for trace filters and clears only the current view", async () => {
@@ -413,7 +640,7 @@ describe("LogsWindowApp", () => {
     );
 
     await screen.findByText("Root operation");
-    expect(screen.getByText("Grouped by trace lineage")).not.toBeNull();
+    expect(screen.getByLabelText("Trace tree view")).not.toBeNull();
     expect(screen.getByText("Child operation")).not.toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "EXPORT" }));

--- a/src/logging/LogsWindowApp.tsx
+++ b/src/logging/LogsWindowApp.tsx
@@ -1,13 +1,17 @@
-import { startTransition, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Button, Badge, SelectField, TextField } from "@/components/ui";
+import { Button, Badge, TextField } from "@/components/ui";
 import { cn } from "@/utils/cn";
-import {
-  exportLogs,
-  listenForLogEntries,
-  queryLogs,
-} from "./client";
+import { exportLogs, listenForLogEntries, queryLogs } from "./client";
 import type {
   LogTag,
   LogEntry,
@@ -27,13 +31,24 @@ import {
 const MAX_WINDOW_ENTRIES = 1000;
 const LIVE_FLUSH_MS = 75;
 const SCROLL_TAIL_THRESHOLD_PX = 28;
-const VERBOSITY_LEVELS: LogLevel[] = ["error", "warn", "info", "debug", "trace"];
-const SOURCES: Array<LogSource | ""> = ["", "frontend", "backend"];
+const VERBOSITY_LEVELS: LogLevel[] = [
+  "error",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+];
+const SOURCE_OPTIONS: LogSource[] = ["backend", "frontend"];
 const LIMIT_OPTIONS = [100, 250, 500, 1000];
+const NOTICE_AUTO_CLOSE_MS = 3500;
 
 type ViewerNotice =
-  | { kind: "success"; message: string }
-  | { kind: "error"; message: string }
+  | {
+      id: number;
+      kind: "success" | "error";
+      message: string;
+      autoCloseMs: number | null;
+    }
   | null;
 
 interface ControlState {
@@ -48,6 +63,16 @@ interface ControlState {
 interface LogTreeNode {
   entry: LogEntry;
   children: LogTreeNode[];
+}
+
+interface InlineTokenFilterControlProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  addLabel: string;
+  badgePrefix: string;
+  onChange: (next: string) => void;
+  className?: string;
 }
 
 function normalizeLimit(limit: number): number {
@@ -127,7 +152,8 @@ function levelsForVerbosity(verbosity: LogLevel): LogLevel[] {
 function verbosityFromLevels(levels: LogLevel[] | undefined): LogLevel {
   if (!levels || levels.length === 0) return "trace";
   const normalized = [...new Set(levels)].sort(
-    (left, right) => VERBOSITY_LEVELS.indexOf(left) - VERBOSITY_LEVELS.indexOf(right),
+    (left, right) =>
+      VERBOSITY_LEVELS.indexOf(left) - VERBOSITY_LEVELS.indexOf(right),
   );
   for (const candidate of VERBOSITY_LEVELS) {
     const candidateLevels = levelsForVerbosity(candidate);
@@ -176,7 +202,16 @@ function levelSymbol(level: LogLevel): string {
 
 function nextVerbosityLevel(current: LogLevel): LogLevel {
   const currentIndex = VERBOSITY_LEVELS.indexOf(current);
-  return VERBOSITY_LEVELS[(currentIndex + 1) % VERBOSITY_LEVELS.length] ?? "error";
+  return (
+    VERBOSITY_LEVELS[(currentIndex + 1) % VERBOSITY_LEVELS.length] ?? "error"
+  );
+}
+
+function nextSourceFilter(
+  current: LogSource | "",
+  source: LogSource,
+): LogSource | "" {
+  return current === source ? "" : source;
 }
 
 function controlsFromPayload(
@@ -233,8 +268,9 @@ function formatTimestamp(timestampMs: number): string {
 }
 
 function sortEntriesAscending(entries: LogEntry[]): LogEntry[] {
-  return [...entries].sort((left, right) =>
-    left.timestampMs - right.timestampMs || left.id.localeCompare(right.id),
+  return [...entries].sort(
+    (left, right) =>
+      left.timestampMs - right.timestampMs || left.id.localeCompare(right.id),
   );
 }
 
@@ -273,7 +309,9 @@ function matchesFilter(entry: LogEntry, filter: LogQueryFilter): boolean {
     : filter.tags.some((tag) => entry.tags.includes(tag));
 }
 
-function levelVariant(level: LogLevel): "muted" | "primary" | "info" | "warning" | "danger" {
+function levelVariant(
+  level: LogLevel,
+): "muted" | "primary" | "info" | "warning" | "danger" {
   switch (level) {
     case "trace":
       return "muted";
@@ -288,7 +326,9 @@ function levelVariant(level: LogLevel): "muted" | "primary" | "info" | "warning"
   }
 }
 
-function kindVariant(kind: LogEntry["kind"]): "muted" | "primary" | "success" | "danger" {
+function kindVariant(
+  kind: LogEntry["kind"],
+): "muted" | "primary" | "success" | "danger" {
   switch (kind) {
     case "start":
       return "primary";
@@ -307,8 +347,12 @@ function kindDisplayLabel(kind: LogEntry["kind"]): string {
       return "↗";
     case "end":
       return "↘";
+    case "event":
+      return "•";
+    case "error":
+      return "!";
     default:
-      return kind.toUpperCase();
+      return kind satisfies never;
   }
 }
 
@@ -380,28 +424,6 @@ function buildTree(entries: LogEntry[]): LogTreeNode[] {
   return roots;
 }
 
-function filterSummary(filter: LogQueryFilter): string {
-  const verbosity =
-    filter.levels && filter.levels.length > 0
-      ? verbositySummary(verbosityFromLevels(filter.levels))
-      : null;
-  const parts = [
-    filter.traceId ? `trace ${filter.traceId}` : null,
-    filter.correlationId ? `tool ${filter.correlationId}` : null,
-    filter.source ? `${filter.source} only` : null,
-    filter.tags?.length ? `tags ${filter.tags.join(", ")}` : null,
-    filter.excludeTags?.length
-      ? `excluding ${filter.excludeTags.join(", ")}`
-      : null,
-    verbosity,
-  ].filter(Boolean);
-
-  if (parts.length === 0) {
-    return `Global feed · latest ${filter.limit ?? DEFAULT_LOG_LIMIT} rows`;
-  }
-  return parts.join(" · ");
-}
-
 function activeFilterCount(filter: LogQueryFilter): number {
   return [
     filter.tags && filter.tags.length > 0 ? 1 : 0,
@@ -419,9 +441,79 @@ function visibleTagPills(filter: LogQueryFilter): LogTag[] {
     ...normalizeTags(filter.excludeTags),
   ]);
   const extras = Array.from(selected)
-    .filter((tag) => !KNOWN_LOG_TAGS.includes(tag as (typeof KNOWN_LOG_TAGS)[number]))
+    .filter(
+      (tag) => !KNOWN_LOG_TAGS.includes(tag as (typeof KNOWN_LOG_TAGS)[number]),
+    )
     .sort();
   return [...KNOWN_LOG_TAGS, ...extras];
+}
+
+function ViewModeIndicator({
+  isTreeView,
+  limit,
+}: {
+  isTreeView: boolean;
+  limit: number;
+}) {
+  const title = isTreeView
+    ? "Grouped by trace lineage"
+    : `Showing up to ${limit} rows`;
+
+  return (
+    <Badge
+      variant="muted"
+      aria-label={isTreeView ? "Trace tree view" : `Live feed up to ${limit} rows`}
+      title={title}
+      className="min-w-[28px] justify-center px-1.5"
+    >
+      <span
+        aria-hidden="true"
+        className="material-symbols-outlined text-[14px] leading-none"
+      >
+        {isTreeView ? "account_tree" : "view_list"}
+      </span>
+    </Badge>
+  );
+}
+
+function NoticeToast({
+  notice,
+  onDismiss,
+}: {
+  notice: Exclude<ViewerNotice, null>;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
+      <div
+        role={notice.kind === "error" ? "alert" : "status"}
+        className={cn(
+          "pointer-events-auto flex w-full max-w-[560px] items-start gap-3 rounded-2xl border px-4 py-3 shadow-[0_16px_40px_rgb(0_0_0_/_0.18)] backdrop-blur",
+          notice.kind === "error"
+            ? "border-[color-mix(in_srgb,var(--color-error)_30%,transparent)] bg-[color-mix(in_srgb,var(--color-error)_10%,var(--color-surface))] text-error"
+            : "border-[color-mix(in_srgb,var(--color-success)_30%,transparent)] bg-[color-mix(in_srgb,var(--color-success)_10%,var(--color-surface))] text-success",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-current/20 text-[12px] font-bold"
+        >
+          {notice.kind === "error" ? "!" : "i"}
+        </span>
+        <div className="min-w-0 flex-1 text-sm leading-5 text-text">
+          {notice.message}
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss notice"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-current/15 text-[11px] text-current transition-colors hover:bg-current/10"
+          onClick={onDismiss}
+        >
+          X
+        </button>
+      </div>
+    </div>
+  );
 }
 
 function tagPillVisual(state: "include" | "exclude" | "ignore"): {
@@ -482,7 +574,7 @@ function TagStatePill({
   );
 }
 
-function VerbosityControl({
+function VerbosityPillControl({
   value,
   onChange,
 }: {
@@ -490,41 +582,307 @@ function VerbosityControl({
   onChange: (next: LogLevel) => void;
 }) {
   const selectedIndex = VERBOSITY_LEVELS.indexOf(value);
-  const fillWidth = `${((selectedIndex + 1) / VERBOSITY_LEVELS.length) * 100}%`;
   const symbol = levelSymbol(value);
 
   return (
     <div className="flex items-center gap-2">
-      <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted">
-        Verbosity
-      </div>
       <button
         type="button"
         aria-label={`Cycle verbosity, current ${value}`}
         title={`Verbosity ${selectedIndex + 1}/${VERBOSITY_LEVELS.length} · ${verbositySummary(value)}`}
-        className="w-[124px] min-w-0 shrink-0 rounded-xl border border-border-subtle bg-inset/50 px-2.5 py-1.5 text-left transition-colors hover:border-primary/35 hover:bg-inset/70"
+        className="inline-flex w-[96px] shrink-0 items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 font-mono text-[11px] text-text transition-colors hover:border-primary/30 hover:bg-inset/50"
         onClick={() => onChange(nextVerbosityLevel(value))}
       >
-        <div className="flex items-center gap-2">
-          <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-surface px-1.5 text-[10px] font-bold text-text">
-            {selectedIndex + 1}
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5 truncate text-[11px] font-mono text-text">
-              <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-border-subtle bg-surface text-[9px] font-bold text-text">
-                {symbol}
-              </span>
-              <span className="lowercase">{value}</span>
-            </div>
-            <div className="mt-1 h-1 overflow-hidden rounded-full bg-border-subtle">
-              <div
-                className="h-full rounded-full bg-primary transition-[width] duration-150"
-                style={{ width: fillWidth }}
-              />
-            </div>
+        <span className="font-bold">{selectedIndex + 1}</span>
+        <span aria-hidden="true" className="text-muted">
+          /
+        </span>
+        <span className="font-bold">{symbol}</span>
+        <span className="min-w-0 truncate lowercase">{value}</span>
+      </button>
+    </div>
+  );
+}
+
+function SourceControl({
+  value,
+  onChange,
+}: {
+  value: LogSource | "";
+  onChange: (next: LogSource | "") => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      <div className="flex items-center gap-2">
+        {SOURCE_OPTIONS.map((source) => {
+          const selected = value === source;
+          return (
+            <button
+              key={source}
+              type="button"
+              aria-label={`Source filter ${source}`}
+              aria-pressed={selected}
+              title={
+                selected
+                  ? `Showing only ${source} logs. Click to include both sources.`
+                  : `Show only ${source} logs.`
+              }
+              className={cn(
+                "inline-flex items-center rounded-full border px-3 py-1.5 font-mono text-[11px] lowercase transition-colors",
+                selected
+                  ? "border-primary bg-primary-dim text-primary"
+                  : "border-border-subtle bg-surface text-muted hover:border-primary/30 hover:text-text",
+              )}
+              onClick={() => onChange(nextSourceFilter(value, source))}
+            >
+              {source}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RowLimitControl({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!(event.target instanceof Node)) return;
+      if (containerRef.current?.contains(event.target)) return;
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        type="button"
+        aria-label={`Row limit ${value}`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={`Row limit ${value}`}
+        className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 font-mono text-[11px] text-text transition-colors hover:border-primary/30 hover:bg-inset/50"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span
+          aria-hidden="true"
+          className="inline-flex h-4 w-4 items-center justify-center text-muted"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            className="h-3.5 w-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          >
+            <path d="M3 4h10" />
+            <path d="M3 8h10" />
+            <path d="M3 12h10" />
+          </svg>
+        </span>
+        <span>{value}</span>
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Row limit options"
+          className="absolute right-0 top-full z-20 mt-2 w-24 rounded-xl border border-border-subtle bg-surface p-2 shadow-[0_12px_30px_rgb(0_0_0_/_0.18)]"
+        >
+          <div className="flex flex-col gap-1">
+            {LIMIT_OPTIONS.map((option) => {
+              const selected = option === value;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-label={`Set row limit ${option}`}
+                  className={cn(
+                    "rounded-lg px-2 py-1 text-left text-xs transition-colors",
+                    selected
+                      ? "bg-primary-dim text-primary"
+                      : "bg-inset text-text hover:bg-primary-dim hover:text-primary",
+                  )}
+                  onClick={() => {
+                    onChange(option);
+                    setOpen(false);
+                  }}
+                >
+                  {option}
+                </button>
+              );
+            })}
           </div>
         </div>
-      </button>
+      ) : null}
+    </div>
+  );
+}
+
+function InlineTokenFilterControl({
+  label,
+  value,
+  placeholder,
+  addLabel,
+  badgePrefix,
+  onChange,
+  className,
+}: InlineTokenFilterControlProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!(event.target instanceof Node)) return;
+      if (containerRef.current?.contains(event.target)) return;
+      setOpen(false);
+      setDraft("");
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      setDraft("");
+    };
+
+    const frame = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const applyDraft = () => {
+    const next = draft.trim();
+    if (!next) return;
+    onChange(next);
+    setOpen(false);
+    setDraft("");
+  };
+
+  const clearValue = () => {
+    onChange("");
+    setOpen(false);
+    setDraft("");
+  };
+
+  return (
+    <div ref={containerRef} className={cn("relative min-w-0", className)}>
+      {value ? (
+        <span className="inline-flex max-w-full items-center gap-2 rounded-full border border-primary/30 bg-primary-dim px-2.5 py-1 font-mono text-[11px] text-primary">
+          <span className="min-w-0 truncate">
+            {badgePrefix}: {value}
+          </span>
+          <button
+            type="button"
+            aria-label={`Remove ${label.toLowerCase()} filter`}
+            title={`Remove ${label.toLowerCase()} filter`}
+            className="rounded-full border border-transparent px-1 text-[10px] leading-none text-primary transition-colors hover:border-primary/25 hover:bg-primary/10"
+            onClick={clearValue}
+          >
+            X
+          </button>
+        </span>
+      ) : (
+        <>
+          <button
+            type="button"
+            aria-label={`Add ${label.toLowerCase()} filter`}
+            aria-expanded={open}
+            className={cn(
+              "inline-flex max-w-full items-center overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-3 py-1.5 font-mono text-[11px] transition-colors",
+              open
+                ? "border-primary bg-primary-dim text-primary"
+                : "border-border-subtle bg-surface text-muted hover:border-primary/30 hover:text-text",
+            )}
+            onClick={() => {
+              setDraft("");
+              setOpen((current) => !current);
+            }}
+          >
+            {addLabel}
+          </button>
+          {open ? (
+            <div
+              role="dialog"
+              aria-label={`${label} filter input`}
+              className="absolute left-0 top-full z-20 mt-2 w-[280px] rounded-xl border border-border-subtle bg-surface p-2 shadow-[0_12px_30px_rgb(0_0_0_/_0.18)]"
+            >
+              <div className="flex flex-col gap-2">
+                <TextField
+                  ref={inputRef}
+                  aria-label={label}
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      applyDraft();
+                    }
+                  }}
+                  placeholder={placeholder}
+                />
+                <div className="flex items-center justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="xxs"
+                    onClick={() => {
+                      setOpen(false);
+                      setDraft("");
+                    }}
+                  >
+                    CANCEL
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="xxs"
+                    disabled={draft.trim().length === 0}
+                    onClick={applyDraft}
+                  >
+                    ADD
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }
@@ -691,6 +1049,8 @@ function LogEntryRow({
 }: LogEntryRowProps) {
   const hasDetails = entry.data !== undefined || entry.expandable;
   const leftOffset = Math.min(depth, 8) * 14;
+  const markerBadgeClass =
+    "h-7 w-7 justify-center px-0 text-center font-mono leading-none";
   const handleSummaryClick = () => {
     if (hasDetails) {
       onToggleExpanded();
@@ -709,10 +1069,16 @@ function LogEntryRow({
       <div
         role={hasDetails ? "button" : undefined}
         tabIndex={hasDetails ? 0 : undefined}
-        aria-label={hasDetails ? `${expanded ? "Collapse" : "Expand"} log row ${entry.id}` : undefined}
+        aria-label={
+          hasDetails
+            ? `${expanded ? "Collapse" : "Expand"} log row ${entry.id}`
+            : undefined
+        }
         className={cn(
           "flex items-start gap-2.5 px-2.5 py-2",
-          hasDetails ? "cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/35" : null,
+          hasDetails
+            ? "cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/35"
+            : null,
         )}
         onClick={handleSummaryClick}
         onKeyDown={(event) => {
@@ -725,20 +1091,20 @@ function LogEntryRow({
       >
         <div className="shrink-0 flex flex-col gap-1">
           <Badge
-            variant={kindVariant(entry.kind)}
-            aria-label={entry.kind}
-            title={entry.kind}
-            className="min-w-9 justify-center px-2 text-center"
-          >
-            {kindDisplayLabel(entry.kind)}
-          </Badge>
-          <Badge
             variant={levelVariant(entry.level)}
             aria-label={`Level ${entry.level}`}
             title={entry.level.toUpperCase()}
-            className="min-w-7 justify-center px-1.5 text-center font-mono"
+            className={markerBadgeClass}
           >
             {levelSymbol(entry.level)}
+          </Badge>
+          <Badge
+            variant={kindVariant(entry.kind)}
+            aria-label={entry.kind}
+            title={entry.kind}
+            className={markerBadgeClass}
+          >
+            {kindDisplayLabel(entry.kind)}
           </Badge>
         </div>
 
@@ -818,7 +1184,9 @@ function LogEntryRow({
                 {entry.parentId ? (
                   <div>
                     <span className="text-muted">parent</span>:{" "}
-                    <span className="font-mono break-all">{entry.parentId}</span>
+                    <span className="font-mono break-all">
+                      {entry.parentId}
+                    </span>
                   </div>
                 ) : null}
               </div>
@@ -900,14 +1268,13 @@ export default function LogsWindowApp({
   const [tailEnabled, setTailEnabled] = useState(
     initialPayload?.tailEnabled ?? true,
   );
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<ViewerNotice>(null);
+  const noticeIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const filtersPanelRef = useRef<HTMLDivElement | null>(null);
   const liveBufferRef = useRef<Map<string, LogEntry>>(new Map());
   const liveOnlySinceMsRef = useRef<number | null>(null);
   const flushTimerRef = useRef<number | null>(null);
@@ -922,14 +1289,34 @@ export default function LogsWindowApp({
   }, [filter]);
 
   const updateControls = (
-    next:
-      | ControlState
-      | ((current: ControlState) => ControlState),
+    next: ControlState | ((current: ControlState) => ControlState),
   ) => {
     setLoading(true);
     setError(null);
     setControls(next);
   };
+
+  const showNotice = useCallback(
+    (
+      next: Pick<Exclude<ViewerNotice, null>, "kind" | "message"> & {
+        autoCloseMs?: number | null;
+      },
+    ) => {
+      noticeIdRef.current += 1;
+      setNotice({
+        id: noticeIdRef.current,
+        kind: next.kind,
+        message: next.message,
+        autoCloseMs:
+          next.autoCloseMs === undefined ? NOTICE_AUTO_CLOSE_MS : next.autoCloseMs,
+      });
+    },
+    [],
+  );
+
+  const dismissNotice = useCallback(() => {
+    setNotice(null);
+  }, []);
 
   useEffect(() => {
     const currentWindow = getCurrentWindow();
@@ -937,21 +1324,17 @@ export default function LogsWindowApp({
     let unlisten: (() => void) | undefined;
 
     void currentWindow
-      .listen<LogWindowNavigatePayload>(
-        LOG_WINDOW_NAVIGATE_EVENT,
-        (event) => {
-          const payload = normalizeLogNavigatePayload(event.payload);
-          if (stopped) return;
-          setLoading(true);
-          setError(null);
-          setControls(controlsFromPayload(payload));
-          setTailEnabled(payload.tailEnabled ?? true);
-          liveOnlySinceMsRef.current = null;
-          setFiltersExpanded(false);
-          setExpandedIds(new Set());
-          setNotice(null);
-        },
-      )
+      .listen<LogWindowNavigatePayload>(LOG_WINDOW_NAVIGATE_EVENT, (event) => {
+        const payload = normalizeLogNavigatePayload(event.payload);
+        if (stopped) return;
+        setLoading(true);
+        setError(null);
+        setControls(controlsFromPayload(payload));
+        setTailEnabled(payload.tailEnabled ?? true);
+        liveOnlySinceMsRef.current = null;
+        setExpandedIds(new Set());
+        setNotice(null);
+      })
       .then((dispose) => {
         if (stopped) {
           dispose();
@@ -1067,33 +1450,15 @@ export default function LogsWindowApp({
   }, [deferredEntries, tailEnabled, expandedIds]);
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-      if (event.key !== "`" && event.code !== "Backquote") return;
-      event.preventDefault();
-      setFiltersExpanded((current) => !current);
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
+    if (!notice || notice.autoCloseMs == null) return;
+    const noticeId = notice.id;
+    const timerId = window.setTimeout(() => {
+      setNotice((current) => (current?.id === noticeId ? null : current));
+    }, notice.autoCloseMs);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.clearTimeout(timerId);
     };
-  }, []);
-
-  useEffect(() => {
-    if (!filtersExpanded) return;
-    const frame = window.requestAnimationFrame(() => {
-      const input = filtersPanelRef.current?.querySelector("input");
-      if (input instanceof HTMLInputElement) {
-        input.focus();
-      }
-    });
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
-  }, [filtersExpanded]);
+  }, [notice]);
 
   const isTreeView = Boolean(filter.traceId || filter.correlationId);
   const appliedFilterCount = activeFilterCount(filter);
@@ -1143,7 +1508,6 @@ export default function LogsWindowApp({
     setError(null);
     setControls(controlsFromPayload(null));
     setTailEnabled(true);
-    setFiltersExpanded(false);
     setExpandedIds(new Set());
     setNotice(null);
   };
@@ -1152,20 +1516,26 @@ export default function LogsWindowApp({
     try {
       const result = await exportLogs(filter);
       if (!result) {
-        setNotice({ kind: "error", message: "Log export is only available in Tauri." });
+        showNotice({
+          kind: "error",
+          message: "Log export is only available in Tauri.",
+          autoCloseMs: null,
+        });
         return;
       }
-      setNotice({
+      showNotice({
         kind: "success",
         message: `Exported ${result.count} log entries to ${result.path}`,
+        autoCloseMs: null,
       });
     } catch (exportError) {
-      setNotice({
+      showNotice({
         kind: "error",
         message:
           exportError instanceof Error
             ? exportError.message
             : "Failed to export logs.",
+        autoCloseMs: null,
       });
     }
   };
@@ -1180,7 +1550,7 @@ export default function LogsWindowApp({
     setLoading(false);
     setExpandedIds(new Set());
     setTailEnabled(true);
-    setNotice({
+    showNotice({
       kind: "success",
       message: "Cleared current view. Only new logs will appear.",
     });
@@ -1206,7 +1576,8 @@ export default function LogsWindowApp({
 
   return (
     <div className="min-h-screen bg-app text-text">
-      <div className="mx-auto flex h-screen max-w-[1440px] flex-col px-5 py-5">
+      {notice ? <NoticeToast notice={notice} onDismiss={dismissNotice} /> : null}
+      <div className="flex h-screen w-full flex-col px-5 py-5">
         <div className="flex h-full flex-col rounded-2xl border border-border-subtle bg-surface shadow-[0_16px_40px_rgb(0_0_0_/_0.12)]">
           <div className="border-b border-border-subtle px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1218,37 +1589,30 @@ export default function LogsWindowApp({
                   <Badge variant={isTreeView ? "primary" : "muted"}>
                     {isTreeView ? "TRACE VIEW" : "LIVE FEED"}
                   </Badge>
+                  <ViewModeIndicator
+                    isTreeView={isTreeView}
+                    limit={filter.limit ?? DEFAULT_LOG_LIMIT}
+                  />
                   {appliedFilterCount > 0 ? (
                     <Badge variant="muted">
-                      {appliedFilterCount} FILTER{appliedFilterCount === 1 ? "" : "S"}
+                      {appliedFilterCount} FILTER
+                      {appliedFilterCount === 1 ? "" : "S"}
                     </Badge>
                   ) : null}
-                </div>
-                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xxs text-muted">
-                  <span>{filterSummary(filter)}</span>
-                  <span>·</span>
-                  <span>
-                    {isTreeView
-                      ? "Grouped by trace lineage"
-                      : `Showing up to ${filter.limit ?? DEFAULT_LOG_LIMIT} rows`}
-                  </span>
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <Badge variant={tailEnabled ? "success" : "muted"}>
                   {tailEnabled ? "TAILING" : "PAUSED"}
                 </Badge>
-                <Button
-                  variant="ghost"
-                  size="xxs"
-                  onClick={() => setFiltersExpanded((current) => !current)}
-                >
-                  {filtersExpanded ? "HIDE FILTERS" : "SHOW FILTERS"}
-                </Button>
                 <Button variant="ghost" size="xxs" onClick={handleReset}>
                   RESET
                 </Button>
-                <Button variant="ghost" size="xxs" onClick={() => void handleExport()}>
+                <Button
+                  variant="ghost"
+                  size="xxs"
+                  onClick={() => void handleExport()}
+                >
                   EXPORT
                 </Button>
                 <Button variant="danger" size="xxs" onClick={handleClear}>
@@ -1258,160 +1622,97 @@ export default function LogsWindowApp({
             </div>
           </div>
 
-          {notice ? (
-            <div
-              className={cn(
-                "border-b border-border-subtle px-5 py-3 text-xs",
-                notice.kind === "error" ? "text-error" : "text-success",
-              )}
-            >
-              {notice.message}
-            </div>
-          ) : null}
-
-          <div className="relative flex min-h-0 flex-1 flex-col">
-            {filtersExpanded ? (
-              <div className="absolute inset-0 z-20 p-4 pointer-events-none">
-                <button
-                  type="button"
-                  aria-label="Close filters backdrop"
-                  className="absolute inset-0 bg-app/10 backdrop-blur-[1px] pointer-events-auto"
-                  onClick={() => setFiltersExpanded(false)}
-                />
-                <div
-                  ref={filtersPanelRef}
-                  role="dialog"
-                  aria-label="Log filters"
-                  className="relative mx-auto w-full max-w-[1120px] rounded-2xl border border-border-subtle bg-surface/98 shadow-[0_20px_50px_rgb(0_0_0_/_0.18)] pointer-events-auto"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle px-4 py-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <div className="text-xxs font-bold tracking-[0.08em] uppercase text-primary">
-                        Filters
-                      </div>
-                      <Badge variant="muted">` TOGGLE</Badge>
-                      <span className="text-[11px] text-muted">
-                        Click tag pills to cycle include, exclude, ignore
-                      </span>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="xxs"
-                      onClick={() => setFiltersExpanded(false)}
-                    >
-                      CLOSE
-                    </Button>
-                  </div>
-
-                  <div className="px-4 py-3">
-                    <div>
-                      <div className="mb-2 text-[11px] font-bold tracking-[0.08em] uppercase text-muted">
-                        Tags
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {filterTags.map((tag) => (
-                          <TagStatePill
-                            key={tag}
-                            tag={tag}
-                            state={
-                              includedTags.has(tag)
-                                ? "include"
-                                : excludedTags.has(tag)
-                                  ? "exclude"
-                                  : "ignore"
-                            }
-                            onCycle={handleCycleTagState}
-                          />
-                        ))}
-                      </div>
-                    </div>
-
-                    <div className="mt-4 border-t border-border-subtle pt-3">
-                      <VerbosityControl
-                        value={controls.verbosity}
-                        onChange={(next) =>
-                          updateControls((current) => ({
-                            ...current,
-                            verbosity: next,
-                          }))
+          <div className="border-b border-border-subtle px-4 py-3">
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {filterTags.map((tag) => (
+                      <TagStatePill
+                        key={tag}
+                        tag={tag}
+                        state={
+                          includedTags.has(tag)
+                            ? "include"
+                            : excludedTags.has(tag)
+                              ? "exclude"
+                              : "ignore"
                         }
+                        onCycle={handleCycleTagState}
                       />
-                    </div>
-
-                    <div className="mt-2 grid gap-2">
-                      <div className="grid gap-2 lg:grid-cols-2">
-                        <TextField
-                          value={controls.traceId}
-                          onChange={(event) =>
-                            updateControls((current) => ({
-                              ...current,
-                              traceId: event.target.value,
-                            }))
-                          }
-                          placeholder="trace id"
-                        />
-                        <TextField
-                          value={controls.correlationId}
-                          onChange={(event) =>
-                            updateControls((current) => ({
-                              ...current,
-                              correlationId: event.target.value,
-                            }))
-                          }
-                          placeholder="tool correlation id"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-xxs uppercase tracking-[0.06em] text-muted">
-                          Source
-                        </span>
-                        <SelectField
-                          value={controls.source}
-                          onChange={(event) =>
-                            updateControls((current) => ({
-                              ...current,
-                              source: event.target.value as LogSource | "",
-                            }))
-                          }
-                        >
-                          {SOURCES.map((source) => (
-                            <option key={source || "all"} value={source}>
-                              {source ? `Source: ${source}` : "All sources"}
-                            </option>
-                          ))}
-                        </SelectField>
-                      </div>
-
-                      <div className="flex items-center gap-2">
-                        <span className="text-xxs uppercase tracking-[0.06em] text-muted">
-                          Row limit
-                        </span>
-                        <SelectField
-                          value={String(controls.limit)}
-                          onChange={(event) =>
-                            updateControls((current) => ({
-                              ...current,
-                              limit: normalizeLimit(Number(event.target.value)),
-                            }))
-                          }
-                        >
-                          {LIMIT_OPTIONS.map((option) => (
-                            <option key={option} value={option}>
-                              {option}
-                            </option>
-                          ))}
-                        </SelectField>
-                      </div>
-                    </div>
+                    ))}
                   </div>
                 </div>
-              </div>
-            ) : null}
 
+                <div className="ml-auto flex flex-nowrap items-center gap-3">
+                  <VerbosityPillControl
+                    value={controls.verbosity}
+                    onChange={(next) =>
+                      updateControls((current) => ({
+                        ...current,
+                        verbosity: next,
+                      }))
+                    }
+                  />
+                  <SourceControl
+                    value={controls.source}
+                    onChange={(next) =>
+                      updateControls((current) => ({
+                        ...current,
+                        source: next,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex min-w-0 flex-nowrap items-center gap-3">
+                <div className="flex min-w-0 flex-nowrap items-center gap-3">
+                  <InlineTokenFilterControl
+                    label="Trace ID"
+                    value={controls.traceId}
+                    placeholder="trace id"
+                    addLabel="+ TRACE ID"
+                    badgePrefix="trace"
+                    className="min-w-0 w-[220px] max-w-[220px]"
+                    onChange={(next) =>
+                      updateControls((current) => ({
+                        ...current,
+                        traceId: next,
+                      }))
+                    }
+                  />
+                  <InlineTokenFilterControl
+                    label="Tool Correlation ID"
+                    value={controls.correlationId}
+                    placeholder="tool correlation id"
+                    addLabel="+ TOOL CORREL ID"
+                    badgePrefix="tool"
+                    className="min-w-0 w-[220px] max-w-[220px]"
+                    onChange={(next) =>
+                      updateControls((current) => ({
+                        ...current,
+                        correlationId: next,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="ml-auto shrink-0">
+                  <RowLimitControl
+                    value={controls.limit}
+                    onChange={(next) =>
+                      updateControls((current) => ({
+                        ...current,
+                        limit: next,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="relative flex min-h-0 flex-1 flex-col">
             {!tailEnabled ? (
               <div className="absolute right-4 top-4 z-10">
                 <Button variant="primary" size="xs" onClick={handleJumpToLive}>
@@ -1430,7 +1731,9 @@ export default function LogsWindowApp({
                   Loading logs…
                 </div>
               ) : error ? (
-                <div className="py-12 text-center text-sm text-error">{error}</div>
+                <div className="py-12 text-center text-sm text-error">
+                  {error}
+                </div>
               ) : deferredEntries.length === 0 ? (
                 <div className="py-12 text-center text-sm text-muted">
                   No log entries match the current filter.


### PR DESCRIPTION
## Summary
- move the logs window filters into persistent inline controls and simplify the header badges
- add inline trace/correlation and row-limit pills, plus bottom toast notices with auto-dismiss behavior
- remove redundant tab-id prefixes from stream debug messages and update logging tests

## Testing
- npm run lint
- npm run typecheck
- npm run test

## Issue
- No matching issue found to link
