### PR TITLE
ci: cache Rust dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+
       - name: Run Rust tests
         run: cd src-tauri && cargo test


### PR DESCRIPTION
## Summary
- add `Swatinem/rust-cache@v2` to the Rust CI job
- cache the `src-tauri` Cargo workspace and `target` directory between runs
- reduce repeated dependency download and compilation cost for branch CI runs

## Testing
- parsed `.github/workflows/ci.yml` with Ruby YAML loader

## Notes
- no issue number was provided for linking