### PR TITLE
fix(test): await menu close assertion in ArchivedTabsMenu test

### DIFF
--- a/src/components/ArchivedTabsMenu.test.tsx
+++ b/src/components/ArchivedTabsMenu.test.tsx
@@ -370,7 +370,9 @@ describe("ArchivedTabsMenu", () => {
         tabs: tabsContextMock.value.tabs,
       });
     });
-    expect(screen.queryByText("Archived Tabs")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText("Archived Tabs")).toBeNull();
+    });
   });
 
   it("collapses and expands project groups", async () => {


### PR DESCRIPTION
## Problem

The "shows active pinned tabs and focuses them when clicked" test in `ArchivedTabsMenu.test.tsx` had a race condition. After `fireEvent.click` triggers the tab open and the component calls `focusOrOpenPersistedSession`, the menu close is driven by a state update that happens asynchronously inside the component. The bare synchronous assertion:

```ts
expect(screen.queryByText("Archived Tabs")).toBeNull();
```

ran immediately after the previous `waitFor` resolved, before React had finished flushing the state update that closes the menu. This caused the assertion to see the menu still mounted and fail intermittently.

## Fix

Wrapped the menu-close assertion in its own `waitFor`, matching the pattern already used elsewhere in the same test file (e.g. the `"blocks delete on pinned rows"` test):

```ts
await waitFor(() => {
  expect(screen.queryByText("Archived Tabs")).toBeNull();
});
```

`waitFor` retries the assertion across micro/macro task boundaries, giving React time to flush the close state update before the check runs.

## Changed file

- `src/components/ArchivedTabsMenu.test.tsx` — 3-line change, no production code modified