### PR TITLE
feat: add debug mode setting and log viewer shortcut

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -45,6 +45,8 @@ vi.mock("@/agent/atoms", () => ({
   themeModeAtom: atom("dark"),
   themeNameAtom: atom("default"),
   agentAtomFamily: vi.fn(),
+  debugModeEnabledAtom: atom(false),
+  patchAgentState: vi.fn(),
 }));
 
 vi.mock("@/agent/db", () => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "@/styles/globals.css";
-import { Provider, useAtom } from "jotai";
+import { Provider, useAtom, useAtomValue } from "jotai";
 import { useEffect, useRef, useState } from "react";
 import TopChrome from "@/components/TopChrome";
 import AgentNotificationManager from "@/components/AgentNotificationManager";
@@ -11,6 +11,8 @@ import {
   themeModeAtom,
   themeNameAtom,
   agentAtomFamily,
+  debugModeEnabledAtom,
+  patchAgentState,
 } from "@/agent/atoms";
 import { loadProviders, providersAtom, loadProfiles, profilesAtom, loadCommandList, commandListAtom } from "@/agent/db";
 import {
@@ -67,6 +69,24 @@ function ThemeApplier() {
     }
     appliedSubagentVarsRef.current = nextVarNames;
   }, [themeMode, themeName]);
+  return null;
+}
+
+function DebugModeSynchronizer() {
+  const { tabs } = useTabs();
+  const debugModeEnabled = useAtomValue(debugModeEnabledAtom);
+
+  useEffect(() => {
+    for (const tab of tabs) {
+      if (tab.mode === "settings") continue;
+
+      const currentShowDebug = jotaiStore.get(agentAtomFamily(tab.id)).showDebug ?? false;
+      if (currentShowDebug === debugModeEnabled) continue;
+
+      patchAgentState(tab.id, { showDebug: debugModeEnabled });
+    }
+  }, [tabs, debugModeEnabled]);
+
   return null;
 }
 
@@ -278,6 +298,7 @@ export default function App() {
       <Provider store={jotaiStore}>
         <TabsProvider initialSessions={initialSessions}>
           <ThemeApplier />
+          <DebugModeSynchronizer />
           <AutoSaveManager />
           <AgentNotificationManager />
           <DesktopTrayManager />

--- a/src/WorkspacePage.test.tsx
+++ b/src/WorkspacePage.test.tsx
@@ -60,6 +60,7 @@ const workspaceMocks = vi.hoisted(() => ({
   setAutoApproveCommandsMock: vi.fn(),
   openSettingsTabMock: vi.fn<(section?: string) => void>(),
   patchAgentStateMock: vi.fn(),
+  setGlobalDebugModeMock: vi.fn(),
   updateTabMock: vi.fn(),
   findSavedProjectMock: vi.fn(),
   inferProjectNameMock: vi.fn((path: string) => path.split("/").pop() ?? path),
@@ -209,6 +210,7 @@ vi.mock("@/agent/persistence", () => ({
 
 vi.mock("@/agent/atoms", () => ({
   patchAgentState: workspaceMocks.patchAgentStateMock,
+  setGlobalDebugMode: workspaceMocks.setGlobalDebugModeMock,
   voiceInputEnabledAtom: {},
 }));
 
@@ -613,6 +615,7 @@ describe("WorkspacePage chat input", () => {
     workspaceMocks.setAutoApproveCommandsMock.mockReset();
     workspaceMocks.openSettingsTabMock.mockReset();
     workspaceMocks.patchAgentStateMock.mockReset();
+    workspaceMocks.setGlobalDebugModeMock.mockReset();
     workspaceMocks.updateTabMock.mockReset();
     workspaceMocks.findSavedProjectMock.mockReset();
     workspaceMocks.inferProjectNameMock.mockReset();
@@ -1145,7 +1148,7 @@ describe("WorkspacePage chat input", () => {
     });
   });
 
-  it("keeps the local /debug toggle behavior", async () => {
+  it("toggles the global debug mode shortcut on /debug", async () => {
     render(<WorkspacePage />);
 
     const textbox = screen.getByRole("textbox");
@@ -1160,10 +1163,7 @@ describe("WorkspacePage chat input", () => {
     fireEvent.keyDown(textbox, { key: "Enter" });
 
     expect(workspaceMocks.sendMessageMock).not.toHaveBeenCalled();
-    const nextState = applyLastPatch({
-      showDebug: false,
-    });
-    expect(nextState.showDebug).toBe(true);
+    expect(workspaceMocks.setGlobalDebugModeMock).toHaveBeenCalledWith(true);
   });
 
   it("toggles grouped inline tool calls for the current session", async () => {

--- a/src/WorkspacePage.tsx
+++ b/src/WorkspacePage.tsx
@@ -51,7 +51,11 @@ import { useVoiceInputController } from "@/components/voice-input/useVoiceInputC
 import { useTabs } from "@/contexts/TabsContext";
 import { useAgent, useStopAgent } from "@/agent/useAgents";
 import { useModels } from "@/agent/useModels";
-import { patchAgentState, voiceInputEnabledAtom } from "@/agent/atoms";
+import {
+  patchAgentState,
+  setGlobalDebugMode,
+  voiceInputEnabledAtom,
+} from "@/agent/atoms";
 import {
   formatSlashCommandHelpMarkdown,
   getSlashCommandCatalog,
@@ -1004,10 +1008,7 @@ export default function WorkspacePage() {
     }
 
     if (text === "/debug") {
-      patchAgentState(activeTabId, (prev) => ({
-        ...prev,
-        showDebug: !(prev.showDebug ?? false),
-      }));
+      setGlobalDebugMode(!(agent.showDebug ?? false));
       setInput("");
       return;
     }

--- a/src/agent/atoms.ts
+++ b/src/agent/atoms.ts
@@ -18,6 +18,23 @@ export const jotaiStore = createStore();
 
 import { atomWithStorage } from "jotai/utils";
 
+const DEBUG_MODE_STORAGE_KEY = "rakh.debug-mode";
+
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+
+  const raw = window.localStorage.getItem(key);
+  if (raw === null) return fallback;
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+
+  try {
+    return Boolean(JSON.parse(raw) as unknown);
+  } catch {
+    return fallback;
+  }
+}
+
 /** UI colour scheme mode (light/dark) — persisted in localStorage */
 export const themeModeAtom = atomWithStorage<"dark" | "light">(
   "rakh.theme-mode",
@@ -57,6 +74,12 @@ export const themeNameAtom = atomWithStorage<ThemeName>(
 export const notifyOnAttentionAtom = atomWithStorage<boolean>(
   "rakh.notify-attention",
   false,
+);
+
+/** Whether global debug mode is enabled across the app */
+export const debugModeEnabledAtom = atomWithStorage<boolean>(
+  DEBUG_MODE_STORAGE_KEY,
+  import.meta.env.DEV,
 );
 
 /** Whether inline tool calls are grouped by default across sessions */
@@ -171,7 +194,7 @@ function makeDefaultAgentState(): AgentState {
     groupInlineToolCallsOverride: null,
     queuedMessages: [],
     queueState: "idle",
-    showDebug: import.meta.env.DEV,
+    showDebug: readStoredBoolean(DEBUG_MODE_STORAGE_KEY, import.meta.env.DEV),
   };
 }
 
@@ -305,6 +328,10 @@ export function patchAgentState(
 
 export function getAgentState(tabId: string): AgentState {
   return jotaiStore.get(agentAtomFamily(tabId));
+}
+
+export function setGlobalDebugMode(enabled: boolean): void {
+  jotaiStore.set(debugModeEnabledAtom, enabled);
 }
 
 export function patchSessionPersistenceState(

--- a/src/agent/slashCommands.ts
+++ b/src/agent/slashCommands.ts
@@ -19,7 +19,7 @@ const STATIC_SLASH_COMMANDS: SlashCommandDefinition[] = [
   },
   {
     command: "/debug",
-    description: "Toggle debug mode (stream event logging).",
+    description: "Toggle global debug mode (stream event logging).",
     insertText: "/debug ",
     takesArguments: false,
   },

--- a/src/agent/useAgents.ts
+++ b/src/agent/useAgents.ts
@@ -295,7 +295,7 @@ export function useResetAgent() {
       groupInlineToolCallsOverride: null,
       queuedMessages: [],
       queueState: "idle",
-      showDebug: false,
+      showDebug: prev.showDebug ?? false,
       lastRunTraceId: undefined,
     }));
   }, []);

--- a/src/components/TopChrome.test.tsx
+++ b/src/components/TopChrome.test.tsx
@@ -8,6 +8,7 @@ import type { Tab } from "@/contexts/TabsContext";
 import {
   DEFAULT_MODEL,
   appUpdaterStateAtom,
+  debugModeEnabledAtom,
   defaultAppUpdaterState,
   jotaiStore,
   patchAgentState,
@@ -40,6 +41,10 @@ const sessionRestoreMock = vi.hoisted(() => ({
   restoreMostRecentArchivedTab: vi.fn(),
 }));
 
+const loggingWindowMock = vi.hoisted(() => ({
+  openLogViewerWindow: vi.fn(),
+}));
+
 vi.mock("@/contexts/TabsContext", () => ({
   useTabs: () => tabsContextMock.value,
 }));
@@ -47,6 +52,12 @@ vi.mock("@/contexts/TabsContext", () => ({
 vi.mock("@/agent/sessionRestore", () => ({
   restoreMostRecentArchivedTab: (...args: unknown[]) =>
     sessionRestoreMock.restoreMostRecentArchivedTab(...args),
+}));
+
+vi.mock("@/logging/window", () => ({
+  DEFAULT_LOG_LIMIT: 500,
+  openLogViewerWindow: (...args: unknown[]) =>
+    loggingWindowMock.openLogViewerWindow(...args),
 }));
 
 vi.mock("@/components/ArchivedTabsMenu", () => ({
@@ -160,6 +171,7 @@ describe("TopChrome", () => {
     localStorage.clear();
     setNavigatorPlatform("MacIntel");
     jotaiStore.set(appUpdaterStateAtom, { ...defaultAppUpdaterState });
+    jotaiStore.set(debugModeEnabledAtom, false);
     tabsContextMock.value.tabs = [
       {
         id: "tab-1",
@@ -178,6 +190,8 @@ describe("TopChrome", () => {
     tabsContextMock.value.updateTab.mockReset();
     tabsContextMock.value.reorderTabs.mockReset();
     sessionRestoreMock.restoreMostRecentArchivedTab.mockReset();
+    loggingWindowMock.openLogViewerWindow.mockReset();
+    loggingWindowMock.openLogViewerWindow.mockResolvedValue(true);
     setAgentState("tab-1");
   });
 
@@ -210,6 +224,26 @@ describe("TopChrome", () => {
 
     expect(tabsContextMock.value.openSettingsTab).toHaveBeenCalledTimes(1);
     expect(tabsContextMock.value.openSettingsTab).toHaveBeenCalledWith();
+  });
+
+  it("hides the log viewer button while debug mode is disabled", () => {
+    renderTopChrome();
+
+    expect(screen.queryByTitle("Open log viewer")).toBeNull();
+  });
+
+  it("shows the log viewer button and opens the detached logs window in debug mode", () => {
+    jotaiStore.set(debugModeEnabledAtom, true);
+
+    renderTopChrome();
+
+    fireEvent.click(screen.getByTitle("Open log viewer"));
+
+    expect(loggingWindowMock.openLogViewerWindow).toHaveBeenCalledWith({
+      origin: "manual",
+      filter: { limit: 500 },
+      tailEnabled: true,
+    });
   });
 
   it("uses Cmd+, on macOS to open the settings tab", () => {

--- a/src/components/TopChrome.tsx
+++ b/src/components/TopChrome.tsx
@@ -14,6 +14,7 @@ import {
   agentConfigAtomFamily,
   agentStatusAtomFamily,
   agentTabTitleAtomFamily,
+  debugModeEnabledAtom,
   jotaiStore,
 } from "@/agent/atoms";
 import {
@@ -25,6 +26,7 @@ import CloseTabModal from "@/components/CloseTabModal";
 import ArchivedTabsMenu from "@/components/ArchivedTabsMenu";
 import { cn } from "@/utils/cn";
 import { shouldShowAppUpdateBadge } from "@/updater";
+import { DEFAULT_LOG_LIMIT, openLogViewerWindow } from "@/logging/window";
 
 /* ── Types ──────────────────────────────────────────────────────────────── */
 type Platform = "mac" | "windows" | "other";
@@ -183,6 +185,7 @@ export default function TopChrome() {
     reorderTabs,
   } = useTabs();
   const appUpdater = useAtomValue(appUpdaterStateAtom);
+  const debugModeEnabled = useAtomValue(debugModeEnabledAtom);
   const showUpdateBadge = shouldShowAppUpdateBadge(appUpdater);
 
   // ── Close-confirmation modal ──────────────────────────────────────────
@@ -584,10 +587,26 @@ export default function TopChrome() {
         {/* ── Settings Controls ──────────────────────────────────────── */}
         <div
           className="win-controls"
-          aria-label="Settings"
+          aria-label="App controls"
           onDoubleClick={(e) => e.stopPropagation()}
         >
           <ArchivedTabsMenu />
+          {debugModeEnabled ? (
+            <button
+              className="win-btn w-9"
+              onClick={() =>
+                void openLogViewerWindow({
+                  origin: "manual",
+                  filter: { limit: DEFAULT_LOG_LIMIT },
+                  tailEnabled: true,
+                })
+              }
+              aria-label="Open log viewer"
+              title="Open log viewer"
+            >
+              <span className="material-symbols-outlined text-lg">receipt_long</span>
+            </button>
+          ) : null}
           <button
             className="win-btn w-9 relative"
             onClick={() => openSettingsTab()}

--- a/src/components/settings/SettingsPage.test.tsx
+++ b/src/components/settings/SettingsPage.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from "jotai";
 import { TabsProvider, useTabs } from "@/contexts/TabsContext";
 import {
   appUpdaterStateAtom,
+  debugModeEnabledAtom,
   defaultAppUpdaterState,
   groupInlineToolCallsAtom,
   jotaiStore,
@@ -119,7 +120,7 @@ vi.mock("@/components/ui/JsonCodeEditor", () => ({
 function SettingsPageHarness({
   initialSection = "appearance",
 }: {
-  initialSection?: "appearance" | "updates" | "mcp";
+  initialSection?: "appearance" | "updates" | "mcp" | "developer";
 }) {
   const { openSettingsTab } = useTabs();
 
@@ -131,7 +132,7 @@ function SettingsPageHarness({
 }
 
 function renderSettingsPage(
-  initialSection: "appearance" | "updates" | "mcp" = "appearance",
+  initialSection: "appearance" | "updates" | "mcp" | "developer" = "appearance",
 ) {
   return render(
     <Provider store={jotaiStore}>
@@ -149,6 +150,7 @@ describe("SettingsPage", () => {
     jotaiStore.set(providersAtom, []);
     jotaiStore.set(mcpServersAtom, []);
     jotaiStore.set(mcpSettingsAtom, { artifactizeReturnedFiles: false });
+    jotaiStore.set(debugModeEnabledAtom, false);
     jotaiStore.set(groupInlineToolCallsAtom, true);
     jotaiStore.set(appUpdaterStateAtom, {
       ...defaultAppUpdaterState,
@@ -245,6 +247,26 @@ describe("SettingsPage", () => {
       expect(screen.getByTitle("Group inline tool calls")).not.toBeNull();
     });
     expect(jotaiStore.get(groupInlineToolCallsAtom)).toBe(false);
+  });
+
+  it("toggles global debug mode from the developer settings section", async () => {
+    renderSettingsPage("developer");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Developer" })).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByTitle("Debug mode"));
+
+    expect(jotaiStore.get(debugModeEnabledAtom)).toBe(true);
+
+    cleanup();
+    renderSettingsPage("developer");
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Debug mode")).not.toBeNull();
+    });
+    expect(jotaiStore.get(debugModeEnabledAtom)).toBe(true);
   });
 
   it("renders the MCP settings section under AI and saves a tested server", async () => {

--- a/src/components/settings/SettingsSurface.tsx
+++ b/src/components/settings/SettingsSurface.tsx
@@ -2115,6 +2115,37 @@ function CommandListSubpanel({
   );
 }
 
+function DeveloperSection({
+  controller,
+}: {
+  controller: SettingsControllerValue;
+}) {
+  return (
+    <div className="settings-page__section-stack">
+      <SectionCard
+        title="Diagnostics"
+        description="Control debug-only UI and the detached log viewer shortcut."
+      >
+        <div className="settings-row">
+          <div className="settings-row-info">
+            <span className="settings-row-label">Debug mode</span>
+            <span className="settings-row-desc">
+              Enables stream-event logging, extra debug UI, and the log viewer
+              button beside Settings in the title bar.
+            </span>
+          </div>
+          <ToggleSwitch
+            checked={controller.debugModeEnabled}
+            onChange={controller.setDebugModeEnabled}
+            className="settings-switch"
+            title="Debug mode"
+          />
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
 function CommandListSection({
   controller,
 }: {
@@ -2184,6 +2215,8 @@ function renderSection(
       return <VoiceSection controller={controller} />;
     case "command-list":
       return <CommandListSection controller={controller} />;
+    case "developer":
+      return <DeveloperSection controller={controller} />;
     case "updates":
       return <UpdatesSection controller={controller} />;
     default:

--- a/src/components/settings/model.ts
+++ b/src/components/settings/model.ts
@@ -8,6 +8,7 @@ export type SettingsSectionId =
   | "mcp"
   | "voice"
   | "command-list"
+  | "developer"
   | "updates";
 
 export type SettingsSectionGroupId = "general" | "ai" | "app";
@@ -80,6 +81,13 @@ export const SETTINGS_SECTIONS: SettingsSectionDefinition[] = [
     label: "Command List",
     description: "Allow or deny commands for automatic approval control.",
     icon: "shield",
+  },
+  {
+    id: "developer",
+    groupId: "app",
+    label: "Developer",
+    description: "Debug mode, diagnostics, and developer-facing tooling.",
+    icon: "bug_report",
   },
   {
     id: "updates",

--- a/src/components/settings/useSettingsController.ts
+++ b/src/components/settings/useSettingsController.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useAtom } from "jotai";
 import {
   appUpdaterStateAtom,
+  debugModeEnabledAtom,
   notifyOnAttentionAtom,
   themeModeAtom,
   themeNameAtom,
@@ -69,6 +70,8 @@ export interface SettingsControllerValue {
   mcpSettings: McpSettings;
   setMcpSettings: (settings: McpSettings) => void;
   envKeysAvailable: EnvKeyEntry[];
+  debugModeEnabled: boolean;
+  setDebugModeEnabled: (enabled: boolean) => void;
   themeMode: "dark" | "light";
   toggleThemeMode: () => void;
   themeName: ThemeName;
@@ -107,6 +110,7 @@ export function useSettingsController(): SettingsControllerValue {
   const [providers, setProviders] = useAtom(providersAtom);
   const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
   const [mcpSettings, setMcpSettings] = useAtom(mcpSettingsAtom);
+  const [debugModeEnabled, setDebugModeEnabled] = useAtom(debugModeEnabledAtom);
   const [themeMode, setThemeMode] = useAtom(themeModeAtom);
   const [themeName, setThemeName] = useAtom(themeNameAtom);
   const [groupInlineToolCalls, setGroupInlineToolCalls] = useAtom(
@@ -302,6 +306,8 @@ export function useSettingsController(): SettingsControllerValue {
     mcpSettings,
     setMcpSettings,
     envKeysAvailable,
+    debugModeEnabled,
+    setDebugModeEnabled,
     themeMode,
     toggleThemeMode,
     themeName,


### PR DESCRIPTION
## Summary
- add a persisted Developer settings toggle for global debug mode
- sync the global toggle into workspace debug state and the `/debug` shortcut
- show an "Open log viewer" button next to Settings when debug mode is enabled

## Testing
- npm run test -- src/components/settings/SettingsPage.test.tsx src/components/TopChrome.test.tsx src/WorkspacePage.test.tsx src/App.test.tsx
- npm run typecheck
- npm run lint

## Issue
- No linked issue found.